### PR TITLE
Fix: variable not defined in evaluation phase

### DIFF
--- a/examples/question_answering.ipynb
+++ b/examples/question_answering.ipynb
@@ -1932,7 +1932,7 @@
    ],
    "source": [
     "if squad_v2:\n",
-    "    formatted_predictions = [{\"id\": k, \"prediction_text\": v, \"no_answer_probability\": 0.0} for k, v in predictions.items()]\n",
+    "    formatted_predictions = [{\"id\": k, \"prediction_text\": v, \"no_answer_probability\": 0.0} for k, v in final_predictions.items()]\n",
     "else:\n",
     "    formatted_predictions = [{\"id\": k, \"prediction_text\": v} for k, v in final_predictions.items()]\n",
     "references = [{\"id\": ex[\"id\"], \"answers\": ex[\"answers\"]} for ex in datasets[\"validation\"]]\n",


### PR DESCRIPTION
Hi Huggingface team (@sgugger),
this pull request fix a variable not defined in evaluation phase.
The variable is ```predictions``` used only in the case of squad_v2 but never declared.

Original:
```python3
if squad_v2:
    formatted_predictions = [{"id": k, "prediction_text": v, "no_answer_probability": 0.0} for k, v in predictions.items()]
else:
    formatted_predictions = [{"id": k, "prediction_text": v} for k, v in final_predictions.items()]
``` 

After pull req:
```python3
if squad_v2:
    formatted_predictions = [{"id": k, "prediction_text": v, "no_answer_probability": 0.0} for k, v in final_predictions.items()]
else:
    formatted_predictions = [{"id": k, "prediction_text": v} for k, v in final_predictions.items()]
``` 