### PR TITLE
Translation: add sentencepiece to pip install

### DIFF
--- a/examples/translation.ipynb
+++ b/examples/translation.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers sacrebleu"
+    "#! pip install datasets transformers sacrebleu sentencepiece"
    ]
   },
   {


### PR DESCRIPTION
`sentencepiece` is required by the `AutoTokenizer`, see https://github.com/AI4Bharat/indic-bert/issues/9

