### PR TITLE
Fix imports for NER notebook

### DIFF
--- a/examples/token_classification.ipynb
+++ b/examples/token_classification.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets, transformers"
+    "#! pip install datasets transformers pandas seqeval"
    ]
   },
   {
@@ -1404,7 +1404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -3127,5 +3127,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR adds some missing imports from the `pip install` cell so that the notebook can be run on Colab end-to-end