### PR TITLE
Fixed sagemaker function call to be compatible with transformers 4.5

### DIFF
--- a/sagemaker/07_tensorflow_distributed_training_data_parallelism/scripts/train.py
+++ b/sagemaker/07_tensorflow_distributed_training_data_parallelism/scripts/train.py
@@ -7,9 +7,9 @@ import tensorflow as tf
 from datasets import load_dataset
 from tqdm import tqdm
 from transformers import AutoTokenizer, TFAutoModelForSequenceClassification
-from transformers.file_utils import is_sagemaker_distributed_available
+from transformers.file_utils import is_sagemaker_dp_enabled
 
-if os.environ.get("SDP_ENABLED") or is_sagemaker_distributed_available():
+if os.environ.get("SDP_ENABLED") or is_sagemaker_dp_enabled():
     SDP_ENABLED = True
     os.environ["SAGEMAKER_INSTANCE_TYPE"] = "p3dn.24xlarge"
     import smdistributed.dataparallel.tensorflow as sdp


### PR DESCRIPTION
In transformers 4.5 `is_sagemaker_distributed_available` is replaced with `is_sagemaker_dp_enabled` . 
This PR modifies tf data parallelism example to be compatible with the change. 