### PR TITLE
Fix translation notebooks

### DIFF
--- a/examples/translation-tf.ipynb
+++ b/examples/translation-tf.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install transformers datasets\n",
+    "#! pip install transformers[sentencepiece] datasets\n",
     "#! pip install sacrebleu sentencepiece\n",
     "#! pip install huggingface_hub"
    ]
@@ -1110,7 +1110,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\r",
+      "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\r\n",
       "38145/38145 [==============================] - 3350s 87ms/step - loss: 0.7139 - val_loss: 1.2774 - bleu: 12.5400 - gen_len: 62.1458\n"
      ]
     },

--- a/examples/translation.ipynb
+++ b/examples/translation.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers sacrebleu"
+    "#! pip install datasets transformers[sentencepiece] sacrebleu"
    ]
   },
   {
@@ -784,7 +784,7 @@
     "batch_size = 16\n",
     "model_name = model_checkpoint.split(\"/\")[-1]\n",
     "args = Seq2SeqTrainingArguments(\n",
-    "    f\"{model_name}-finetuned-{source_lang}-to-{target-lang}\",\n",
+    "    f\"{model_name}-finetuned-{source_lang}-to-{target_lang}\",\n",
     "    evaluation_strategy = \"epoch\",\n",
     "    learning_rate=2e-5,\n",
     "    per_device_train_batch_size=batch_size,\n",
@@ -1019,6 +1019,9 @@
   "colab": {
    "name": "Translation",
    "provenance": []
+  },
+  "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fixes a tiny bug in a variable name for the PyTorch translation notebook of `transformers`. I also added `sentencepiece` to the installation as popular models like M2M100 depend on it.