### PR TITLE
Update sm notebook with latest TF & transformer version

### DIFF
--- a/sagemaker/07_tensorflow_distributed_training_data_parallelism/sagemaker-notebook.ipynb
+++ b/sagemaker/07_tensorflow_distributed_training_data_parallelism/sagemaker-notebook.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"sagemaker>=2.31.0\" \"transformers>=4.4.2\" \"datasets[s3]>=1.5.0\" --upgrade"
+    "!pip install \"sagemaker>=2.31.0\" \"transformers>=4.5.0\" \"datasets[s3]>=1.5.0\" --upgrade"
    ]
   },
   {
@@ -445,7 +445,7 @@
     "    instance_type=instance_type,\n",
     "    instance_count=instance_count,\n",
     "    role=role,\n",
-    "    transformers_version='4.4.2',\n",
+    "    transformers_version='4.5.0',\n",
     "    tensorflow_version='2.4.1',\n",
     "    py_version='py37',\n",
     "    distribution=distribution,\n",
@@ -482,7 +482,7 @@
      "output_type": "stream",
      "text": [
       "container image used for training job: \n",
-      "564829616587.dkr.ecr.us-east-1.amazonaws.com/huggingface-training:tensorflow2.3.1-transformers4.3.1-tokenizers0.10.1-datasets1.2.1-py37-gpu-cu110\n",
+      "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-tensorflow-training:2.4.1-transformers4.5.0-gpu-py37-cu110-ubuntu18.04\n",
       "\n",
       "s3 uri where the trained model is located: \n",
       "s3://sagemaker-us-east-1-558105141721/huggingface-training-2021-02-16-11-57-47-658/output/model.tar.gz\n",


### PR DESCRIPTION
Currently the notebook fails with

```
[1,14]<stderr>:ImportError: cannot import name 'is_sagemaker_dp_enabled' from 'transformers.file_utils' (/usr/local/lib/python3.7/site-packages/transformers/file_utils.py)
```

Because the script used - https://github.com/huggingface/notebooks/blob/master/sagemaker/07_tensorflow_distributed_training_data_parallelism/scripts/train.py

`is_sagemaker_dp_enabled` API is introduced in transformer 4.5.0 [not available in 4.4.1]