### PR TITLE
:bug: hotfix asr bug in quicktour notebooks

### DIFF
--- a/transformers_doc/en/quicktour.ipynb
+++ b/transformers_doc/en/quicktour.ipynb
@@ -286,7 +286,7 @@
     }
    ],
    "source": [
-    "result = speech_recognizer(dataset[:4][\"audio\"])\n",
+    "result = speech_recognizer([ex['array'] for ex in dataset[:4][\"audio\"]])\n",
     "print([d[\"text\"] for d in result])"
    ]
   },
@@ -814,7 +814,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/transformers_doc/es/quicktour.ipynb
+++ b/transformers_doc/es/quicktour.ipynb
@@ -285,7 +285,7 @@
     }
    ],
    "source": [
-    "result = speech_recognizer(dataset[:4][\"audio\"])\n",
+    "result = speech_recognizer([ex['array'] for ex in dataset[:4][\"audio\"]])\n",
     "print([d[\"text\"] for d in result])"
    ]
   },
@@ -825,7 +825,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/transformers_doc/quicktour.ipynb
+++ b/transformers_doc/quicktour.ipynb
@@ -286,7 +286,7 @@
     }
    ],
    "source": [
-    "result = speech_recognizer(dataset[:4][\"audio\"])\n",
+    "result = speech_recognizer([ex['array'] for ex in dataset[:4][\"audio\"]])\n",
     "print([d[\"text\"] for d in result])"
    ]
   },
@@ -814,7 +814,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
# What does this PR do?

Fixes issue [reported in the forums](https://discuss.huggingface.co/t/bug-keyerror-raw-on-quick-tour-pytorch/17819) where the quicktour notebooks fail on the ASR pipeline. Perhaps this is caused by the new release of `datasets` (CC @lhoestq)

The pipeline from transformers is expecting a key, 'raw', that doesn't exist. Instead, here I just pass the audio arrays as a list, which is another accepted input type. 

## Who can review?

@patrickvonplaten @anton-l 
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
