### PR TITLE
Use `data_dir` defined in a previous cell

### DIFF
--- a/examples/accelerate_examples/simple_cv_example.ipynb
+++ b/examples/accelerate_examples/simple_cv_example.ipynb
@@ -208,7 +208,7 @@
    "source": [
     "# Grab all the image filenames\n",
     "fnames = [\n",
-    "    os.path.join(\"../../images\", fname)\n",
+    "    os.path.join(data_dir, fname)\n",
     "    for fname in fnames\n",
     "    if fname.endswith(\".jpg\")\n",
     "]\n",


### PR DESCRIPTION
# What does this PR do?

Small fix: use `data_dir` instead of hardcoding the path to the images. I was going through the notebook to try `accelerate`, my images were already available at `~/.fastai/data/...` so I changed `data_dir` to point there.
