### PR TITLE
Add missing install in exemple/token_classificanbtion.ipy

### DIFF
--- a/examples/token_classification.ipynb
+++ b/examples/token_classification.ipynb
@@ -1029,6 +1029,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#!pip install seqeval\n",
     "metric = load_metric(\"seqeval\")"
    ]
   },


### PR DESCRIPTION
add install cmd for `seqeval` before loading it