### PR TITLE
Fixing the dataset http link that points to the Not Found page

### DIFF
--- a/course/chapter5/section4.ipynb
+++ b/course/chapter5/section4.ipynb
@@ -55,7 +55,7 @@
     "from datasets import load_dataset\n",
     "\n",
     "# This takes a few minutes to run, so go grab a tea or coffee while you wait :)\n",
-    "data_files = \"https://the-eye.eu/public/AI/pile_preliminary_components/PUBMED_title_abstracts_2019_baseline.jsonl.zst\"\n",
+    "data_files = \"http://eaidata.bmk.sh/data/PUBMED_title_abstracts_2019_baseline.jsonl.zst\"\n",
     "pubmed_dataset = load_dataset(\"json\", data_files=data_files, split=\"train\")\n",
     "pubmed_dataset"
    ]


### PR DESCRIPTION
The original dataset link links to Not Found page. I updated a working one