### PR TITLE
Update training.ipynb

### DIFF
--- a/transformers_doc/training.ipynb
+++ b/transformers_doc/training.ipynb
@@ -9,7 +9,8 @@
     "# Transformers installation\n",
     "! pip install transformers\n",
     "# To install from source instead of the last release, comment the command above and uncomment the following one.\n",
-    "# ! pip install git+https://github.com/huggingface/transformers.git\n"
+    "# ! pip install git+https://github.com/huggingface/transformers.git\n",
+    "! pip install datasets\n"
    ]
   },
   {


### PR DESCRIPTION
Need to `pip install datasets`

Also the first link to the HuggingFace datasets page points to a 404 page

https://huggingface.co/github.com/huggingface/datasets

Also 

```
outputs = model(**batch)
loss = outputs.loss
```

Needed to be changed to on AWS but weirdly enough this isn't an issue on Google Collab. Both are using 4.9.1


```
loss, outputs = model(**batch)
```