### PR TITLE
Fix: removed non-declared variable

### DIFF
--- a/examples/token_classification.ipynb
+++ b/examples/token_classification.ipynb
@@ -416,7 +416,7 @@
     }
    ],
    "source": [
-    "label_list = datasets[\"train\"].features[f\"{task}_tags\"].feature.names\n",
+    "label_list = datasets[\"train\"].features[f\"ner_tags\"].feature.names\n",
     "label_list"
    ]
   },


### PR DESCRIPTION
The `task` variable does not exist in this notebook version. Replaced it by `ner`.
The cell otherwise cannot be executed.

# What does this PR do?

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Create a post on our forums and tag @lewtun (https://discuss.huggingface.co/c/course/20)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
