### PR TITLE
Fix the link to run_summarization.py

### DIFF
--- a/sagemaker/08_distributed_summarization_bart_t5/sagemaker-notebook.ipynb
+++ b/sagemaker/08_distributed_summarization_bart_t5/sagemaker-notebook.ipynb
@@ -195,7 +195,7 @@
    "source": [
     "## Configure distributed training and hyperparameters\n",
     "\n",
-    "Next, we will define our `hyperparameters` and configure our distributed training strategy. As hyperparameter, we can define any [Seq2SeqTrainingArguments](https://huggingface.co/transformers/main_classes/trainer.html#seq2seqtrainingarguments) and the ones defined in [run_summarization.py](https://github.com/huggingface/transformers/tree/master/examples/seq2seq#sequence-to-sequence-training-and-evaluation). "
+    "Next, we will define our `hyperparameters` and configure our distributed training strategy. As hyperparameter, we can define any [Seq2SeqTrainingArguments](https://huggingface.co/transformers/main_classes/trainer.html#seq2seqtrainingarguments) and the ones defined in [run_summarization.py](https://github.com/huggingface/transformers/blob/v4.6.0-release/examples/pytorch/summarization/run_summarization.py). "
    ]
   },
   {


### PR DESCRIPTION
The existing link to 'run_summarization.py' is broken (404). This commit corrects the link to the supported run_summarization.py
Moreover, the latest run_summarization.py is not compatible and the file from v4.6 needs to be linked.