### PR TITLE
bump diffusers to 0.2.3

### DIFF
--- a/diffusers/training_example.ipynb
+++ b/diffusers/training_example.ipynb
@@ -57,9 +57,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install diffusers[training]==0.1.3\n",
-    "!pip install accelerate\n",
-    "!pip install datasets"
+    "!pip install diffusers[training]==0.2.3"
    ]
   },
   {
@@ -398,17 +396,17 @@
    "source": [
     "from datasets import load_dataset\n",
     "\n",
-    "config.dataset = \"huggan/smithsonian_butterflies_subset\"\n",
-    "dataset = load_dataset(config.dataset, split=\"train\")\n",
+    "config.dataset_name = \"huggan/smithsonian_butterflies_subset\"\n",
+    "dataset = load_dataset(config.dataset_name, split=\"train\")\n",
     "\n",
     "# Feel free to try other datasets from https://hf.co/huggan/ too! \n",
     "# Here's is a dataset of flower photos:\n",
-    "# config.dataset = \"huggan/flowers-102-categories\"\n",
-    "# dataset = load_dataset(config.dataset, split=\"train\")\n",
+    "# config.dataset_name = \"huggan/flowers-102-categories\"\n",
+    "# dataset = load_dataset(config.dataset_name, split=\"train\")\n",
     "\n",
     "# Or just load images from a local folder!\n",
-    "# config.dataset = \"imagefolder\"\n",
-    "# dataset = load_dataset(config.dataset, data_dir=\"path/to/folder\")"
+    "# config.dataset_name = \"imagefolder\"\n",
+    "# dataset = load_dataset(config.dataset_name, data_dir=\"path/to/folder\")"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

Update pinned `diffusers` versions to `0.2.3`
