### PR TITLE
Update sagemaker-notebook.ipynb to fix the error message due to state.json schema changes in datasets>1.5.0

### DIFF
--- a/sagemaker/01_getting_started_pytorch/sagemaker-notebook.ipynb
+++ b/sagemaker/01_getting_started_pytorch/sagemaker-notebook.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"sagemaker>=2.31.0\" \"transformers>=4.4.2\" \"datasets[s3]>=1.5.0\" --upgrade"
+    "!pip install \"sagemaker>=2.31.0\" \"transformers==4.4.2\" \"datasets[s3]==1.5.0\" --upgrade"
    ]
   },
   {


### PR DESCRIPTION
Updating the SageMaker Notebook to fix the error message below 

Error:
Traceback (most recent call last): File "train.py", line 42, in <module> train_dataset = load_from_disk(args.training_dir) File "/opt/conda/lib/python3.6/site-packages/datasets/load.py", line 781, in load_from_disk return Dataset.load_from_disk(dataset_path, fs) File "/opt/conda/lib/python3.6/site-packages/datasets/arrow_dataset.py", line 684, in load_from_disk state = {k: state[k] for k in dataset.__dict__.keys()} # in case we add new fields File "/opt/conda/lib/python3.6/site-packages/datasets/arrow_dataset.py", line 684, in <dictcomp> state = {k: state[k] for k in dataset.__dict__.keys()} # in case we add new fields
--
  | 2021-04-21T16:26:09.969-07:00 | KeyError: '_data'

Root cause:

Current Notebook uses  "transformers>=4.4.2" "datasets[s3]>=1.5.0" and thus it used dataset library that had schema changes in state.json which is incompatible with sagemaker's hugging face docker container that only supports transformer library 4.4.2 and datasets 1.5.0.
Thus, the error came since the dataloader used in the notebook used datasets lib > 1.5.0 which was incompatible once loaded in the training script inside the sagemaker docker container.

