### PR TITLE
Update import for AdamW to torch.optim

### DIFF
--- a/course/chapter3/section4.ipynb
+++ b/course/chapter3/section4.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import AdamW\n",
+    "from torch.optim import AdamW\n",
     "\n",
     "optimizer = AdamW(model.parameters(), lr=5e-5)"
    ]
@@ -361,6 +361,9 @@
   "colab": {
    "name": "A full training",
    "provenance": []
+  },
+  "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since `from transformers import AdamW` raises a deprecation warning now, I changed the import to `from torch.optim import AdamW` as per the deprecation message suggestion.