### PR TITLE
Correct .jsonl Filename Inconsistency

### DIFF
--- a/course/chapter5/section5.ipynb
+++ b/course/chapter5/section5.ipynb
@@ -396,7 +396,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "issues_with_comments_dataset.to_json(\"issues-datasets-with-comments.jsonl\")"
+    "issues_with_comments_dataset.to_json(\"datasets-issues-with-comments.jsonl\")"
    ]
   },
   {
@@ -508,7 +508,7 @@
     }
    ],
    "source": [
-    "remote_dataset = load_dataset(\"lewtun/github-issues\", split=\"train\")\n",
+    "remote_dataset = load_dataset(\"<YOUR_HUGGINGFACE_USERNAME>/github-issues\", split=\"train\")\n",
     "remote_dataset"
    ]
   }


### PR DESCRIPTION
1. Renamed .jsonl filename to be consistent with later cell that copies it: "!cp datasets-issues-with-comments.jsonl github-issues/"
2. Make explicity to use user's HF username

# What does this PR do?

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Create a post on our forums and tag @lewtun (https://discuss.huggingface.co/c/course/20)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
