### PR TITLE
update diffusers install version in sd_dreambooth_inference.ipynb

### DIFF
--- a/diffusers/sd_dreambooth_inference.ipynb
+++ b/diffusers/sd_dreambooth_inference.ipynb
@@ -734,7 +734,8 @@
       "outputs": [],
       "source": [
         "#@title Install and import requirements\n",
-        "!pip install -qqq diffusers==0.4.1 transformers gradio ftfy \n",
+        "!pip install -U -qq git+https://github.com/huggingface/diffusers.git \n",
+        "!pip install -qqq transformers gradio ftfy \n",
         "\n",
         "import diffusers\n",
         "import gradio\n",


### PR DESCRIPTION
# What does this PR do?
Fixes https://github.com/huggingface/notebooks/issues/278

In short: new models won't load with the old version of diffusers.

Fixes # 278

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.
@muellerzr, @LysandreJik
really anyone who can re-run to validate
