### PR TITLE
Fix colab widgets in diffusers training

### DIFF
--- a/diffusers/training_example.ipynb
+++ b/diffusers/training_example.ipynb
@@ -57,9 +57,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install diffusers[training]==0.1.3\n",
-    "!pip install accelerate\n",
-    "!pip install datasets"
+    "!pip install diffusers[training]==0.2.3"
    ]
   },
   {
@@ -398,17 +396,17 @@
    "source": [
     "from datasets import load_dataset\n",
     "\n",
-    "config.dataset = \"huggan/smithsonian_butterflies_subset\"\n",
-    "dataset = load_dataset(config.dataset, split=\"train\")\n",
+    "config.dataset_name = \"huggan/smithsonian_butterflies_subset\"\n",
+    "dataset = load_dataset(config.dataset_name, split=\"train\")\n",
     "\n",
     "# Feel free to try other datasets from https://hf.co/huggan/ too! \n",
     "# Here's is a dataset of flower photos:\n",
-    "# config.dataset = \"huggan/flowers-102-categories\"\n",
-    "# dataset = load_dataset(config.dataset, split=\"train\")\n",
+    "# config.dataset_name = \"huggan/flowers-102-categories\"\n",
+    "# dataset = load_dataset(config.dataset_name, split=\"train\")\n",
     "\n",
     "# Or just load images from a local folder!\n",
-    "# config.dataset = \"imagefolder\"\n",
-    "# dataset = load_dataset(config.dataset, data_dir=\"path/to/folder\")"
+    "# config.dataset_name = \"imagefolder\"\n",
+    "# dataset = load_dataset(config.dataset_name, data_dir=\"path/to/folder\")"
    ]
   },
   {

--- a/diffusers/training_example.ipynb
+++ b/diffusers/training_example.ipynb
@@ -43,23 +43,47 @@
     "This notebook leverages the [🤗 Datasets](https://huggingface.co/docs/datasets/index) library to load and preprocess image datasets and the [🤗 Accelerate](https://huggingface.co/docs/accelerate/index) library to simplify training on any number of GPUs, with features like automatic gradient accumulation and tensorboard logging. Let's install them here:"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4dnwEwhV4SrD",
-   "metadata": {
-    "id": "4dnwEwhV4SrD",
-    "pycharm": {
-     "name": "#%%\n",
-     "is_executing": true
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "!pip install diffusers[training]==0.2.3"
-   ]
-  },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "4dnwEwhV4SrD",
+      "metadata": {
+        "id": "4dnwEwhV4SrD",
+        "pycharm": {
+          "name": "#%%\n",
+          "is_executing": true
+        }
+      },
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "!pip install diffusers[training]==0.2.3\n",
+        "!pip install \"ipywidgets>=7,<8\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "As google colab has disabled external widgtes, we need to enable it explicitly. Run the following cell to be able to use `notebook_login` and `tqdm`:"
+      ],
+      "metadata": {
+        "id": "Hp79FSkYihOh"
+      },
+      "id": "Hp79FSkYihOh"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import output\n",
+        "output.enable_custom_widget_manager()"
+      ],
+      "metadata": {
+        "id": "olGZ1D-Bg4GN"
+      },
+      "id": "olGZ1D-Bg4GN",
+      "execution_count": 2,
+      "outputs": []
+    },
   {
    "cell_type": "markdown",
    "source": [


### PR DESCRIPTION
# What does this PR do?

Fixes the recent issue with external widgets in Colab to be able to run `notebook_login`