### PR TITLE
QA: fix the missing do_train param in trainer args

### DIFF
--- a/examples/question_answering.ipynb
+++ b/examples/question_answering.ipynb
@@ -1117,6 +1117,7 @@
     "    per_device_eval_batch_size=batch_size,\n",
     "    num_train_epochs=3,\n",
     "    weight_decay=0.01,\n",
+    "    do_train=True,\n",
     ")"
    ]
   },


### PR DESCRIPTION
Hello Huggingface team (@sgugger),
As discovered in the [issue](https://github.com/huggingface/transformers/issues/11200) 11200 in huggingface/transformers and #21 is better to set the param `do_train=True` in the Trainer Args before `trainer.fit()` call.

Kind regards,
Andrea