### PR TITLE
add: semantic segmentation using PT and Trainer.

### DIFF
--- a/examples/semantic_segmentation.ipynb
+++ b/examples/semantic_segmentation.ipynb
@@ -1228,7 +1228,7 @@
    "source": [
     "What do you think? Would you send our pizza delivery robot on the road with this segmentation information?\n",
     "\n",
-    "The result might not be perfect yet, but we can always expand our dataset to make the model more robust. We can now also go train a larger SegFormer model, and see how it stacks up. Here's a call for actions:\n",
+    "The result might not be perfect yet, but we can always expand our dataset to make the model more robust. We can now also go train a larger SegFormer model, and see how it stacks up. If you want to explore further beyond this notebook, here are some things you can try next:\n",
     "\n",
     "* Train the model for longer. \n",
     "* Try out the different segmentation-specific training augmentations from libraries like [`albumentations`](https://albumentations.ai/docs/getting_started/mask_augmentation/). \n",

--- a/examples/semantic_segmentation.ipynb
+++ b/examples/semantic_segmentation.ipynb
@@ -1,1253 +1,1266 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU",
-    "gpuClass": "premium"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "CL089-JvFAXe"
+   },
+   "source": [
+    "# Fine-tuning for Semantic Segmentation with 🤗 Transformers\n",
+    "\n",
+    "In this notebook, you'll learn how to fine-tune a pretrained vision model for Semantic Segmentation on a custom dataset in PyTorch. The idea is to add a randomly initialized segmentation head on top of a pre-trained encoder, and fine-tune the model altogether on a labeled dataset. You can find an accompanying blog post [here](https://huggingface.co/blog/fine-tune-segformer). "
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2UEtIWt0sGkR"
+   },
+   "source": [
+    "## Model\n",
+    "\n",
+    "This notebook is built for the [SegFormer model](https://huggingface.co/docs/transformers/model_doc/segformer#transformers.SegformerForSemanticSegmentation) and is supposed to run on any semantic segmentation dataset. You can adapt this notebook to other supported semantic segmentation models such as [MobileViT](https://huggingface.co/docs/transformers/model_doc/mobilevit)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "j9Fe4GuFtRMs"
+   },
+   "source": [
+    "## Data augmentation\n",
+    "\n",
+    "This notebook leverages `torchvision`'s [`transforms` module](https://pytorch.org/vision/stable/transforms.html) for applying data augmentation. Using other augmentation libraries like `albumentations` is also [supported](https://github.com/huggingface/notebooks/blob/main/examples/image_classification_albumentations.ipynb).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Depending on the model and the GPU you are using, you might need to adjust the batch size to avoid out-of-memory errors. Set those two parameters, then the rest of the notebook should run smoothly.\n",
+    "\n",
+    "In this notebook, we'll fine-tune from the https://huggingface.co/nvidia/mit-b0 checkpoint, but note that there are others [available on the hub](https://huggingface.co/models?pipeline_tag=image-segmentation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6EGlFGE8uyBS"
+   },
+   "outputs": [],
+   "source": [
+    "model_checkpoint = \"nvidia/mit-b0\"  # pre-trained model from which to fine-tune\n",
+    "batch_size = 4  # batch size for training and evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "d32sBZeq_HQ2"
+   },
+   "source": [
+    "Before we start, let's install the `datasets`, `transformers`, and `evaluate` libraries. We also install Git-LFS to upload the model checkpoints to Hub.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vAvgC48er3Ih"
+   },
+   "outputs": [],
+   "source": [
+    "!pip -q install datasets transformers evaluate\n",
+    "\n",
+    "!git lfs install\n",
+    "!git config --global credential.helper store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qSq03UMRvjRS"
+   },
+   "source": [
+    "If you're opening this notebook locally, make sure your environment has an install from the last version of those libraries or run the `pip install` command above with the `--upgrade` flag.\n",
+    "\n",
+    "You can share the resulting model with the community. By pushing the model to the Hub, others can discover your model and build on top of it. You also get an automatically generated model card that documents how the model works and a widget that will allow anyone to try out the model directly in the browser. To enable this, you'll need to login to your account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PlSGaFpFuQSW"
+   },
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import notebook_login\n",
+    "\n",
+    "notebook_login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XalxdrirGkLl"
+   },
+   "source": [
+    "## Fine-tuning a model on a semantic segmentation task\n",
+    "\n",
+    "Given an image, the goal is to associate each and every pixel to a particular category (such as table). The screenshot below is taken from a [SegFormer fine-tuned on ADE20k](https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512) - try out the inference widget!\n",
+    "\n",
+    "<img src=\"https://i.ibb.co/8B8xy1R/image.png\" alt=\"drawing\" width=\"600\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mcE455KaG687"
+   },
+   "source": [
+    "### Loading the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RD_G2KJgG_bU"
+   },
+   "source": [
+    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download our custom dataset into a [`DatasetDict`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasetdict).\n",
+    "\n",
+    "We're using the Sidewalk dataset which is dataset of sidewalk images gathered in Belgium in the summer of 2021. You can learn more about the dataset [here](https://huggingface.co/datasets/segments/sidewalk-semantic)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 281,
+     "referenced_widgets": [
+      "6de4fc2807bc4bb0825befbbaca366c9",
+      "77c817c830314013805fbd0d203ea8b8",
+      "f1f9875ed07b480591c975222fc95950",
+      "3a36ff18a13e46768228e7128e02002b",
+      "c7d020044efb4725a24a0a84ae7409fa",
+      "ad66d4abe2e2450cb7c8a573dc50d9ff",
+      "3e3d572c197e464da6a3ce0cfc4cc89e",
+      "59c9c5f2ef6d4625a97a4bc9bdc331b2",
+      "9725bcfbf9d54824974e8e69c64ca6fd",
+      "83896f5e610144adb992c63e9cbd56ff",
+      "ef4a5405c1d34d5badf0a813a8ea1fa5",
+      "289120fb74224df4a9d2aa2821432ba5",
+      "f7e2d0f3ee6e4231b22616fbf933bf02",
+      "78a551a0db66493f876fbe18030c3174",
+      "f3174b816bec4c918cd3ab4b10ec0efe",
+      "4fa96e02fc4b44cb9996bbef089fd74c",
+      "0031937aefa0465683e219549c935dd7",
+      "d1b7953db7a6462f831fb075199542ef",
+      "1c4348e789704fe2b25cb8698e88ca8e",
+      "bff07d8078824308b8aabf71faf16e88",
+      "12a94046754c49868ad14d688c48d88f",
+      "5ad48a5ce1dc426faa6e790064418c9b",
+      "3de3cc234bda43c1ad0b354dbc474ef6",
+      "d9f56ee4b21f4e0e8693232cbb490cdd",
+      "05621203ac434c5f93d355bb6ce6db3d",
+      "d134802237f84c73a2717eed6cc1ecb4",
+      "afce9206edbb444a944c291d5282c217",
+      "a60fbc5906394df9858d898670a7f819",
+      "1ee064e37e61448cb9a34fa7e66a3e34",
+      "01ecfb419b3f460b8377c79793740982",
+      "43f8dc298b7941bf8ca651015dec533c",
+      "32988ad67af149489bfd676c0942dbe4",
+      "a687b33460fa461eafec017738c863de",
+      "c5030cc8ebff4e628da62e8835965f33",
+      "33ad7766b2c146afb54a3470f352b8ee",
+      "915fad5434a545b086baf639459d4558",
+      "79894b070903437584f7aca3052e50de",
+      "ad87c3f60ac7492ab8aaa471630c41c7",
+      "e74bfbec17f94789bfb8e367983aa193",
+      "dccebc6c988d49c887484b78f4ee95e9",
+      "d04bc0eadaf242b6a81a9ade962c4de2",
+      "4ab875034a084c338994bc7909053241",
+      "3e2ff151429e49f5aaffd0a940d36805",
+      "0459a4d9fcbd4478a52481ac016ddd78",
+      "23735d2bbcf24587859d5d36bf901fd0",
+      "ca4341aa40384d228a99074543527b31",
+      "974c53ab4fb94ee3a86f650bba9562c1",
+      "3d40886e38454a618a8a9a756f5c458d",
+      "8db4e36ccc6a4d4492b78a50c7ec2409",
+      "ab102484e15d44a4b1182029637dfc30",
+      "389469716c4e42c884ca47c6659d5612",
+      "4d6b9ad04eab4a70bf1df3f43a7f5f94",
+      "b969b475e1b149dda5b119e37d7761c7",
+      "c298ba164a35417b9b1fff7a97bd7f7f",
+      "c8cd775a94a944d9a0e0ebeb2c3645f8",
+      "2cbb298d54ac4771be87a85cbcb5dff4",
+      "1a5bc3a601a949b5ab59b4a4b776f2f0",
+      "8c9c506bf6dd47fd882e8d70581e54c2",
+      "8652d0f8599843e98edfe6c21de5be9c",
+      "3b280d74e111402d94a18f61fe8c4478",
+      "998feff5e78b491dacc43d045c73cb8c",
+      "9747349d77e14ab3a47fd4c479970a0a",
+      "47cf642995f44f04a56be02be4ab0a87",
+      "dadc0338ea954e478246a588b2aa1dc7",
+      "219ab526698c43f895ca102befa0135c",
+      "ff2adb06e63e47798f7130e9630c1255",
+      "f596082d8bda42458543179605fb2dc2",
+      "af8c7c09c55341a6a14b4799ae2dff44",
+      "396a68b4f1b947b9876a9587b6958fce",
+      "a3a68016faa148158bd9f4d805863295",
+      "3bea3ea92ee8481fb036fa4e07c08009",
+      "0d05591c5dd74c26b9399ece8cea12b0",
+      "ea01151241174b9da977485761a27463",
+      "b2985292e9d24f8ab6c6523056d8371a",
+      "4af03fff36ed4c569c86908f228f7954",
+      "ae1bd290c1474450a169593db137974f",
+      "097c5b79a85642efa389e68aa5df428c"
+     ]
+    },
+    "id": "U10po8Q3w9ZJ",
+    "outputId": "292c707c-2cae-4818-fe23-f9c71efe0f37"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "CL089-JvFAXe"
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6de4fc2807bc4bb0825befbbaca366c9",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "source": [
-        "# Fine-tuning for Semantic Segmentation with 🤗 Transformers\n",
-        "\n",
-        "This tutorial shows how to fine-tune a SegFormer model in PyTorch for the task of semantic segmentation. You can find an accompanying blog post [here](https://huggingface.co/blog/fine-tune-segformer). \n",
-        "\n",
-        "This notebook shows how to fine-tune a pretrained vision model for Semantic Segmentation on a custom dataset. The idea is to add a randomly initialized segmentation head on top of a pre-trained encoder, and fine-tune the model altogether on a labeled dataset."
+      "text/plain": [
+       "Downloading metadata:   0%|          | 0.00/635 [00:00<?, ?B/s]"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2UEtIWt0sGkR"
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "289120fb74224df4a9d2aa2821432ba5",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "source": [
-        "## Model\n",
-        "\n",
-        "This notebook is built for the [SegFormer model](https://huggingface.co/docs/transformers/model_doc/segformer#transformers.SegformerForSemanticSegmentation) and is supposed to run on any semantic segmentation dataset. You can adapt this notebook to other supported semantic segmentation models such as [MobileViT](https://huggingface.co/docs/transformers/model_doc/mobilevit)."
+      "text/plain": [
+       "Downloading readme:   0%|          | 0.00/4.26k [00:00<?, ?B/s]"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "j9Fe4GuFtRMs"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:datasets.builder:Using custom data configuration segments--sidewalk-semantic-2-007b1ee78ca1e890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading and preparing dataset None/None (download: 309.28 MiB, generated: 309.93 MiB, post-processed: Unknown size, total: 619.21 MiB) to /root/.cache/huggingface/datasets/segments___parquet/segments--sidewalk-semantic-2-007b1ee78ca1e890/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3de3cc234bda43c1ad0b354dbc474ef6",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "source": [
-        "## Data augmentation\n",
-        "\n",
-        "This notebook leverages `torchvision`'s [`transforms` module](https://pytorch.org/vision/stable/transforms.html) for applying data augmentation. Using other augmentation libraries like `albumentations` is also [supported](https://github.com/huggingface/notebooks/blob/main/examples/image_classification_albumentations.ipynb).\n",
-        "\n",
-        "---\n",
-        "\n",
-        "Depending on the model and the GPU you are using, you might need to adjust the batch size to avoid out-of-memory errors. Set those two parameters, then the rest of the notebook should run smoothly.\n",
-        "\n",
-        "In this notebook, we'll fine-tune from the https://huggingface.co/nvidia/mit-b0 checkpoint, but note that there are others [available on the hub](https://huggingface.co/models?pipeline_tag=image-segmentation)."
+      "text/plain": [
+       "Downloading data files:   0%|          | 0/1 [00:00<?, ?it/s]"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6EGlFGE8uyBS"
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c5030cc8ebff4e628da62e8835965f33",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "outputs": [],
-      "source": [
-        "model_checkpoint = \"nvidia/mit-b0\"  # pre-trained model from which to fine-tune\n",
-        "batch_size = 4  # batch size for training and evaluation"
+      "text/plain": [
+       "Downloading data:   0%|          | 0.00/324M [00:00<?, ?B/s]"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "d32sBZeq_HQ2"
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23735d2bbcf24587859d5d36bf901fd0",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "source": [
-        "Before we start, let's install the `datasets`, `transformers`, and `evaluate` libraries. We also install Git-LFS to upload the model checkpoints to Hub.\n",
-        "\n"
+      "text/plain": [
+       "Extracting data files:   0%|          | 0/1 [00:00<?, ?it/s]"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vAvgC48er3Ih"
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2cbb298d54ac4771be87a85cbcb5dff4",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "outputs": [],
-      "source": [
-        "!pip -q install datasets transformers evaluate\n",
-        "\n",
-        "!git lfs install\n",
-        "!git config --global credential.helper store"
+      "text/plain": [
+       "0 tables [00:00, ? tables/s]"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qSq03UMRvjRS"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset parquet downloaded and prepared to /root/.cache/huggingface/datasets/segments___parquet/segments--sidewalk-semantic-2-007b1ee78ca1e890/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec. Subsequent calls will reuse this data.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f596082d8bda42458543179605fb2dc2",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "source": [
-        "If you're opening this notebook locally, make sure your environment has an install from the last version of those libraries.\n",
-        "\n",
-        "You can share the resulting model with the community. By pushing the model to the Hub, others can discover your model and build on top of it. You also get an automatically generated model card that documents how the model works and a widget that will allow anyone to try out the model directly in the browser. To enable this, you'll need to login to your account."
+      "text/plain": [
+       "  0%|          | 0/1 [00:00<?, ?it/s]"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PlSGaFpFuQSW"
-      },
-      "outputs": [],
-      "source": [
-        "from huggingface_hub import notebook_login\n",
-        "\n",
-        "notebook_login()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XalxdrirGkLl"
-      },
-      "source": [
-        "## Fine-tuning a model on a semantic segmentation task\n",
-        "\n",
-        "In this notebook, we will see how to fine-tune one of the [🤗 Transformers](https://github.com/huggingface/transformers) vision models on a Semantic Segmentation dataset.\n",
-        "\n",
-        "Given an image, the goal is to associate each and every pixel to a particular category (such as table). The screenshot below is taken from a [SegFormer fine-tuned on ADE20k](https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512) - try out the inference widget!\n",
-        "\n",
-        "<img src=\"https://i.ibb.co/8B8xy1R/image.png\" alt=\"drawing\" width=\"600\"/>\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mcE455KaG687"
-      },
-      "source": [
-        "### Loading the dataset"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RD_G2KJgG_bU"
-      },
-      "source": [
-        "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download our custom dataset into a [`DatasetDict`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasetdict)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 281,
-          "referenced_widgets": [
-            "6de4fc2807bc4bb0825befbbaca366c9",
-            "77c817c830314013805fbd0d203ea8b8",
-            "f1f9875ed07b480591c975222fc95950",
-            "3a36ff18a13e46768228e7128e02002b",
-            "c7d020044efb4725a24a0a84ae7409fa",
-            "ad66d4abe2e2450cb7c8a573dc50d9ff",
-            "3e3d572c197e464da6a3ce0cfc4cc89e",
-            "59c9c5f2ef6d4625a97a4bc9bdc331b2",
-            "9725bcfbf9d54824974e8e69c64ca6fd",
-            "83896f5e610144adb992c63e9cbd56ff",
-            "ef4a5405c1d34d5badf0a813a8ea1fa5",
-            "289120fb74224df4a9d2aa2821432ba5",
-            "f7e2d0f3ee6e4231b22616fbf933bf02",
-            "78a551a0db66493f876fbe18030c3174",
-            "f3174b816bec4c918cd3ab4b10ec0efe",
-            "4fa96e02fc4b44cb9996bbef089fd74c",
-            "0031937aefa0465683e219549c935dd7",
-            "d1b7953db7a6462f831fb075199542ef",
-            "1c4348e789704fe2b25cb8698e88ca8e",
-            "bff07d8078824308b8aabf71faf16e88",
-            "12a94046754c49868ad14d688c48d88f",
-            "5ad48a5ce1dc426faa6e790064418c9b",
-            "3de3cc234bda43c1ad0b354dbc474ef6",
-            "d9f56ee4b21f4e0e8693232cbb490cdd",
-            "05621203ac434c5f93d355bb6ce6db3d",
-            "d134802237f84c73a2717eed6cc1ecb4",
-            "afce9206edbb444a944c291d5282c217",
-            "a60fbc5906394df9858d898670a7f819",
-            "1ee064e37e61448cb9a34fa7e66a3e34",
-            "01ecfb419b3f460b8377c79793740982",
-            "43f8dc298b7941bf8ca651015dec533c",
-            "32988ad67af149489bfd676c0942dbe4",
-            "a687b33460fa461eafec017738c863de",
-            "c5030cc8ebff4e628da62e8835965f33",
-            "33ad7766b2c146afb54a3470f352b8ee",
-            "915fad5434a545b086baf639459d4558",
-            "79894b070903437584f7aca3052e50de",
-            "ad87c3f60ac7492ab8aaa471630c41c7",
-            "e74bfbec17f94789bfb8e367983aa193",
-            "dccebc6c988d49c887484b78f4ee95e9",
-            "d04bc0eadaf242b6a81a9ade962c4de2",
-            "4ab875034a084c338994bc7909053241",
-            "3e2ff151429e49f5aaffd0a940d36805",
-            "0459a4d9fcbd4478a52481ac016ddd78",
-            "23735d2bbcf24587859d5d36bf901fd0",
-            "ca4341aa40384d228a99074543527b31",
-            "974c53ab4fb94ee3a86f650bba9562c1",
-            "3d40886e38454a618a8a9a756f5c458d",
-            "8db4e36ccc6a4d4492b78a50c7ec2409",
-            "ab102484e15d44a4b1182029637dfc30",
-            "389469716c4e42c884ca47c6659d5612",
-            "4d6b9ad04eab4a70bf1df3f43a7f5f94",
-            "b969b475e1b149dda5b119e37d7761c7",
-            "c298ba164a35417b9b1fff7a97bd7f7f",
-            "c8cd775a94a944d9a0e0ebeb2c3645f8",
-            "2cbb298d54ac4771be87a85cbcb5dff4",
-            "1a5bc3a601a949b5ab59b4a4b776f2f0",
-            "8c9c506bf6dd47fd882e8d70581e54c2",
-            "8652d0f8599843e98edfe6c21de5be9c",
-            "3b280d74e111402d94a18f61fe8c4478",
-            "998feff5e78b491dacc43d045c73cb8c",
-            "9747349d77e14ab3a47fd4c479970a0a",
-            "47cf642995f44f04a56be02be4ab0a87",
-            "dadc0338ea954e478246a588b2aa1dc7",
-            "219ab526698c43f895ca102befa0135c",
-            "ff2adb06e63e47798f7130e9630c1255",
-            "f596082d8bda42458543179605fb2dc2",
-            "af8c7c09c55341a6a14b4799ae2dff44",
-            "396a68b4f1b947b9876a9587b6958fce",
-            "a3a68016faa148158bd9f4d805863295",
-            "3bea3ea92ee8481fb036fa4e07c08009",
-            "0d05591c5dd74c26b9399ece8cea12b0",
-            "ea01151241174b9da977485761a27463",
-            "b2985292e9d24f8ab6c6523056d8371a",
-            "4af03fff36ed4c569c86908f228f7954",
-            "ae1bd290c1474450a169593db137974f",
-            "097c5b79a85642efa389e68aa5df428c"
-          ]
-        },
-        "id": "U10po8Q3w9ZJ",
-        "outputId": "292c707c-2cae-4818-fe23-f9c71efe0f37"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "6de4fc2807bc4bb0825befbbaca366c9",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Downloading metadata:   0%|          | 0.00/635 [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "289120fb74224df4a9d2aa2821432ba5",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Downloading readme:   0%|          | 0.00/4.26k [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "WARNING:datasets.builder:Using custom data configuration segments--sidewalk-semantic-2-007b1ee78ca1e890\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Downloading and preparing dataset None/None (download: 309.28 MiB, generated: 309.93 MiB, post-processed: Unknown size, total: 619.21 MiB) to /root/.cache/huggingface/datasets/segments___parquet/segments--sidewalk-semantic-2-007b1ee78ca1e890/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec...\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "3de3cc234bda43c1ad0b354dbc474ef6",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Downloading data files:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c5030cc8ebff4e628da62e8835965f33",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Downloading data:   0%|          | 0.00/324M [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "23735d2bbcf24587859d5d36bf901fd0",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Extracting data files:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "2cbb298d54ac4771be87a85cbcb5dff4",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "0 tables [00:00, ? tables/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Dataset parquet downloaded and prepared to /root/.cache/huggingface/datasets/segments___parquet/segments--sidewalk-semantic-2-007b1ee78ca1e890/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec. Subsequent calls will reuse this data.\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "f596082d8bda42458543179605fb2dc2",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "  0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from datasets import load_dataset\n",
-        "\n",
-        "hf_dataset_identifier = \"segments/sidewalk-semantic\"\n",
-        "ds = load_dataset(hf_dataset_identifier)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "y5z6SfJpJ5-e"
-      },
-      "source": [
-        "We're using the Sidewalk dataset which is dataset of sidewalk images gathered in Belgium in the summer of 2021. You can learn more about the dataset [here](https://huggingface.co/datasets/segments/sidewalk-semantic)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eq8mwsZU2j6t"
-      },
-      "source": [
-        "Let us also load the Mean IoU metric, which we'll use to evaluate our model both during and after training. \n",
-        "\n",
-        "IoU (short for Intersection over Union) tells us the amount of overlap between two sets. In our case, these sets will be the ground-truth segmentation map and the predicted segmentation map. To learn more, you can check out [this article](https://learnopencv.com/intersection-over-union-iou-in-object-detection-and-segmentation/)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 49,
-          "referenced_widgets": [
-            "4b1915eae45c4710b6a3f8495093956d",
-            "b42d735eeb0043e7b318004de525b55b",
-            "d1148b579b6e41af99f2463a799d6c90",
-            "501ff9d5db294d928f6367741bdd8f37",
-            "a494ba6485a14473abcff9a343e1038e",
-            "6fda21b649114145af09deb02b2d1e95",
-            "dca0b5e19b504879b6e821f43ccbed00",
-            "e9bf0dfb0a574cceb00953779da8d5f3",
-            "8de21d3ac33f47a39fbefa6395d703df",
-            "2da9282150f94994ad230dd70d9ddbbb",
-            "faa9ead661124af59981d5b0cb5d38b9"
-          ]
-        },
-        "id": "8UGse36eLeeb",
-        "outputId": "682ed0ad-b48b-4988-b8e2-aa25d216ae76"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "4b1915eae45c4710b6a3f8495093956d",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Downloading builder script:   0%|          | 0.00/13.1k [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "import evaluate\n",
-        "\n",
-        "metric = evaluate.load(\"mean_iou\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "r8mTmFdlHOmN"
-      },
-      "source": [
-        "The `ds` object itself is a `DatasetDict`, which contains one key per split (in this case, only \"train\" for a training split)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7tjOWPQYLq4u",
-        "outputId": "cf7abc33-2ce4-40c6-ee66-e8ce47a1c208"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "DatasetDict({\n",
-              "    train: Dataset({\n",
-              "        features: ['pixel_values', 'label'],\n",
-              "        num_rows: 1000\n",
-              "    })\n",
-              "})"
-            ]
-          },
-          "execution_count": 6,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "ds"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Yt_phZQsxz5M"
-      },
-      "source": [
-        "Here, the `features` tell us what each example is consisted of:\n",
-        "\n",
-        "* `pixel_values`: the actual image\n",
-        "* `label`: segmentation mask\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nfPPNjthI3u2"
-      },
-      "source": [
-        "To access an actual element, you need to select a split first, then give an index:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 217
-        },
-        "id": "BujWoSgyMQlw",
-        "outputId": "59c0dc81-3be5-4b38-f3bf-037133024e57"
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAEAAElEQVR4nGT9Z7Bm63IehnX3m1b44g6T5+R7zsW56dwLXGQQpGyAZDGBgChRLldZkgPtKrv4QyVX2ZaqZPuXbJfKVpUl2iRsmakEiwQE0YgkCJAALm4Abg4nzJlzJs9OX1zpTd3+sfbMPaL2VM1MfWGttdfbq/vpp5/uF//6n/+LX//617RWiAKiC6OrogTm137ore/eff/p9tHLr9y6OHt6+7XjDNz12QYYdi0nvbpY/+SP//T//W/9XWM0APzzf/LrX/q1X3nnwZO833zirU9/9d073/76n7z2yiv/x//N/xZL9+t/8OWXP/7qG2+84X0slPnl/+T/PJw+BTIggogAIILe93px+Kd+7K3PfuINNVk+3O2iLvyjB//P//pXlbaIiIhKobMaAf/4nQcvvvmjk2l5dTH77FtvvvTqazGph7186zvfuvN7v/E/+1//B0fXbnHOIpIyc0YkFlRCKEgAAggFgNNCiEqRMcYZVIiAwMwxxvGqiBQiEarg26EfTk5PTh49WiymWdIf/ovfff+9t//wi/+MSBuL9WLStM3nPvGnXnnljclk+Ydf+P2vf/OLyJxTECZE8nm4fu0aJJ7Oph988OF8uZjPCz/0bdesV5vB58l0LsgAzJIItbW6bRpn7JXjKxfbTVnZ4JMyCQC71jNzihJS1gilq5fLZdvtJvW8bVtjNRFsNtvXXnvFWnv//oO+6xUpo3Xb9lmEM1y/eaQIzs82Qx9u3T48PKqatlssDpC4rAofhq7r9s2+KhZvf+cRKbCmRIQQktaqbbvCuRRjShKGSCiuLBPn2bz+5CffvPv+nf22y0l0k/qH50+VUiiEQE7T1ePj5XSmiGaT6d373XTiX37tKlrqwq7yLF6Orhtrivt3w8X6otlvlweHAGAKR0RImHO2Sl2/dfP9u3f6zg/9wCl+9tOfqQ4P3njjk7vdbrNe33zpY9979NA5FFGAAiDMwpxYBEHlHJc2vXZYn/fwCAEABAAEEHE0lMLao3m9OT8p3XUU6PseEAB4avFzb336zm//8vmTx8urL3DOiKRIKWQEBKUFkDkDIgJWhma1BkIWSBlyBkAABGFE0CAAACAkAoycMpByTdvW9TQGsIVRWj98eJ8zhBBdUXkftdYgyZFCgaHv1+vV1aPjvutjDCICCpp92+53Xd8Bwm63ns2vOlemnJDIWW20boe2KDVksEZzzoRUVuV6t51Mah965wof913bx8iECIhKEwcWwe12K5ByDrPZJHPqup6IQghd1wFISslVDpBylsSZGWL0piq01pOJWSwWfb8jgv1+V9eThw8eLw5nXRs42d22A6Cc2LOfL2prDTOmlBAh52ytizELsI+BmYcheJ9i5BSTs4VeziYaUQGqUs8Oq1lZXL1+4CaU6lVxNLz147emxyzUPXh4Dmj6tgshTyZO6zy5MqOw223Xo2HZwuWcEzMLV7b49Gc/9vad91XTM/P56cXv/sk3P/1jP3h4PH306MGVK7f+8v/8bzR9++SbXyMCAAYEARYQYRbB7W47n5dWFS/M6m2hCAmeWReAMOeU4tF88nCzh3iUQ1ws5jknAeU4v3rz6EffevOD9959+TM/xiwgorVKcSi0AwDvvTWEQAiKgfokFhCQWAA4MUjOGS5dIyFgDJk528KQBiFYLherkzMk3mybP/iD3z87O+lavzw4KIvyfLtKUVIS1pRyTjmllEOIIhhSQkJLbr9vrdYxRmusKWi3W2mliLQiVVW1ccV6vyEkIru8snj08HFZOFu41HsiMsYIZ2OMVhz8oJxGAAIJAVJMIeSY/HK5UBogK2M0Z9P3/ejmF4t5VVbNvu+HMJ3VwxAePby4euXIFXazblarNalwcDTPzG27365z328Oj6bWMmd7cEDWlv2wL0u92+39gDEmrZTRBhEBIbMgMyEGH7/y5T+p6xIQkVDPJ66w1bXbixc+fvXoVu19H3NsY/OkWU+XUyXydLVyRrEoEWhazxlTyJMZsu0RVg+ffPjiy68BQOGs1tpo4wETpIPpoqwmoR2Yc9vuf/mX//F7T9/+3d//Vevstasv/C//V/+7N37ws/e+9idOawAFCMDMgBDT4mjx3ffvPnr6pJhXuqpWq41CzIICMaWolEJUmVEr2p89OAE5nLiu349mR4gG4VMfe3lVXemGXisKMRqOj+5+bzqdXb/+0ubi7PjKoSoKzhBzlCACShABlWBGACAEGO8MEACS7NrOFpOcIpG+OF0hqgf37gmm4+PlB+8PwrDe7NqhM9b4vgelnCtzopyyNabtOhQkIkAkRYv5winKHHPOgDH41EWvlDZWscqBfVFbiwZYCuusLnLOwfuisqhi4YhFiOzQRcmcQyqca9shRwicrDWKeLvdzmZ1ymCt9v3QdwNprOtaEaGAD6EoCwSNkHLCGEVprOtiCHFSO+3q85OnjrSxEEJIDK4qopeM/uDKlfUqxdjvmj55DENUCuu6IiSlFLMIC2o12hkCMkvMmax106uTN3/itfoaPVp/eLp/+uHTB6v97mK9f/jg8Wa9FdbNjrsmr8/3hSslU9/w9ixSUl1u/pvf/rttvwcA7QwaVCBK6ZRSVVfTaYnEmQMi3Lx5Yz6vTs+f9KFP0v69v/uLq8364MYtXc4ETIqQs2hSnGExn/+FP/dnsaj/43/wD//Wr//aF+/doVoxRxFkhpQkRg4xI9Nrt6/rPJRKHCkEFBCjtEKVev+xl1+JKaWQ+mb/wZ3v/PFX/+APvvDPnp7c+/Z3vtp2OyLFzCIIglFgiDlkjkxJiJEAySltldIajKbz86cxRhElTLPZLMZw88atGPODhw98aFnSMAzrdds1SUSsNYoUIYkwMxMRIipEZE6Dvzg9a9pdjCHGIMwiQqTatpvPZ0pR8J5Y+r7run4Y+tm86lovDNduTEllkaS14YyICoCiz97nqqq10TnnqqoWi2XXxb7PCtAa60NARK30drM/P1+HEJbL+cHBHFCms0lVFT70wxBSZAJdFNXqYtc2QwisSGllm12DLAJ5eVCHuAXMPqSqqokIAUSgbduyrOqqFgZEZGYRQSQiijHGGHU9mUwP3ePThyH22pLRulDFdhVCZB86Ms18PtEkikhyYjZa6bIqMuDeR1uob7z9R//F3/tP/yf/o39POyOQEQUAUspVVdf1/HHEb3/wyBl1eHD0+PFZOS2bLn37W3ecOv2//J/+b//aX/5rofO+2Q1d852v/vGXf/XXEGjoutKZzvOTi27NpxdD+/oLr57fPQdWCEhAIMRJUElRazFlVbvj5QEAAAABAEu/azgkN7EQZH1++u1vfOnBw/cBEDE/PXly9fqBqxaKLIICACAC4ZQlJVFKAWYCFs5WwFktyD72wmJN6f3Qdh0RHCyX3/jWviqrqpzttucAIpy1RmSllAIAEWGW6MPx0bEmfXF2BgAouFjMYmrrer7ZbK9ev3Z+frpv2qqqjDG563NMmjBkPjw8Pj4+6vp928TZbLZdt5t1XxRKUApTep+ECRCNcdaanAQB+364dv1ot9unIK62nJJWlHLSohDUyy+92Ow3Z+crW9jlcjqZTO5295AkZ1Gop5O50bprexE4ODg+Pr567/6Dod+uz1fVfKo0AQCSBB9ilHpSa9IxBGN1SsEYxZlRAAkBlFaKiJjFWquvHh1U1WS336LmIXJoGm3QmKJrOo0VQkhDNNoESb1nFq+yan139fqRTzz00U3Nr//zf/iJT/3gq7ffdLpwRbkHSTFU9aSoyoPrt7/5wVld1cX8hlEHjW9hgLOTi7Z5/O4Hj4+PbwiQmSxfev31t376p5y1//SX/itW+rzpf/tf/sueySTKQYfkXaliF1EhCgMYArAK0ejEkjkZawBICTEykCCRcAahEPs7d773/t3vpdzlFN955xs5p69/84u3X3zTWco5xUSIiEg5ZxFBTKTAKEIEBSoJx5S0Nn3TTeeaFAgBA967/2Hq9sez+QcxK6WjD5A55yggZVE552KMOebJpIx+0K6czScA0g8xcwohrTbb2WwSYqjqGkDlnNoukBjOrY85JUaUEPui1K7Q5YR6H4WhaXpncbVfA6CwaK1HVM7CpKQozMXFeQhhsVhwxpCGsqx8iCHEuiwQBIEQsK7Ki4ttCMEo0sY6Z5eLBXPshk5p1EY/OT0n4pdfvvnoATb7ZnWxQaSynMzn067zft31Q+uMQdRvvPGxzP0wDNuNSynljDmJVQoRjbWIqA/m87oonz55YgqjtRkCVsb2vSdUfR8Moipdigm1QjQIqiwLRH92epEhKScppqND/v/95j/4t/+Nf08ZY5QiIslCAsvlwQf3Vg9XrW3S9PBm5dzNwu535/PJjX2z//JXvv7Gx8NiuTRa9237Az/w8l/+H/8777/3/oePTv7k7t0/+N67rWTYtVVdhpB14fKQiUhEQJhQA4AiUlprRYXVQ0YAQAARycwhhgTchO7uB9+7uHgkHGIYCPV8sXz88MOLi8cvvfgp5gwjWgdOAFpEERASCnLChCI5phy7rv3db/3TK1euvvXWZy1pn+XBvbtf+ePfe//dd1hSypGZEUEpzAxEtFqtlKpIKc7cti0JoYKqLKyiEINSejKtJpOyql3OWWm937ZtMwCRCCOiMRoJrcWUQz2x9cQwaleozSZzDlVZGy3tridSTdMpRVprAECFKXBV2xi7ld9rTTmpvu9n87osy9OTk9lsprVt9l3XDcZYpVTfDdOZ2zYXItk6XVQGBHwYHj9+HCKXRR2GvF5vympy8nR1dDw3WnHMkjjmHFNkzrPZrO2aT336zRDCB3cf7PY7ydkWxmjtvdelcXVRaTRKFIlUk2LwvSEz+MHoomv2k7IgoGGIpJTSmgX7LgMSoOKcU8qr9far3/j9o+mNhTMIwMJh6Dml6Ww+xPzeO99RSjvr6kk9m81n9WQyX7740kvv3Tk5Oe9ff+Pll156OUW8e/fepz/5A3/13/l3f+/v/+I//C9/aRPipt1XN24QqvOL1bKegwCzIApABlBICCCcszZmMZ893TAoEIGcmZlTzhnk4vTk/jvfWa/PtSPO2Zq8W69TzE8ef/ix1z6XsyACs0KUiphQEyALAAhSJrJIRnI0hvp++3/9T/7uT/3En/r8539MK6UJN5unWXyMSSuiwuQUgLh0JZEqyzKEMRqy1qYfelTo/UBGgQBzns8mIfn9PqQUm6ZBsDnz0HeAUFgThVPKiLbvm3qi68lks2kQ0ahCa7vfd85pa7X3wRhnHaUUEXE2nRKSsWKM3u0b7RQRGFOVtvA+hBA3m20MaYj9ZKq15rYJIcYssQsNkeq2fGs2zXl/fHylMNB3cX3+dDFfKGWMUYdH05RCjMkZ04UhCQPQBx98eHRl4f3Q7h8G70McRt+viIaUU44aUq6LwigKwQfPutJFVUsWrVO79wI4dAM6JxkFBERiHpQTYFFK58xd39OkDNR/47tf/KGrn0IEQuKcWXLMkHMiQuY8hGFYDWdnZ4pUWVb1fHbrxY9h256eb159vXj/3ju/+etf+7m/9GcP59cOb7xUVGUcusLYYej3u+bw8KpROACjkAiIMOqUGCQSZEg+cYqMyCwoRKCODq9U1WQX+IMP379YneXOM+m6KInI+6hdePDwbs4RkAFBKa0ItEIiQkBCMKQICYlF5PHjs2/+yR99ePeO1vmb3/rK66+/Yq17773v9e3Qx6EfhHMmjUU9sRYRGYEAIEsehi7nrLXJwgTKWAeIOQXnDOesEPt+YMkxsu+7lDIL19OKiEEyCNx5/97yuDbG3rv3KCfYbUNh65RjzjlGIGMskFYIkJUiET49PS3LqizrzWYHhAKYOC7n8/22z3lwziHqGJp+GGbLhdZYz8xMVUbTfD4bur5UZmjB2tIo2O32kNx6vU6caleQoLVms2m1toKMikjQaDd0/XbdHF85eO/d+7NJkVNW6hJhxRAEUFtrM8tmu5/NZwKCIDEkrXC+KNv9LifyvTaExjm0oCBbS9a5GKBtB2ud0ZlQe4bT5mQ9uWqME5Gcc1WVwzCsVhc5eq20AiTCmAVAvO93T/fV7Ojhwwffe/vtru9+4ef+0uM7d3/lH/6jv/E3//2D199sSy0KrDECeTIp/RCrg+M2N1qRiIw5CKEIEMgYy0BAWESjKI2m0LYwAOrJ45O+95gh7JIGRhRmdjGfn5923b4s6pyZVCRLZBSnbLX+2pe+8K0vf/Hateum1A8fPbDWfP3rX7AOlwfl0He/8Zu/8vrHPhlSN5vN+hh8t1VKKa2d0zEGRCAFiIgAiOiczTkrpUVk3zSEVJVFVRUC2Tqdstpuh77zIHrMPLz3Wol1zvvgSoOkY4wgEGJ01oYYtSZESYmDj0ZrwDiZzIchtG3LObatjzGIgK1szpKiDEMQAaVUjElrrZSy1uUIVWGLpYshlLVy5WRPpm9D2w62hKp2jx89Dd1OOxNCElCYpagqY0zbDH3nERQhW4VuUimirm3Kyhlnj49cNZlt1ts4ZolAWgBuXL8efNjvG6UoDaycskaosFpTs4uQs1Yq5VA7W8yK0A/WlDn7wXd9H7QmrcVqFf3+4e7hMb0MgCBCSOvtZrNZPXrwsHBFWVXOWaWsspUAK4WKyFiVOPzmb//GweLgL/3CX//Hv/iff/drf/yZH/ns/Or1+OhBPyRrTNe3ZeFiAkSNAEgoAoiEpFAZzBJjBGERAAEBzhwyJgEBUVqXXe8/8fobP/IjP1lPJq4o7t27b0tz86UXGFJZmIcf3v293/61z37urYOj4xdeeYkFv/W1r3zrK3/wHVJ96rKksqq23W4yrU/PT6ez+sbNI2NV226ssykzEAJDCAGEUStjiUYqFyHnzAxEpJRqurYsq2qiC2djiBWqnIPWlBMDKICxdkQIxJJh5GcpFYXy/TBfzDcfPmIhIur7jhTkBMaaxWxxfnb6xhs3Hz58uFnnkeDYbPaFK4q6QJDBx6rktm3ni2VZuGEIMcXj4+PEXikjGZwzQ79nadrOh5Tn05FKIBCIMRpnRfBstSGkejIpy5ITncX94WJhMJdFKZz3bVOW+uWXX0wpJj+cnp+nJMZoEQFgzZom5UQCixYRadNgswVH01ofXzWVrc5ON6uzeOVavX66qyZHtihi9KSlrMq2y5khRTYWBx82fn9YSBJOMbAPcd/M53NCHYIfhn673eSUjS506YqqxBz6rgnSXb9963v33n3xzos//XO/8Mf/4p/+yE//RFHNjXFlWU/rWpElRdt2R8SKbM5Jk82SrXGvv/mZd95/b7/df+0b35vffkUEEamLaRciXKz7cjqZzEnrz/7gDy8PD0LvC21fuHWrqqYHh4fnTx5AjJbw/p13v/g7v+YK9+//h//7Wz/wmZOzE+1cFlBoyqJuunbow9l6HSHpyjx5/KB008K6ptkDMmoayz05s1HaKqOVERFESDnGLFVZBu9TSkrp6XTqLE0ntXBcr9ciknOcTSZt12dmSWKM6Yd4cG0GAK3fIbDWOLTdres33n3vgTBZRZEZUSmt9vstgJytzpquU4Tz2WLf7EJIxhrgrJQtCgMAyuiU8uHxwZPHJy+/+pK1Ombftk0IKYZALlqnUVhrQs4ovF7tCdX1a9d9ykPwRusY477Z37h2pMAQnBMgkbFlsdqsTWVni2XmEIPf74fVeaMNzZcT62zOSfcxKXKFnTXNfnk4nykdk58tZwQAKlYTPkiGgz1YTrqBtpu+qBSpqAzVM9s0ndJWQIQBkGKgx83pdrcdZpNmvz/QpeS8WC6M1iISwuD7rm/2q/1uvz/f33qp2W2ibw4XB69/8rWv/Mkf/dzP/9XJ1Rt379xdr1cxJkXKWjubzQ4OD0oXpstJVVAKiSMMAxstiXdOS2JzPrjNo4bDAIoudv1kdqONwnJ6ODOvvvSxX/x//O3NagUcCwXOWG1sAqmnB7dffvWv/fV/6zOf++zJ3Xd0jP/4l/7Lf/tv3t5v1lGSsYWzi/fvvt90O1TqfLet6iJHWa8v8otDUZTATACKKAISkXXOWquUIkQWQcScU4wpO9Zaa60Xy8nQx5ykKFQYhslkst00ABhCQMSxYhNTEpHMsSzcZHHQNl1RVIJw7drV+w/ONqsGDDlnbVnlzKv9WWZ4enI6qaaQwFgDAEXpqsql5BGoKAtmnkymhSt3u511Win0wWtDzCDC1lplNaEyRscmlfNyGPY/91d+7itf+uMY0un5qj8fiIiI2qbZt+V2u7dO977DygX2rrR+6FbrC+/Dcn4ITIiXFTetVUpRv/3u+09On7pCJSi6dphO6mHoQx/OznZHV6fO0uxgcnbaf3j/ydVrk7YJSIXSUtRQzYprpPfroEn5EOazydwd8sA555S573oW5pQzZa304L1Inszni4PDgxD6vidIqNhYk9rm9P69zeOzP/zd3//sj/7wr/3Tf3T7pcNi+slm150+Xa1Xq+vXDu68d3+1PismMCnc4eF8WlZOtQ+eXlQHy0i3Pzhdtd3JfrsDxOl0Vk/LqtzcvHZMuTfkfuD1z2y22xAaTeJc0XR9DMEqe3F69ru/989+8od/ZD6fiaT33/7mP/g7/+nTJ3erGp2Dk/P1vt8OIShSoelzTGVRBMYnj0/6/VZSjj6KgDEmhNh2nSucCGfmZt+4okZARTQMQ2kLbQxLKCo6PFyuL06FAZH63seQY4yucJlZcgACrc1+v/ehu324CBG6dlBE3/zGN3Pmsixi8CnlFDtjzHRaDn4ghUPfc84nJ6daU1UV1mkZUl3X3veo1HazOzw8tJaePH283++MsUrjvtk755hTZYthCM6a6fHBbDrVRt57753dfv9Dn/uh4Wtff/jokSip60ppyiDKmqouCmeL0obkO98jy27bFGXR9/5itVYKAYQFQogAoP/g9/8oSDw8WtjGn682KXNZTJMPs3oe/DAMsS6n2mCzJx9Ikn7yeH14WCKaJFzUWkRBppA4BdVu8bNvvPnVs203+KbtzzbnIDKfz6qyartus137IURKiFSXExJ48fZLICojf/OPv4k+NK3/4Z/66aPrL/7u7/+yZL+YzK5/5o35dD6fly+99ONN151cnJ48OVnv5PHj9W6/Rgx1tfjk5z6e4loEYg6M3K28bnDq6tDuf/qnP/ftr/zxh93Dejops1WaXOGgaDDLwfL45Vdem84mH3x411au3XlC+pe/8xvzeV1OS8+71W613e4TcKls6IdKF33jlTEKzXK+aM/cgxBFtPchxjyd1tOZ221bFihcmbKIQOHMYrG4du1KyEPTn7mimE6L/Q6bnT8+unJ+ttaGtNHGuSFFYbbWTWfz9eYi9Xxx3iyXc9CRc3auaJqdNS4nAkW7XVMVbnkw6/uIWeWUtNbRJxEhRSF4EZ7URfAdKbOYzxDTet0Uzu5De3Z2XpYFS8yRUFHI+9KpV1+9fnayfvho7Zz65je/eX623aw2r7/xsfmsDswHR/PVeiWJSVgVmHLaN33mCAA5Q996Z+piVh9fhd1m2/U9MwCSJtJ/5d/8c6Lkt/7Fr/uH/dWr87OzdQy5qi3lvkDttM5BSqta5if31642Oavt0wiHpQohFZnAGFPgAKWebS7asp7fvP3ilYODfbMdCHVBDx5+eH56cfvW7bquY4jAIsAp5V6yP03FZFFX9cROLjanMeRf/cf/9ec/96k3Xv+pL/z+b6+ePplPN03bWKdfvH1jsVxMpsVLn38rZ3n89OLb37p7en5RuhuoihB8TH07DMBZmMhLrfE7X3/nUx+/nlPoh0FyWl2c5RQPD5Y+hsls7uqKlJ5MpmenHw59H7wPGSDnw+OalAeJRaFYkEllGEutvN83pi5n81m/WyXhSVVvmo5jMIS3b9z47A++9s9+54tIKCApsYhcuXJ87cZyPq9W6wGxBlJPn174IRljnz49A0RjFCkZhr7QJqY4n82BKOfsrEUpuy4WpSCgzzmlHHJXFKWPSWtjy6qezrebvWRYLCcgiKAG7/u+hyGmwFW5Z0ZJ4rTb7zvnCuYk0lqrmTkGqCo1WdQx94vZNMZkLaWklDZDn6bT4uz85GJ1cXh0GJo2BB+THwaMKcyX89os7tx51xXKWsMEiLbvwwvT6cc//voXv/DltuuYmRRJzPo7H3ypnta3X1leu7lYr/YppYcPzrp+IGJrrbUqZzm+coypT50g5MzJWRv7ZGtKKROwM9qQOn+8ptR+7Vtf/9n/3s/+4Oc/95u/+RshxMODxdvvvMMhPX7wwesf/xhAiD4QOWFkIQuSu22C5EM6WCxLV54+fvqlxD/2Y3/hJ374p37p7/+dO+9+W5PkdniYzp4+XJsCjw7mB4fV0cHiL/35H921/tEDWG/2oonzwN4TKadd4kiCTuM3/ugLsdsvJ3UW6dv9dtVmH44PDyeLxaysY8za1B977a1vnJz5tBFTVItSFynEvh+47XoRFJ9ZRVKUUpTMybntZhv6pu27oe+QWSt64wdet1YfzKtJXREpIgJMiLjf745y1bQ5DpGjHvJAgNYWYUhDH5SmGFIMnCMfHx3tu912uz48PiKizBxjZMnVpEyZd/utczYnAEDmJMIh8eMnT40x9bw+ulJvtztrqrbtQAmRCcTOFcbIft9tLs4XixkixRhv3Lx5584dyNJ1cTJRRFA6t1ws9vsdS67qYuiDMcbU5H3vB1mvNmT10Hcx+qgIEEXSyenZpJ4WhUo5JUg3b9+8/8GDfbO5d8/vdnsAAkCjTIiskz55cNpsVr7vYkpROXClOCRhHQb2PqCYnHTfxJyzEwuQUs7Nrq2mE2GNinKXrS52IaS+feedd46WVz/1w5/f7doPP/xAlFnO5x975ZW3v/u9ru9ns5mUFTP74IP3OafMWREJS99cKEi6nDWN+/JXvvYXfvan/6P/w3/89//+L/7mr/8KxLBv+tK51ME2NDbk0itoQhJUeEiuRgPOLhYzSSkBAGcGoJdevH3z/Xf29+63Pty5OPMsGqnbb0Py56szp83MWLtb/8Wf+8u1/on/7z/6FU04WQCDH7p0cdGcn+2bdkBQxaQQxJw8KZeCKG02u3XnOyAIKWUBQvif/ru/cPPm9S9++R0QAGDOKeeYc1RG933nBy9EZaG7ZugGr5UhwsViuZZV8BkhEEFdW4HIudcWDg+PLp6ez5elUroZMip9MF/6IaxWW4WiEPp2r5DK2STnbrfrycJu7X3I3g/WmpSi9x2i5gRVPRlCL5hSzD7YzKzAlKVr29YHf3ilbra71cXu4GgewsCSXaF8GMi43ISuaW+9eK0dGqsdESnl2r0XUMIpJ5zUs8XCPHr0qOl8Pwybzb7vgxAgUfY5h6R/+MdfTilFr4YhhhD329y1QRtghu2mf/jhLgSYzeph2KzP+2EIZa2Ncz7G3dZXUycogYPVYp2rqHzjtVeXB7N93/3YT/z4O3ff/+Iff+3o6PjzP/IjIeXValUWFTMIJKXRucQiAtx2awBUBJH79ukjde/Oxz/5+UdPTj7/g3/mb/wv/ubpyeoL//K3taW+D6U2q9U+D50NovMBgPuhH/z81Td+NOSglTHakEKtSCtz/97df/6rfy+cvp+sfvXo6oebswhSVcWLL7zwrbffGcJw+3jxp25/stqfnP3qP3w/9CHn2HXFJJyeNJzVZu37NuUExgAippSYMyCXZVmVlTIFaBvZ931fT2Y//ad/qu/Of+f3visAxhhmHrzXWhOp1WqlCUBrDTmEtG+a0rmqKpnL7WY3my4GMzRNlziGGGazKZG2WufYz+YTa5HQCEejSxFRWs3n04vVhVJmNqtBEIBDDNKhrZAlD33S2jhXKkVN0ypN1tWHR7Wx9PTp6YsvX9nuWudcjqIQjHbOub7piQlAhehFhLP0vQ8xSjbKGExRhFKUXdNfu3YgLN3WF4XZ77uyKL3fxpRCSM45IiqKYjqrQwrTabk9a5RSOmXPwroYCtPNbX31xiSlBJBFEHHxoz95k1kNQ/jxf+3mZh12m2633w0+DUNcHFQP7q2MIa15uSyfvi3nH/j5ZH791uz+0y9PbfXX/s2fufnS8v0P7tULKCayvntqjKnrqXOF0aVSGYkFGACEIeW8223fe/eORCBTH1+7+id/8rXQro+PFwKSUkaRNmRD5BX2QwREhXj//sOvfvBbHBMiCZBxanmweOn2izdvHN64/fJ3nt5/cLrJT3dSLQwIWufBzOaHMxEy9Ef3Hkrfvkn6/OpCm1iUOkTpB0+g+r7PIoo0sMSYR3KfOQ++R3Q3bnzszp33UpLl8vDnf+Evvfba9S//4W8+vti0fRSRnC+z4WEYEKcAnHIqnLq42DMzi6SUODMicWZEtKVBS5ABQLQmjdZ3qW2b2y9eAUFnTQyhH/oY4mKxzJJX51tO6fU3Xv7e9+6myHU9DWnvKtXsYTKZ9X2Dio0pANN8Wbkq1+XkypU3Hj5+2LUeAJhTjOn6tRsEtNn4ST3NqR2LsCHklBMgk8pkEANut3tXuOVsMfRekfZ9qqtiNp237aAytH1fuKKeTpp9WxTlYjFrh26+mG/PG2udBhDmKBKYOeeE2mcOWmtFiiiDcExRFzgpYXJgFdVEV5lT5qy1BH+ra3vSbK36l6en5+83AMqVYdt9Yzeo2s0+9xPFx3/wBe/v/6k/t3jtzTeePGpOTj5U9dx33HWioJzUk8JNM2cj6fTk9MVbt8piev/D9+YH87g/+fm/+uff/IGP/4YxKSUCzJlRqyFIEEgs1bTO1n35934/eT+tJyQQJR4eXfvJH/707ZuTs9OTtUeslySUciKAzPj45IKUJYJsXTddHNTFWz/zE7/xz//ptE1n27OEsWl206KSrBMnlFEvTZBECBhYaa1NUVXTm9df+cC/96M//LlpBV/60h9eu3blyXaFiMJ5GHqldYohhUgARDCdlEoQgKraGmWMUVHYGIXEs4VjM+n6vUjuPTtXzqa1sWYyLYuiQMll4S7OLkY9oFIaCRVJ0+7Pz88QAFEvl4enu0AOJzOtNAHyZOL6fkDCfmhv3Hj54smKruDZ6X67GQBzToygrl+/Op3Nfu93H3WdJy0sgkzex6HLs3nJnJXBSV04Y43VtS7atnHOblXXdf7w8GCzaUKA0lV+GGY15kuFHOSYHz58kpm7vtciSEqzRKNLAEx5IAIiJALmJIIsYqwGxMxjv4tCxYVTLKHQXNQQk1hN1gmj9D4oxbpolVIefAJVTWw1g+XV4tU3b6agwpAAoe/k9GH3pT/4YHOxW2/Q2okrJsz5h3/kh65evf5Lv/TLzfb0ne/t/7MnD37+5//iZDrdbjcsQgKJwSeJOQ8hrE/PZ/aFGwfTzcq/dPOwKt333v7usqQ8rL/19Q+Z5fTkTBBBUc6CZKwziBgykFaVKdoQmth94Z23Ty62124cPz477VOMES+aJiVgzsikiYhoLBdVVXV4cFwUJga5euWF3X71O//id7773cWVa7N/8ftPy3qGeKCVQTKxC8y8mB+KoCuKnNIwhOzj4XyeOcUUu6GfTCaooOkb4Qg5KbLC0rXd4eG871ukLJJZJAQ/mVQvv/zaN7/5Ta1V2/UCDCAPHpy8+OIrfuh3u50B23V+Mpkq0l2nqqpumjNtLXM+Oz3fbbem5JdefvGD9x9uNm0MuXB6Mplcv3YdBJqmObwy3e53yasUZdQnpBi11da51fkmRrDWLJaTuq6nk6HrYtv0IpJSLsvCGKO1Hj36MAyK1KQsVv025KQlqZhyyIyY67rIiUlRylGyeO9BgEiTaKU1IqACRSRMIKDQipA2OMJPrQ0jhBRyhsIumFnSkFP0DKgUEUpCbaioQYjrBV2/vnjz059r9vH+vZNvffX07W8+9V7Kojw+OiydGhuzQPBXfvlX+q4TkbFLh0UAKA9R+th04d0nX6kntXXY9jsfVFlNdvv2H/3Kb83n9ZMnj0SCJgCNnHNoOQyaARkFAYZmo4zrQrc+eXT7+nVrC2Gds0pBMJEAAkRAIIVGUWndZ976lK3mHPNmd/7gw4dHi2s5ix+EuUSqLrYeVxc3bx0opQUxMyvSt166cbK6n/NgC6u1WsznQ9saa/3gR2mP0RbIEiDHxCSECISZoWk9ksQ8UFYx+8l03rZdWZYAIiCIRCh9n64eH+2azZ07dwCBRdTMBB+7rtvv1WRaIREI3r//4NqVZT/45WR+68Xrq9VdQTq6dnUI4d7D+/W0EgERcK5s9w0AzOaTnCNnUQLD0DFzThAklEVprc0cFWlmCD6SwsEPy8U8xJBy5hgyZwQ1n9bnJysA1HFAEW2oRMKhj5mD0igcfWKtjSZCQGRIIQoCZ46YEGmsYDBzZBBAoqytsKTgkx+y9IPWWpGJKQhnJRpRaWMpYUqZmUEDqKitmR3BJ5bL1z9+8/xP03vf7c5Onrz9drvfbz748MOXb7/4yuGN7e6MMWuNvvfCSMoo55C0APshPHl8YYuiKgtkyTl5D5tVv9nF4+OF1gogQJ9DLy2DAivsY07CSQAzGqMMCgRkgeyHIQTPkISjIk1gIpIgCeeq0J98/TOlKy7aIaacOXEeSOnBp8ODw4+98UbnT65eXT5+uFIa275FUF07tLv2vfa9F16+bgvJ7DWSYur2WTIZNfaWITNzzoAAAjkwE7hliUiotWjZ7vsqaFeYg4PDh/efxugRMWdGBECNFN59/05dmxgZEK3Vw9A3TT+b1sJoLCZOIubgcGor9fRkUy2W2mVXuum8Lqri29/7Xjmxi6NZu233bU9aFZUx2sHYB8kYIwMzoSVK1tF+31inQojRc1lZUoioDg5m1uj1Zm+NLks39P7ifFtVVNZl2/Q67VhrA6CoiPXUMbqUY8jiSKEoS4aIQFgRM3AEbNsmRlSkJ5PKGJNzEox6WoJGZmYWEGJg0CCMRmsUkCyAWSQq4xSWGYMhFfKQY2bJgmyLcONVVc703Tvx6f1H9VJ9eO/u8bI6OcGj46NPfuqNsnDvv3sXI56vNjF6sjPU4EOfcopte+3qlZ/5mZ/JOf7hH37p7t0H221jdZpPnRCUhTWsM+CP/eif+cQnXmrabU7xj7705Tvv3i0VEoJ2Sku+cuWKZNTKcuGy9wSKSHs/HF2pX3nt1gd37/omCNijw+N+d+oKk5gV0fn5+e/93r945bUrn/zUD7z6at5tfc6stbos9STfNM1BOYkpMUAI3vtMGoFARITRD6kNPoWYYhYBjYQs+93eORcgWlspxSHEs9NTwJxzPDq60jx+yizC2Zpis97nrJl5Mp2WlUs5LLTRYPqhN1lFkarUywNrSrzhFuv1+cHh9M1PvHL65PTi7KTp97ODGyi5npcC4JxNOYeU2AcAPL5yfP/hw8IoSRx9LKuZc0XOSUSJQNcPxurjoysvvnR8fn5RelfX5Xa71sYog00/WFtVZaUn/lCD3vdrYtMPUZeWhbQ2oIS0sqStpb7vJTNzAkBrXBj8w8enwafJtDg8mrtSxaROT/dAEHMgm1lzHzvlSCNRUlkiCPLgVfRVVSZOOSUBhpyt0Ykx5Xi6elyWxVs/tsg/NP2pn731wbfzm6/82K3bt5TSd95/7/69e6+++NLZ03NEHNo9Jr84KI69etjsNrvmnbffPjl9qrVabS6MKT7++ieIqKyc0oVHDUgFagYh0DeObtTT6v69J6dPt1qgdK6elIWpDpYHn37rJ8QVf/RH/6T1O1SsAX70Rz5x/frk7OnFxWqrQV85WMwqE9qVSJkyxxhTjPP59PR0h/rd69euGWvHkjMiAwEAnJ6eTabWKN02uzREESTSoGRaldttr4wSpn4IxCQSjXGL6WyzXTtXgGcE7npfWBLgbmjLunSF01rFkEjryta59xxFWEJISDKdls4Vvk3bzfbg+DClvu+7h/d31cKVlZlOZ7ttb+wwOZ7Mjucf3rmLIJlzN/R9GydV4XNerfY3j69aq0SYUx5iyn2WLCly2wxaF1VVrbom+KiVyjlXE623CgA3mzWiFKUtK4uku67ru6hvLT+mFHB906d+3+0kBVcXZ5snkQZdJ1dS8t5oSBlIC3NUgLOlmy1vpqD3++35xep8vR/2kti8+cNXl1PYhovN6X1tqZwUzhWlqaxVKJgjE0GCNmNkQUWQGYcogCCQFfFmcw4qIGVVm49//uCgPLt56/Xrh2++9eZnfAyr9erhw/vNervdbB4++IC58dJvv/7AubKcVqQgxP7w8LAq66pQzhXKZgDyiQlFSL76tS989+tfcEaDUSFmbfRsvnjp5ZenTp+dn508PX3ztVelqB38FKA3yhTW/Omf/EFUNLRe/qKxtnQ6Xpzcu1jfe+fRlrkrNF+/Or/58pWQ/GyhtQtkq5GVEI5k0XfeWZOGRJqUWBRURpBoSDFKGEIutRVGQk2IykDw4eGDR4vlxA9DTEEjF4VTyCFGpVUUvv/oPgOQ0sHH0K0nZaV1mbnb71vnJk2zjyEKY86yX3VlbVLOKYlvKPWxpf1sWux3ayrnzhX14VwAROStT392s9o/+PC9SVWmKPuuq9H53b6wNvkQAQ4ODoCoa3xZ6KoszvJGAIwp5guji1xNiv7BGZFoohhiUbi+9SiYctKGrCGt1MRRntormX3KQdu6D13Yb8OmAaWH3Lmp8hQiB0RS2ghEAjxcuvns6pUrR30v+HEsChtCd+/8q9WyL+pJGnzOiWZEaBWRmJSYvfeKpCpdiiFHKMtis2qqclpg6aop95CyBKY275r0bW7clR/9+G7X3n9wv+26nGRxcK2sFvX8MKah8d9p9uuf+NQntpvVnTvvvfraq7vd/uGTp0fT+tHD+3ZiU0pDHxEBlEIkDwAgo44OhHo/rLero8X82rUrKYef/yt/9urtW779s8PQ+75n4KFdzWbHRltiPXh/fvLeay8u79y19zdfbNqTl15eND1G8K6QoR9yzs5Ncko+sw/9fr8dhp5zbNvOLebWuLYdtDWdH7ohMUJi6bqOJVd1GdpgbUEQhz4U14rILMorQ9pITphTSin5FFOMSllmFgAkEoVZeBSsZmYCcc5uN/uyLPwQNHJZ1VGYg4CS9W4jsdYlFUXZNK0yEmPQpLbbZr3ehBBmhwsfM4iwQB99VRSAIEgHxwsi9ejR4xAyoFy9dmW9XltLAqnrGsF+NnfNrifUo+xsGNrSFoCgYxyUKpOIUrbQBtQEMFccJeSc49A1Sfx58xSBQNXst4zACoq5SXrgBEhhOpNimnNiVLEyVB2VwDb4GFLIg499MgdXM2KOHOMAKDkxt7FwRqLNMC1kDk2xnCxTMFeObgPZerKoy8WkmDs1EdDz5cGnlouU8r7p16vVbrvb93613Z5erBQGBZ5SOJjWn/zYaw8ePFhW5QvXrzy69+HgyYeeBSWzcNbKIuGz9kNhDuC5b7Zp6IvSFQWm3BkdsarKqkJgBOjb+uaNl5RWIWXm/MYPvOiH/a4PqL4UeJ2VBySFKrMPUdardjHLIok5931zeDz9xCduF66QnJ3F7XabOZMYAQghG+e8b5YHi2a/s1aNIwTarrfaIKrVeqWcVMYNw0CoxukCnHKI2TDnzFppZgFEZi4KN/jBOacIU+IQ8uHySoy95ND3w2KxTByF+JVXjrrtXiCfPjkx2hwfTjfrZj5fNE272WxdUWmjATIi7vZ7sqaoa2VM5ubk7HQxmzmrL87WjHD79s0QisVBsV610wUpI30fc6ZiVu2bjdMGgBAJAPRFl6DbDcNwtDieOJ5OKxasywoK4RwnxcxHP51cZZF+2GadgCCkffb9kDtV0pAvuv2+KktBYc6p5UJpS67PQ9eGnASBiuLqpJoLQsRYTaZWucPFzdLOy+KgqqYIVmGhbEGgnMGISlAJgzAQcpQgkRUji9SVLfXxleXyk598M8b4Ez/0+b/+C/96Smnofc6MgEqj1oqI/q2//q//2m/91t/6f/8XWpUxJwDy4rUmHNXNCkQyAhJi0+yePHkM4kFYC4oCBChdtbo4OztfM9jMnGIElpxy025+4zd/++77Dyezsm1i28W+3+ecQz8YbcojFfomRQZuP/9Dr2udhn5Yr7YJ7BB9Oa2axjd9j6Sd1b0nUpBC9MjG6LJ0uw2lGLq2r6oigc8pMYO2BJA1GcxeMvmYZ9NZ3/aCiQiHYbCFrSfFcjFvuxYQi7Jab9d1aXLKRLTdra/evH66Wt1eLLdn25ACZlhcmbT73g894mwymaXD+XZzPgxDUbn9uq1Kt2v6XW6Gzvve11Xx9OkTTSYMaX40A+Sr1w7K0i4Wi5T3bRuHLsfIbddxzkoBESIBIumf+cv/xm6/PTk7eXz/wYP1hdlcpBzrsjw6uqKICm1qO2GGnEKla07CklVF5CBTZsU+N0kFUirE4KOfHMyKqp4US8lqUi6tsUBYuIlSRmmLqAQMohLBy9kbwIkxSwqMwMAiGTjmAEpy8sF7QwSZta5SilpphYoFos9KmZu3X7r14m2lSMiMOkwkHMspVVl+8513QgwAlpmVgh/6/Gebpuv7fgh+GHzXtX3bjZrPmPz52fkH9x60QwBgrXRd6Q/ufqCVPT3bjhJ+QIgppaHdbxv0eP5k3/Z+v++899bRyy/eeOutVwGqR/c+cKbkYb9tttroYehDyCG2KUn0QRByyki6adrJtFKKtDaKwFqz3zdKqRyT96FelBfbXUykjQZhpXQX+hRZAqMmJAwhMucYvYgEH+azhUCuKgcAzb5NMXeQCZUhRYxN2+6bZrtpLzbbxXL24ku3SacnF12IYbtdx5KGYXDOEFEeQuZcuNKpJDEpgNmkSCmKiAiISOyHvjHBmA8+eFSWNFsWN2++8PrPvnDy9On779/TOhmtisIQgdZap5xdNbn50uzWi68g+91us9ts1hcX9cERskBIZVkiICIrIgEpq0qbIpEobbRxqDDkaIzTpAWJtEbUIIhAkZMgAAKyAAsSsQiPoFEyaCOcM0BIA6qMApzRMzVtq60hqzOnOMaWmNu4zgwoGlCEhRQRYkZWWhMSS8o5ZRZOQGhEpHBm3+wF4Pj4iAXarvkP/6P/ABgfP3rSdo33YYjpN3/7t997+539bhOGATierdasHLDUpblz5/5mvblx/UXwLAIpJUFBUt2uOTu7GHZ+1XSeGUC9/Mqtn/7vf+rg2D188HDz5JxAxWHIPklS3ssQBKkI/d5YmxNPqnLf9Dln0hCzl4FdYbTGvhu0KgEiEU0mk75rC1vExKgUYxZgAUxRJGPm3Lf91StH+/32jddf+9a33w0+2MKysDYoIolTzrGupyEwABmjd+um2w0PHjwwBRlrOPv37nw4PagQVWLVdU3XtZzzUV056zaxpYpQJCc+WC6364sUktaGgIjA+8hZmn5fFrbd99aWTx4/QVCT6fT4+Oji/DEAlqULPopkPYSklEIQUkrZ4ujq9WvXb1lSGUQAMLMwI6BCAJAEIoIgSiGi0kgEAk4YAMY+Gc4CkkY0gyIokHMGQAFBQQAkAQAxRgdgBmbmzNn7kHMOQ5CEXQzaGNKXQxAQEAESKUREoHEEUe/jfrdt+nbvB07se++DTzmnIXGiEANw+t533gVQIeaD5aLr2r/9t//OrJ4Nw6AUVmVdzuY/+pM//kM/8vm/94v/r9D2zHq375RtC6tA/Pnp6uDgWEQjAiFao4MAKT1dLG+98PK733676WO28sKr1//Mz7x1sXv07vsXKUClppr0xdnq4qJl4elycnCw2O8bayyTgEhOSZEi0lk6BFMY1/W7fkgxpZdef/X99z8UwKHzQwy2pJFjHwfixBRz4sOjo74fmqa9fnx8dPDCfD4FwLouBWUIwXfdYjY31mmjjbPDMKrnxHdBk1JKSOmU/Wa7UYpySNYYERbMqFgp2e32u03om3h8YDSpPob1esNZjHUiosdWS6U7P7Rdf+VouZwf79vd0Od3330fRF27dp2IYszaqOgTc9aFK8YsgzkjImeOWTJIJpGx45gUiCCOlgOktCJHI1HDLCzCKAjMTBAIRCudckYiTYo54/ghkOBjzpmEWDjnmEQAMYtkwQwwViEF0RWTccwaIKpncFshI4AC0EorUomTLcxUT6tJxQAo2vdD23ZN0+w2bYwcUlwcHn76U28Nw5BysFb92n/zT6IPAMwgAkCgtLXVZNJt9lrpT376Mzlwt9u2nIiydZWA6lqPxFqRAGQhgJRSP50c/tRP/8yT05Metq99+vrDR++vNnvEwiq37/puc05kJ4vy6pXbk+mknNUPHn54sVoxgbGmazwRdb0vKoMCfdMNfUycEfHevXsxRAQBwOvXr91//KFSJiWwhdFFseYWEWKMOWdrjQgtF0ff/Ma3l4v54fGiC7uyNNudDy4ZowCVANe1Ozq62u32XdcSYT8M164dTyfT87PzsrT7ri+KggS01iLiCjv0uWsDiDCz94EIAcBaCwBxXCvAm7euAMHm/ZYZkWS9WS0XS0A7+H69XnOGpmkm06qsjNorXVRWBABIRAAZgDMzABGPRLoQITAwCCBy5mbYEinOslwukQBJYg6k1AiRYubAAQFJhBEEQQgIFIJoLYCYmBGJjNPCiKQZGAQRgRlQs2hOUZiZnnWpIxFiVgYQENEoq5Wup+VVfY2zaMKYYtsPIYRxcIMI5pxTijmn/8H/8K/1w9APfuiHdt/2Xdv3XbNvmrbxg99ud4MP7b4lpT7xybeEBTlfv3aFFBTOHh0dg5AxxmhFipyzmhQohJ/6SQBJcXj/g6//f/6r/0yAnZsqY9t9P5kubt98dTo9tGZSu5kBo6wJnt9+9x2GnECLZAa2bpzTort+iMKcxRqdM7Ow0co6HaJ3zhFpIuCcQWkkYoDtbjfmHWenZ3VV5IRFrSfzkpvBGHP71q2nT0/7dlhMJiISE7/wwu0P3nufSHH0fohDP2ilEIlI+m7IGea6ZOEYWYCNUdqAUWa327rC5a5nTmSKEAIzJ0YRSDF/4lM/cPLk4uJ8rZUuC3dxsZlO59a4nLIAts3gnL569aqPoFmCCIqgMAAgqbHjklGh0poEAFApbYwZ+yqZeb1en65PLy4u5vMZgJAS55xSitAqZYlQBEYlJyIiKAFARGU0aS6IxlZmIPzI0B8WkZyFUBNUABhz4szCDAgAkBSPcxlEcvAx9sAERDRKRnPOwiAg42AQImWtEhEAqOsZaIWAePnkANE4ERJzijlnFg4hpsjAXGq97xofgrMmxZRSHoZm1LADSM48zqqMMYLI2cnm9rVPFIUjoxfL42GIVVGVdkZIAopECqfns3nbbnJO1lkEnVNGAgSARCD6+Hi23W2DT1ppY4wATKcTZRBAUHC/30xVrbUdy8n1fNZsGs4yTm0dfK+UquqiG/YsbI1hzqOn9z4oMsL4wd0P902jjc6dOOesdQDgnD09O1FaHRzOFBICIgKnnAFyYo1q6FPhzNixN95DIkQmY3SOfO/ufavNbtenJFU16br1brs7OlqCYFVVgCut3dOTk7aLOoSotSEygokIUFhyghEkA8QxQnka7+kopxSR27dvijCAQgIieTYHRglLZmZmBGRhZh4H5I3Lz8zBh8EP3vuQ4vju+Po4U4qzoBCRGgOEIICA1joBDzH2PgxtLwzACrRSWhtjEFEpBQIpJ86ZRcZ+5PFqEUGIkEhpwyIgggRqHIiGoI02WmulCXJd2asHh0+/8aRpu6Isch5HVYhSemxWTimN3xvrx4fLmz/74usphl23iwzAqLJobZTW5dQezKaz6Ww6mZ48fQCMIISEzJJzjgGIKGdYr7fG4dRVza4pSzOdL8MQQ4jGqpQzEgpkFIaUU0rj06iAALFt+s16d3S8cGXF0I8V25y9c7Zvhq4bRDyhvjg/FxFkQcSicH0/eC9Xjq+uN6tyOt1ud4Vxs/n0pds316v9rmkQ9XrV1XUxm9qUfd97o6wxOoQgkrTBpm2UpuADAnadny+mRlufAzM3TY84M9rkDF0XU2StlCYigZRSaJr90OwAoK4mZVkSESkaXdFoOiKXzglRRGRsfUQChJEVI1Co4HIQ8mid4xhMEWDOzIwzZM7MOaY0csgijAjMDCICkCOIUMzRx9gNIeXcD33ThK73PmQEIywgIElyTjEwgKACzpwSx5RYGAXgWVgEgEwE4zw4REIkhQDAOXNmAiSFRunCUFXg0/uP1ucXk/lMIQoBACKMYxYFEQXGYVqIiBZQI1GmwpTRRis8nUzndV3Xk7KqjBUQIFAp5i/84RdizEDJFbqoypQh+SCMDEKalKbghySpH7r5cjmpq6p0q/WFda7turHefHFxAQKZ0zjflwCzcAhJKRSIx1evEMl2vUlZIDMKpAQioCzVdbXf7Qc/GEN9PwDIbF7tds3B8mC13+bEEWLX9LOqPJjNT882fRsAQIRRZWt1jISQEQgFx0mFIaYQ4nQ6Y973TT+fTcY5IPtmn3NyrtBG+94rVAisU/aZSSltnSm5dErPplMRHt0gKA1IwjB6l3HBUkqjG0JEIjU6M85MGhExpTy+orVGpOceFRCV1mN7EBJorZAUogJgEX4+wTZnQiDPade0yiYkiikdHOecM6JGBBHJSbpuSDEzMwsnDmMt1seYcpbMAJJi4gwClASeGwSAkEJCZKRMCQlFMkAqi/roYHL66NFyuTi+enWxWGQUY+z4iyilCC8HBhEpQKAsCmm8BVlSzlkrNdKvAjnn0Qg4JX92cS4AMcVKTxWKUl5EtFIpxWpalIXebBpAnbP0Q2t03fusrO67gUbdURAUyJGLstQTvd+01mhm7oeh6waDcbVCbfDpw5O28UVpndPz2ST4XDinSOWUrLMxh8EnH5MgDj5ao7uut87WkwmwnD5ZHR8fxyFJzkTofdw3jTAzZwTUxk4Pln0/xJhiTH7YXL9+o+u6rvfAXJR2t2u0EBGlFK3RMUZjdPBBT+r55fJDrusaS2JmGH2+XI5fBLwca4aXsQCeBYXLMCfPlHgwtg48Q05j4Lh8H0BEiFBEISgeUyBmAExJEocxyCrSMaXA42w7zMxEpAmVugxwAGgtldVUnlkMi4xjwMenQTKLMOecMuTImUGYJeWUUsqZ+RKWsWSWnHNikePDWb9fXzk6/IE3P2XLwlgTOCLA6KeRiFgkM40ZIgJlVkAsrJVWSgvwZr0CERBQyogSGOeEhWG1WqXEcUjFJJICbZCIlYKcGUGGwU/qCggXy5lIRmIQUETGoLHYtr4sK8DgnC2Kom16RTSmbNYY770YfVAcPH16trpoZ3VVFroop30XfeisoRCwKIoheubsnEISrfT59txqXVVFWVUxxuTD1cPjF1988enJibP9xapRSiGSACyXR6uLC84CAn3XG+uGwStFm83Gey8ggx/sOIMdFCIO/VBPSwO2dNa3XocgCBkvx2ILQgYiACUAY4Sj7z/uz/6Fy+l5ADgMg3OWhRFpnDA7PuXjh5gzIbA8+wYAIhEQICVhzgmZY4btdpfHZQFEDMz8zIJHigMBBFEJj9AVhDMAA9DoCYFwVHteju3Vl3UFASWAhAgynhxEBDBrrZGUcAZhQphU1WxS33n7O4vpTBFoozIzXj5NggAil2QewdgcCsyQURAwASNzVbqz6BURoUEEpRRzEpayKhYHB49XJ9pqUGKMyh4AGYFNoafTKkZ/dGWZOQ9DbvcdpFiVE2116gIiWGs5MwIYQ0oDc1IKOSGA0kZV0wo1KFLri/Xt2zcX9fzRyYeH12b79jRzbtr2+KAIXib15GI9COf5fEqkUYEtrbYUfIgh1EW1WMyvHM9v3TietGG9fv/wcHHrhYPHD5/6ISoiWxrRgnaMKJdRqqqqwW+7fjicFsYoZiFSKUetad/1GlErpS/RUhaiESsDACilLsPX93HF9/3Ts5gIAKK0yjyinoyCzwPfJXYGgJHkJAIGYUYAzpI4taEfI1fInAUkjtB4pLAARXDcROLSJPBypS/R3DPvhUBKjRYpoxXKMzJWRpNDGo8FgoAgoBSSQqu10Y4IJ65YTGsfBqPRGsWcFVHykQhYWJ49QCyiSDELoCAQImYRAAjB19aFgIdHh/fv36vKmSADp5yTsBirX37lpa9886tXrx8bQzmGvutRgS2NKbTRZK1lTtZapWyz3RPpcar4KCQvCtv3AyIJ5BiHmGJKmUHqwn3s9ZdcpQKns/Ozmzeu1EVx/959QEVGxrI75BSi78NgXJEiI0FOuW8HyQkJfAgpRK3U4IfV6uIP/vAPAQHROWdi8MaI0nhx1hSFrmezbuiVtd2+FwZBzDkhojF6CAEwVxOz3XRKUJECYCIKPmmj9aW3R0RkHHluIIDLUU/PLWk0l5zzR18Zf8aQ9+wg+GziyrizCBGqkSnIzJlFYgwhd/0Q8sCIiQFG9fOzn/FEzAwgCvFytjEAPLumj35SEGBMTS+tCS8NAQThEsQDjskuj3yvIlJIGkkBWjKlK4D54vSpQiqrUsAJM2RWpFBABC7ZExx3ZBh/QUZCZM4IWusYkyQuazubTbab3XwxDX5AQGZ+/87dK1eOysqRAm0oJSmKYvBRiFPyAlokaeMQJcRGGzlYHlV1sW0bABUCz2Zmt9uRqLIsBDDnJma21szmZebQddnWRVGYaTkzWjunp/N5125EwBiq3dQ4M6y3vFkTkcBl3q20zjkJiFJKRGaz+b5pGBKnHNkw82q1P3niZtPZbhMBEZCC52bfaVAIkHK21pZlmZL0MTDzjRtXm909RCCF+10/mUz6xs/qWn8ELSl4ltDJ950XfNSwnkP4EUQBXJJSl3QDACDwWLgRzhk4c0wp5BQ59ymycIxRGEfbBUD1HKJdJl/jGPFnsVMIEHPOo+f5714PClya1+glR283PhxaXdINzz9MSEikgAAJwCg9mVTOkO/2u91mtpgLkjE6Zy6cFWFS+vkBRxbj8lQswMIxkybSeug7RkKSg4MDRAhhEJHMOef8z/75b/3xN//k5u0Faogp+eCV0QwZEJaHiyShLkofUkqd1mq+mJCCSV1tdhuO7JTb71pCIqWU0v3QlaUCwaJwV24cTZeTbuhSjCKy7xunXVkXpDjssxKjNLR9R1YhEQuLgHXFbFYPg59WVTWtRVO/awkpJK8UamU8ZxBWRAgqJipRXIGo1BA6P3itlWTJICLgo59Ma2ttWZdF6WIKytBiOW+atmm6ejLNkjMk/RyJP3NAIAIi+Xk4G41p/P9HwFNEBEQz3vfn7yqgMUmOKQZJMUkIHDnFnOkyqAGLwHgkAUC5ZKsABSBzvly5y8Mic35+Cn52dhwn1T9zYJepwzMnemlbOV/SVciISIaUUkg4qmWs0UVZoAbS8PTpo8wZCPf7ZrEsU0pCPBL9zz3288PS2AaX2WjtyiLlDEUxMggpydHR4cXFKoRASp2vzlPulcuFpSH4zELEpEApGrqBuUaVh8F33TCdOULVhX6zPfN9h4TTyeThg6ezxQQUp8AhRGuUV+QKQAq7bndg5jFCbL1CEMzd0AiGrh0MmaFrbFG00fOYmiJk4clkOptPs0RgCD5IhLbxh4eTmKMtahAJKSYfi9KFKN73+yZobRiEkEhhaVzT9Jf4gog0KAWTumybHWmlDbrCrNeRiIYhlGXJJPq5VY0RbZx4PtJLH72hHzEpuaQXQcZp8YQoIn4YkKjrOhHJmX0IiSCzxJxlxEf8bO2B4PJocvkHvm8xo0LjmRN9jrGevyujVT2nXp+Dv+ex+LlLy2MPDLBSl5wIMJAio3VVFVoTQHr44Mn9+/evXr9GhHU9QVTaiI8p56SUdtrIs7M8e+6+b9YpJdLKgBlrCyDoh5SiBB+Ksrg4P73/4MPNfqMcaq0AgSNzjkXhQDRJ7vpOU9G1vStwMitTotSnlFPpKkCpq7ptu+m8jMMQc1RKx8AhpMOjRQxxdbEqppWYqBFz8s2+qcpKE3k/jOhHa8WZASDmzCDr9dpWNFnWZ08vSlVWrux1rzVlUSH4qpgiDM5hzlFrAITO+xSldO7iYtv3w/VrV4RJEqYYr1271jbrEPq2Y12qlJOx1PXNSDMNw7A4PmYKGgDGPP8ZO3C5KM9CG6FcZlvPUE5WCkTG3q/IfMmUJpYw9CnnPngWQaWILzlTGX3ec/MAFLj0CCBwWccGAgQgRIAx7lwCmrEENJ4D4aOvP5v4+X3z+j5n9hwdIiAoBJJniYUmQmStSSQSAwDXVTWdTId+mB4cZpGUgjVOtH6GqIiZc845Z2stICIBwSWJpVBlzoIYUxz6/snTJ0dHR/cfPvzKV7985/7bp7vzalr52IHiMY4qQ4gszCLsTLHdtcZp61zvOyIFmJBwv29dWcScqqJCQFCqco6J0emqdNdv3W7brQhsTlcxhMLqqqYrVw8f3j8zaGLyXecz0sGiVqQ5wcV6NakrqyixV9pqq3ebFgWR8mq1rusqCzdNM+55FsNweLQkxe3QxeTH7VXKogSQorTCebsOm916s7lA0aVx1hqMYCa6qsqujcPgY4opx6ou9OWElo8AcICRqb6UhwsDiBBRTNF7P5pdjJlZfE6ucCFG7xPC2E0KmQUAOGVBeb7uH3E6z73ViLWREEVwHGQ9JmGj0XzUTY7XxMwj5PxojIbnicZHYvpHnRwijtTauH+dCDtbaK2NsSg8m05mb7wuMI7jZmaWzKQBkfiZCxw5UmOMtXZUsHHKiigLD8OwXm8ePX603qw22+1+t99uNwmGTb9/ePFAV3RZXWBAQFJj7SUUtgREawttAyIhmapQ63WTWGAY/JCHYei7lqOdmGlOEinNjxektU99Nr0tsW3ybtceHs1zHqx1i/lkt+najQcga03MApL2+3a78VevXmEOwslZTUSAUlcT72PfRUQqS9BaD0PUpJqmq6cupjYHcYUq6yrFvD4PnNPQ+xu3jgBssyMffGbgnKcLZ40zenH//gMi1JqEuSrrvuvLqdPwfbD83Od/n/YcfRYKjsW7YRhSTCJCpAExRY6xz5wBUZG6VPUTQR5dFD1bTngWRjMiAhJcJmwgzDCmd/j9oDdeAxHyKIX4ft6Kz53TR6uQz30tIj6PeqM1fDSFBBEkNNrUdU2kAGR9saIsQrI6v5hOpwIRYZxVzlob9cwFjhfA+XLfJUNIxqYYY4j7/X61WsWchhgSZzK6D/7tO99ThcuCiZMzBeecUmy7npR1hU29OGtE2A++KIr9vmvbnnSRUs5AHCKilpyODg6Mtc2+T0Maej+ksJhXN68dBR8Rs2R54YXr9aJutqvtdo2IZWV3Fw0ZVRTWIgnEFKNW5AyGyImRWXXtMJ1UeVC7XV+WBSB0XXt4eIigOAuAKIVtOxwcHJCBkAZmQIJCmxiTH0KMKaXMWXKCojCksiJtjCnLYrftRZgz+i4G4oPjAz3i9EvADDQW9ZAuhZo5xeCjcPYpC2AMEYiYNHMen0UQGBmBUWUzHukZ9URjpvYc/j93XyOPynyZwDOPip1LZynPesnHabFaqzHyjg5pTPs/GgfH43+0GPDcvBBRKf3c/Kw2s1llDJKCHHK3bwpnY0g5Z2MMC5Ma9zOksag1xl4ZC+okq+16d3/HKffdMPiwa/Zt2wlgM7Qxhsxx8HEyP/zEm59dbVdk5PHpdzMzMKTAfR+VlrKcVjX17VCUM9IYM/RdP59Pm31gUH3fT2wJGQ8PjlKC04tzH0KIQQQkUumsBWMKyyoL9GL8vkubzXpamn4Y2t1gjT08XJyuVgkgx1yUFgBOTi5eeunaowenkqVaqNm0DJyN0daRUtYPw263r6uqcMYovb1oq9mUrPS+zaz2u2CUVqRiTCkKoSZFSqMIlLUCUU+enmqtc4rWKWOK/XYYK8K7baNHk8gpjchGKcXCHPMIvKLPIbK2OiYJKQGwIpPGcvJoBTzOyx31c0Bj7RCRmRlQALTSMCpbRIgu934ZrQRAj85GP6PTRr+GiAA0Tr4H4JSjIjumaM+D9fPjPHdmozF9H109Q/QpB0VEmgypaV2VpQNkVPrkyVOjVFmWcbcft5dJKaccFWkNFHMccbpk2e62FxcX62bXdB0C+K5nIQQcQkgpJYbIHJOkxErbtt37kLuuJyYUFGZFyihjlBOWi7PtpJxWZa20jrlHtAfLeVVXp6erBMDM1phqVh9fOXr33Q8JgVR2ThlTuEIh5l23v3L7WhyGzCHmlDiSQjMtOaacsgBFn5wpQtemJCKSOR0eL4MPILKcLofQ7LdtWdZNG2PmnJvFfEZoYz+Iyc7aZheC57TbGQdl6UJZQMQYU04SfBqGoayccxYBq8qu102OmGIA4KKkzBlAGFhEdrudZpYQgtEaLqnk0HZtjIEInSsyQgII44woAUHglICeVQNhzPAEmfG/g52FBRG01ohojHnOhD1H3yIyApdnmsIx6Iw87TNpMioAYYljSRGeJWXyjN9/HqrkmWUTqWeqCso5AeSRZShKW1ZOa41a+q7nlG3phmHY73cHB4c5SQjMIuRU4kxKiQgh5ZQuzi8ePLwfQQC1MQa0HWXbqU+II7agEFiECGh8SJxzT89WXTMYjQQqRtZgqrrs+w5FMUuMcRxxaq0ehgFAlNJjhnxwMN3tV0pjQaVxQKg2605pcgX2PnbNru8774fjazeUVrKYdF3ru74oCltX23VLQpxgTO45iwg+fnhelg4UFFVZWGga7+qq3W3nc5eSd8YRYFk4zsNiWQ8cAY1CqZxuFW83rVJKkY4h5yxaE2dWCo1RFxd7TmPvNxmr9rsoQsKMiNY6nXLQRDHlxBEJREAZpW2ZGPqcWSCBgCggGgkuFoBnZsQiYw3pI2TEJaDOOQugUqrvk9b6X2Hn8RmvIeMgMuZnMU4uPQ5nGN3gpYsazSgjIKIek1aFCM+gOl7ytCjASo0kCCCw0iiojNaFdnVZWmeREAHa7XZWTxCAsy+KypgyM2tDnLMiYkICSiGsm+bB44f7Zi9a5zCmhsCcSZHSSimVM+ccAS/xWIzeOROSdkbNJtOuXQ7dLuc4grbtprt2dORDiBJziKhxMqmaHGLmwjok5eZacmp2W2YGyHU9TUnrgoqyRMVZoiIqrVnv/GI+f//td5ybVKWzioKPhbP7tgs53Ti6rva79X6XBQDCxdmmKOt66kytRMt+12y2jdKmnDgiNW7/eu3K8Wq/vrjYLJeLfTNwxsnEnZ7uJNnprMqJOQsiKm1zZqWRFBljEFROohV67/0Afe+1VoUrUsqHh4d68B5FyBAjjVsgX3oCUox6hNsiQJerOOKhy4r0aFyZs0J5rp955kUQcazOXQa+/xafKQIAo4J0jLmjUSqF9IxhTzmN/ue5H0QEYf5v5ZXPwNbo85QmAQ7ACKgvNYBagJ02k6Ioy0qIUNF+s5KYq8ksxtQPjTUWUSOJIlCYCYgYiHDf9Q8ePNi0eyFhEK2tSGRm76NzOuQ8ZspIqJ+V6jMnBdpovV2t+30/qxap88ba2uqLzUYpDQlRcL/d29JVtiAx3jfWFVoZ7/3Q96V1YUig4MbN4+22GcveHfu6cLPlApF3+91kOok+ck7trhs6P6lKJM2sh3aLLAn2RY3U5RwhZzFaVbULMTZNCypvt01mEUmumkSft6vN4bzad7rthpQzKSrLoukHYxEV+D5YY5Sitm3rugo+IUFV66YxfR9izIA6RK8UBs/WmbLCwhVhUA8fPiIRTor6IG2ffITEevybWaEoEHUZXugZCUDPSsFEBulSYPARNP08Ho0k7fOFHz3T+NQ/z+NGk3HOjXY2fmwc5AUAgJco6plbIrzkZp/hfLjcr0Zrba01WiNCiHH8sLXWGOMKV1ZlUZZ4aaZ8dnbmnB1P5L0vywIBiJQmA6JEkAHatn3w4MF2uwshcGY9QgUBUsoYPeaqxhiltIAkH6flpHDOuYK0nla1EjyYHfjOIyMxceCu72OMKafLvBtU1/rdtremsNbE1ANw1/Vt2202zdD77XatlBGRptkCR+Z0dPVK1/nNZp99sFpbZ0mRUnq365UiUoBKisrqQq02az9E76MwEZH3YblcimBZ1MoZMmoyn4mijIJGRZYMUpR1Wbu+66bTiXOqbb3RWheajFJKXbt2rSjK4FNO0jbBD2EymTjrxsCnlM0JqqpYHpqqpsF3KSXdB0ACYAIEAclZEDUgPdPrfb/4AgDMQHA54Q5AGACVMqN04ftq4GfEFQqCossywCiER2bWSo3NIQCYciJFOUYcI+yohLgUlALHcfNLJlLwLAQTXu63OyazgDL2hZFSzBkyGSJNSo37MSvllCqNI6vHDZG2F+uJq6aLQ0CK3eC6SpmSmYkUCo7q/wyCBucHU11S0/VZSCsbi0RaOeuCD977sYMlpTT4IYUEgNDkrpemaZJIiqlv28pUWISu2TU5DH0wCoIPfRy0Vn3jXWVSypJzjIMpnSa9XTdWW0mShtjFND+cIwWjqdl39aTc7rYiYgyk0M8Ojtu+3aRGaSBUrrAi0VV2Mp2DQu9TSixJaeKiKKpJIciTulJVoZptikkLYBYEKCtnratn02bbGW0AJHFQWpjh6PB4t+2H3nf9kJNYpw8OlykG30eldOh6BBIBRJVSRIKcgtIqBdnvWgDUMQoRM+exEgRAz1I2+Ah44hEgMeeRNQcaHcbYEDHWzp+pG74vpbokAeDSNpGZFREhxRDHVSdEYYYxvMlzduuZ58PLjcSelWmeESMj1QlAapThCDCMkmhjDI1tuzGOvFyMSQGCIqONcN5crK5dOSZtAKHrO61tZuQskIeUUtN0SiltDUuqJpOqrpfMjOb05CylNDpZ51zXdV3XjYbVd32IIaZorEUAyRmJPvnJT21WF7vd5uwCm/1WkSq1m01nGlVdVtvtFjKnBClFV9p9s68QJfsUYyLttMmZU+LpbGKTfXBv71yVmWPwKQcinM4OMiRFajItjbb1pOz7XiQfHC78ELshFa70fRczKwUMfUwCwVgw3W47q6cn2+HsyfbgsFIEk7IgpPV6TaCrqg7Jez/M51PrVAi+0GayrB+3ZyEEVOKHeOPGtZy609OtumytEmYuCgOYY8gx4H43jIutc07MOKZ4DJd8+/Oca1zPkYgHeIaU5bIkjDjy4Cw5K6IRM9GzzrHRwEY7Gzc+/VdIS3gm0bxMFS+/OG7wfonAPqKngO/nB/h91zgqsBAJUY1dFIg47noNADklTeNVISBt1xdOGzeZjLXLvu8tqbZtm32732+7rosxCojSKsbYdb0izSCMahgGH/oQY4rp6OAYEPq+H9srhmEYHXqKUWtd1XXOedj3VVX3fau1TsKaaFlPnHWSJAMrAbQqcgo+aqNTFK3svt3FmEJs5tNZYYoY/Pvv3z04WrBkjWrskooxlmU5xHjy4UVl9Xw+m89mu/2m79uDg4Nmt+/bfnGw9CFYWwbflKUNKVrmYfDd0BOC1qQQyZhJWcXgFUqKvm3CpJ6P6NYY40PohyisjmdXdvs2pZiTHB/f+OCD+x988OHR4VRESFGMUQS0UsEnQClKNXTJD5kIcpLv52ssLCxC/yobNDqKMZaNbmkUJAB8HwARIgNIToSXLDkpIqScIcaklCJCZlAKlUJ51if5/AjPLWa0NyQYZ7PRM/D+/GL4Uts5akoFQYABR/0NjoJqIiTrrNNm1HsWWpdlhVZlyWePn05scfrwUcppt948fPhUGENMIy3bdi2IhOjHySKd90pbpZRzRQyRGTILacPAl9JaIhgnaY67zzIrrZXWOWddlCj5mI4RwjD0TbMPXS8MMeWm3VljVFl0fd/GYbPducIZ0jnk2Wzu+3GHATCFcoUNsb9289Doogm7lHNRVMIy+IE0udoAphh9N7Rl5ULwQx/aJk7mmBJr0MKolEEGRbpwOPSDJGm6bjqbLBdzIthudwJsrSECyTn4RBpQVIxJJMeAD7aPERUpIIQU/Gw67dq2KCZA1ufnNoIpJaVBmIZeUuCjw+MXbt3Sz5dWEQnROFuBnwmznse1ERIRkYCMwW1cxecoW2S83c8ECJdSVmRmkfSMrJAQwvMmBXkmtsFn1PglQcXy/SN/hFu/dFEsCAiAIjlnEQal1JgWIpJWqAgVIAkgyuWIPYWAdP70ybvvvDMtKkDohmF9sTGuEiBhBsLCWGJgFoXKWpdSAkQGUQicM4AoY8wYssekQZEhIyLWWR/C91t4iFLOmTnF0O33bdNZMpUtIQoS9sMGALRSSCqGFIdYTStg6Zp2jPLWOoMqeV8f1F7y8cGk2fsH9x4cXKsKNwn9oI0BH46vHrfNXllpuQVEYdztdv0QDq9cKeq6nrb7i04kj2pmpTCGMK0nfT/0vtdGC4oPISU21ilNVV0pMClmpSjlFGNgzlpbXdphCMdXD1PsjcWm2U8m1eJgfnp+FlOuJ1PvN9ZaH7xzRlsEQFfosiZbov5o5i/MkEQARGHOeaz4fl8oMEIM5me6qGfOiQiAAUdWhLTWKaUxTDxjQy9d3UiX58zMaQyLo3k9r/mMxiGSRwnhCGKem5eIKEVwCedRafV8yAh9hOmALIw5J1GalHmWSaT8zte/tVlvvOmQgEWzqDQ2ehBooxOBBx5l7WPQGaGdALA8M2siYPbeaz1220lKiRC992NBamRrc87MIiDOFteu3jSkzk5P9qntfY9aa62bpqGUUkyFKWpbZ8lKK2tN1w4AeDyZB+Gh64pJ7Wy5SU1ZmWs3lilHZr44OxWixntS5W63Voq06BB8jNHVBk0eUiwqtzpZCbBzRjk9mdQAVd8OWuuD5VJZg1pvzs8Xi3nre51QizJOKWtA2BgVMsXIVW0A7Wq3L2K/mM1OnlwAQFnptt0xxxSA0B4cHOScRJjU/5+tP32y7EryAzFfznLvfUu8iMgdQAGo7mIX2WST05oZG5PZyGxkJpnNHyzpm0wz+sAZNtXdbHazweqqAlAAco3tLXc5i7vrw3kRBVJKg6VlJoDIF++de9z957+F0dy8nLa70K3zTx+/de0Da58fIrLDqgpgQKagBNSIWQANQHqiSZGINZSraaI8NbwN1YT5fCycC7Xmto78edWzx7h5/BnC+XiNKSKIVkKHP+MsP4pa1UyZyUzAkJAUm0M1IZJ3HLxjo4CMiI7BoREZIHz48OHb739i5gIMqqalMTHAESKGGNSMPBOzibJzxOTUqpnUaqimpm1LYiaqUOsyz7XdtWa5lKdng4gYqFo1A2JkCj52oe/7ZalahyGqyjjOgb2jQh2mWrWk0DstVWtFIA8w11JBVeo8LfMyb9bDaX/sN4N37rAfr68udRZwlJIxaLK0GiKYVpM5TZh1nhZAWG0GY4g+lFLZYS5JTeOqu3x+9eNPf1iWBIA+smpNUgDZgNlhreo48tARu5Kqiu6uL28/7edaX332vJTFez+Pc8uS3e12b9++d45rqVK12QKAS9XAPX7SZ6xImZAQHvFua6qYR4gc8dwU/+yuOuscft7vP9FlHrnO2LCrR9o4EAVEeMKr2il8vCDBGlPnsVaWUlrL/0TGQkQiJ1Lo3FWxqtW8SGWLMTpXQJnQMeUsZR5V7e/+7h8EwDtH7ICxLAswsGMjVFNEzMvStk+A6Lpg82gAxIyAjtkxzyVLraWUqRRCLKUYQAiBmL337QJr38tquy739zmXdDod7x+cRwM4nk6qkpbFzNabjSIDQb/q57lgNSqC1Zg8AUx54eAvtgN7rrW+fPn8tD+CuOW0MNKb1y+n0yT3Rx8CVstVcrLddt1fdncPt/OUuhg22zUJ7na7u8Pdx5ubzbBab7vg+OE4bnbru9vbNsOexsktfrMJhGCm85xj50IIASiVmlIts+ZZ00kP96cYw+Fwco4BsAsRHUsx56jv4+k0tWPAzoFZS2dxIYSnS0tN0Tkz47YWNGuuMkTnWe+pjcZHmsv5ZmK2KiJyBsrVmB07V3JVlaZDfnrff971/9fdFTxCE+e+7fzjqS6bKSGL1Ob20DALAHt4uN/vD2aw3W5XXVx30TnMmU3FRA+n0/v370MfiT0RCQD56Nkxs4po1XZqHzNzLNXiYmjCaTAM3ocQYBrT4UBEXdeVWhj9WbMKEGPMOf+xXnsfnX/78VPncFgNzlPswul4HMfj7eFezRiJvOv67uVnLz59uF2gduvBr4bjj58Y7TBP3jPUkMbp8tmKmQBkGqtzaAjE1HVdPlWt1QPPp3l7sVKpftP3w5Cz1lqB6OLZZpkO601cxrK/3e8fxhAQCe9v7jnwi1cvbj/cf3b1ep4nxwYKSAQAOeeh72vV/cPB+VBK9p5vPny0oopmZF999fWHt293l1f7w/7ubu9DMIBm7cGOiWxZFnMWYnGxi0QIoAgdEiFSzkVFBExMTeBJuoPYVKOtAlII8ZEaj4h2pncSNasdIi9SiYzINdmFGbS1z+OWEP7Lw/THY9RGO3gUMoQQnhQyAFBFABqpAY7jOE6TSJ2nWUSDc2aHWkItIZydIx1TfPv2ppTSxV6qSCkuBDVDAxBTs6ZXeIRIyEzBSFQIgRhj8CpVFGsVUqC2hjLgR/rYU/soIq2zzDkT0uXFpXcUO38aT7DUi+3mu++/NYDr58+K1KUU793xeFjSEvoIqnWpteRF4GJ3sSyjHcdSy3yw07EMQ79/OIrI+rJDcJ44g/gQtpt134d+E99/fP9wOpIqI+33pxh7KSXPC3n//PnlvR7GUwlhtch0PKT1RUjj0REcj/vLqwspdTyOu92aEERABQ/7Y83VOWa23dUgRWJ0fRc/+/yzmw8fcinEGPwQuqmWcjrM603XFv8AhkBS9HA/uhiZHiGGWqrIeZ5nIhUA1AZiNf8q5iarOcscGnaAiKoCrfVufM5HEj1RI3g1wILlUeBgpk+cevwZ4+Vncyj8vPFquEObMKRK4zWXUu7uHx72BxUgQu8oDn7dd3103qFD9p6JeJ7Szc2dc0FEPbECqKqIPkJr2vd9KaWdXTNjdo55qlVAWVVKDd63dXtr5QBgvVrN85wf/5d2252vPdW0LCH69fMrLWLVmOuY71T1+tlzUw3Oq8g8jsggNXtjMyVRSQWNAGGeFwQY+ujCahyP3SasLzaH42nVD1aVIo3HUzcM+0NO0/Hy2gHaeljPxzmVfHF9HZ9fILGUksYsCqGPoQ+nUwqhOx5OcQjd0JlBKYUQxbBobd6tlZGdN0UV6LroHVDwvuuWMWPgi+1Frcu7dzerVUDEV69e7Y8PRRKSXVyuDGqVusw6nsqGnffkclkcezMUKaVkM8/0RFkBcg10QDMwBTNzjg2qnjnxXqQAnh1FAZGZa60NbX0iAz6djydW1lNL187fE6wFcIa4fmbt8jPN4SMTq2ERN58+7fd7ACAyFfX9OjiOjgi05kLOm3HfDx8/fUxLckPfandKCQBD1yEagIpYSulpPm2FVUQR6XGLpaUUH/xTvWbiGOKyLD9fjzbyT/u1FhFmU80lpzmRWfDdahh+8YsvtpvNzceHw2EM/uI4PozjPVaJu86IilkXB9TqmIlwmo7P1s8Q1+Dkw83Nkkvf9dNxGWLgjr0juV9mmbp5G1DYOQwdiu4urkTcd99930VWlWdXz3/86W68O5Lhzc1tQXVOs/paMMRumeZpWYLXfvBELZZRmTrvOqMSIpaSi2RwkOdsBt/+/g9NaiEih+PBOSKWq+tV0SUMZqlOSVzPsffOFfdwfyCiJssxA4TCzpFjVSUmQjCAEJjZl1JLVhEFVAMCpFJK20xrlaZlL6UgoikYtDMEiGcgvvXvPy8fTxysRmZv/+rp5nj6w7Zjfpq52sDw6dPNw/2h3XBsgM5HH9fDIHUiQO9cCOHHtz89e/n6/aeProtEDomY9ObTT2+++GWMwUw758fT/vvv//PXv/pzdr5R+70PZtV5R8hmJiDIrUGXtEAppUABwlornp8QVcPtZrN/eLAGl3DNJdWc9g+3IcahHw57+e7b79cXF2i4WW+Zw5JKSQn7Ms6n6P2shVdDxJL2DzGs2PE8n8Zp2j17PtcRJhElYj9suujc6vL6dBiHrROR27vbLg1d73Opz948/3T/8OGHO8c0jVMfVx/e3tx/OKz79eVuNc4TAylICGF8WAQSEDI7lQVDn0uWaqCYLTfjE2YyxdPxROxi6HI5dV1z2XFLWroI6/VqyWMVHae89Ry7cHHJm603yKWqa48mYtv/mSEUqfyYQYsIiLQs4j065zOkJ6KeqjVGm6qaGCESUyOWMDkmQocAqPqYqPuzhr09+k9Emqfn/hHK+qPMq7Uv1mwbtBFH8f37Dz/88CMShxARAar64K8uNkMXRQRUuq67vb39ww8/fPvj2xg3IXTIbKhLmlOamT1icGwodTwdCW2InQBKPVPEnONSzsBY69ZVteRsj45fABqCz7k4ZjVItZRcAICJxnEkRs98vbv0RCnneRqTlF//63/19u37jx8+dHENCCnP24s+ZzTUUoqYxC6WMg1DJ2ZaCiClJB/ff1jyyKHzIcahWyYBc44juxx7JnPTOM9z2m4vskubzcWnTz/VWsBQi2ZLKubZ+cC+8y8vnn26v5kXHU8FAUuR9c4B5LQUq53HisiAaKLeh5vbY8zu+YutgeVUQ6D7+wep6AKGSP3QA8A0T1J1XKp31HEAUnRz0aQCtap7ugxaOZCmb3qkqTiHzMHMwEiqeeef+gnv6cmSz0wNqDGriAjwbFPWlqlnhLLWn09/T0fqCTh9Onb/fy42KKrgXVTVm5ubjx8+iCo7JyqmhmqD6xj0dDw8HD5thj7G+M033/zd3//Hz776k1989dK52LyHj8fjer0RKcwEhnVJV1dXn3/+0oduLtUYVAQRiJiYpJ5pZN77xjl8pMrwPI/r9coTS1UMDplUJee8zEvNhRldF7sQh+cvl2WZpmmzGd6+/cN4OsWmTxfZXe0A7NOnD877/eFw+fJFkoLIcQiGWnPx3r948fKHdz9Q8Ko2rNe5BpVq6scx1Wo55eCh6yK57rCfiN3h/jgfpxBYa3VEVpv1nYnlaiUdRwMtRbJMQ3Sx8zFaqVPf9athEzjcfXo4HI6r1ZqIrq4vljSK1BfPX9zc3C7LnHNtBXS16qa0jNOkVU/HzNF2zy+ARSoYGFBwxCqLe7ow2ufNaIjURHjN0aZxXcyUGZreu/GMn4AA1bPW3lTBkJnNkAhF9GwBpCqirfd/wrfa/QXQ0OxHcpXzYMrMTOCcJ0IENjMF7qLLud7d3d/f3yGR9z7X2nY7nfcINM/z0MfdbnN3e2eIz148/+Wvfr27fIHVcpm476Sku5v3X339ayAmUgfOiI778ccfP37+2a9cF8EqGGotymhqraw3jKrd4I/Qnc7juBwevvria3TEwaeq9WyLpEPf55QCcxdjrTXGGEK4u9fN6urrrxi1AFCtRQHGcX88PVxeXhTJBLCcxrJk5zvnfSW7fPZsfbHa5gsFvL87hWr7/XE1DMNqMy/HGNxyShy7GDEt5fb2vltFBA0MU7KuWx2PE0hGwBAoBj4eDkQmoAbad7Fbd+gUqAaGi4vtENaHm4OWGnxEIDDJee4Hz2A//vhjKdoPcXPhADAED2Y+OkrGPXcViwqgFFFQIaRlNqjKjpz3vpHvnPPNa4XYG4KZee9FVEScc48ywz/ObrXWlFKtlZ1jhCc0wcxElIhKKQ0Kyrkw81MXhef4bn08YQAgpVZA9CGQaRdD7z0AiFRCMMBcqmi9vbl7+/bDeclDrICIMPT9Z69eg2ldZtXUbLoOp8P/83/9f73+7KtrH5BwOs4BJKfTvEzBcRyGXOYiVREur5/7LhhASllNEImCTynN89Lu5vZSuxgJyaz1Bnh1eZWn4/F4f3m5g7kiuppLu4xFBInmafrNP/x9Nwyr3VarlVy6vu/77ni81YouhJLr5dX1xW779v3bvuvevnt/tds9f766n5dpzhebdZEiTochTtOiNRMMXRfWm1jqdDqdJEua8i8++/L9/H48HS+2l6fTIbsUmDYvn4kCMpUlq+rLFy+Pp5PVshm6LBlZtpu1ap1Sba53DvmzV29kkvEw7i63ORci8I4ur3chuDkt7KphFRBQnObUd/2qj7GLacnOkQrXItwwVsDDoaBqjODaqSJqfhjnxbPYmeXSKppzrmkG24/WULfC55hLqcgMpk/vbDtkj1iD/lyEo+dtMT414wBgcKZ9igiCgqlTc8wlZ7DivHeOT+PpdDwyOSNGUueDAADIat0ZVJW62Q7v337rg//tb3+barm4urx69oyjZw4rW+d0rDWt1xvTClq990nynJbh6vnW+TzPquBcQMQQYqmlPQPtqTuXbMIYIzOF4GtOKPlwuC91WQ2rfnWptS5zy7StYOYIw7ojxsP+jtBP0+K9Y+84eGSGqhF9LvPD/V3J1TGvh1VZUh85gC5Sa5q3u+tP796G6O9vblCx5tQFl9Ox5NymoukwPdyeUF3w3dCtTvsjGnQxTMtExH/yyy9//OkndjyVUdHQuSUlI+37OAzd8Xb/anN9s78JFx2D++G7724+3YUQnj27Op1OSORGOy2nSGG96di5rGV/GCVZcN1mvZnynHMupSDAMAxdtzodj8FT29n2A7Mz196+9sG3YwRQANExS62eCREZG7LFKo8YphmoMaDzzvN5I/t48JTItc9DRJ7cItsF0MzKG7voj7TjRxkPETG5p9WKDz5VnbXub+9uPt2KKBp6RkVqFbbveyYap2XVdZ54tVq9//D+mz/8br3efP7i822/6ciLWhfDh59uvv3hdy9evOlWGwCTIii6W226Pt7fTwWggrIhg5VS2J3n0DY9hBAQ2lbeex8QSQk364vr6ytEkJpLTVqqA/AAfYzDMLCHqZxQ9ebjp7ubT59/9gsknKYTEzcJjUqpKW/X227dffPNP/Z9P6dpP03dsHu52YFjIgTFZZlLqUwxpzSBrtDXnKZj7bs+DvHtux+J6OJydzwcTc05P06zOuLo7h4+nU6H7W4tYqf9NGwGUc1TfvbqGQrfvX/YDOvtapOn6eNySwyiYKY1LbUsRUo22T+M9a52itvtNqzCsOpHmdGRoj7cH2OMF6tNyYXZHfbHaZk9WQxxO4QwgNHkYoz2aIjdQMhHNnC7YrCh0vD/o2R3zOhcO4tPyPUj+/QMXznnRP64VWwoVNd1f2zzH7+gkZVSuzhEH5rdWqpZwYro8XR6++5jSsl5LyLeOR9CThkonE4TIjgXAAiBh2Hj3K2Y9cPm5cvP+zgEH8wQDIYYd5vtl59/KflsVJFT6ULXPADVTM0YEQm6viulPCmL2svz3HoGnecZEatmDqFfb2op85Kc8+sVl1IcMyKuVsNvfvvN3/z9v6+13j88fPXZ1103bLcXXd9F45wUYEpJc17G6XSocyWwnMm5fvNstb0cp7mm0kUfuwBMz19cMfmf/nC3WfW1VFPwzplaP/RSbZnnu7tbYrd7tp7zknNxTNcvXv/ww/sl16HI/pBOxxK6st36NNePH2/KVHwISx67VVySpiX7AHnWzXqbazmNU62Fg3fktWgVeP/uYdhEYozOl1o+fjqWbNHjPMqyJHYLeA4hMGhKhRjUFEFdO0lPQ76ZtaGQiFRaHotv/5aIpOrTmXjq33PO+ChQhvPijx+nAWy4vP2XZn/thJ3lVABmatayo8A5AkM1qSYpl3lZbm7ujNxq2zfDuForOz4cphiHv/7b/321Di9fvN4MqzfXz07j7V/9+79G4KvL54xd83ZnZCJ8dnldJadpnseRiLyPtYqs5HQ6pZxaAykizRKn1togup+/YO+9WT0/gUjZJFVRtW61QbMueiR2ju/vH4goxrDdbk305dWzq8sXXdft9w+I1vVOBd69+3G97j7dfEC0ftX/z/+X/+s3//mb29MDdXE8TDcfPtSiv/qzr0/HO+dxverv70YiHMdxWAUR8z5O07S/H/vYm1nKxQXBwNyBY0Bw7378sByW4DpVNNZ+7ZldzeA93R9GrHF92Q2bIJIb9UrN2PmU8sPxYIBEwQRQcBVWtVazVLNKFbdm56zWCuhykTyfnOdSBMyK6uV2UFmGFYMvVcA1ZPnprDAzKDIH51DwnHeDiMzYGvn20T42TAZAZueh74kCo9o4EdoWhfhozvZ0DTzxFIionSdAdo6Dj81BuVRl58p0+nR7c5qmrt+UWr1z7GKpNmfZXj3/5u9/L1n/H/+3//vh/tDFbr1eXV5tih4///qXF8OOAAkJzASkit48HPr+IsZOtBAyU3AR0OPh4aFF7LHjMzvrZ+hae0OIqKqkeSHnnHOlFCYHZkWEEK0IoOW6iEnwrFhubvab1cX/4V//t4R48+nDMAzTOP3i8zfTdLq9v7/5ePPuD9/FldcsInWeDv/ur5e3b99ePb/W6qZpMpCu8zE6N1FO5e1P9xcXa+dxd7VVMZFlnhMYO+fmJXvvwailGDnvLq8GSXZzsw/OO4rznGN0gghg0zyXXHcXq+Ugwzoq28N+IedAAAFrtRC9A1yt16XaeBoZXfC+GTznImoqZMfjYgY5ZbTGj3LO+cOYVuu1c9QNDV9gMHVP3JVH5EkaeFNFuSWNn4ugMlGx+nRRAUApAmcuXnOJAe9dCx155CdJO3lPx6jdju3LOueIuGFYTWbTHBad84hhHKf7u2k6ZTASqQ3BX+bl5uamCAQ/f/j0TnL+1Ve/3F/sx9O4Pxzmcvj86+vPX3/m0JWcvCdGEqlmstpuCD0RMvh2nhWt6cMAUKSZaaFnXJal1voE0bUhtOs6xwxIosrM3runJAgzw3bjMf/0/u04TSXpeuiiX326+TTOs2g10Q8f307jxD4+f/GK67Ifb2+Op2VZ9nl+d/Ph+sX17f39zc0xz8tnb54Llt/8/hv2brVebfqNSvXOD0OvgtM41ypMrKqA0PUeICx5QsTVdtut/MKnfutIw3Qsc55Xrl9t+i44hHjcj9uL7bv5drUd5nzYH9P1ti9Zu7jCoLUWIkzpKAarYXWYTkuaROrQDykfQoibzXoaS82qgsQe1BCYCWPw3pOIDP16SXMkg6oupUSPlgqN+fQ42Yn3yuwfxzdo8axPk127sVoQSBNsPMpK6Wk1a9ZyIXzDhNr6ufVe7bfMbFaZiR0REgCK1FpLzvnjx3f7h/sYO2InpqYqIqXUV69ej5P+1V/9Vd/Hb//w2z7Qs6vr59fPTPV2vnv56tkXb37hkGutuRYyqikveX44nq52L0E1Rt9cJMkEAGKMKZWG7DOzqJyBK0AzfWoSCJGZy8+QW1WptQK2THoDIGM0wvcfP+6Gq3meb999vLm5/fjx3etXz188f75erbfbDZBHc88j/ru/fltRFgfR9ZDS7797O54WzbBdD2Q0HmfXYalK4JcpPXtziZDmaXI8pFRj7No2s+u47yMAGFYFXU6TZJxOo2NUNLUkFbTAokfvhovNJi2p693nX7xYXaxOn04v3myckKltNhd5zoeHA6HLkmLfbTZrRTuO9zknqeYcX19fOkfeu1Jq7ChEU+xUJeXZiJzHZVmWOYdI63j14f7GtZHwaZ3SLi0zaxhBU3WKiHPc7EWbnQicfT7+aEbFzI1j3DSsP1sbt7GgtV/iPTU/kUeagxG5xghkx4BWFU7T+OHt+8Ph6L3zIahB8FHB9vcPnj1o/M/f/M3Q8Y/f/fbcKdYKjAXn9eC//vzr9eoiUACQLDMBFZPb/S1zIEeIJKAIZKqOkZ1Xm5uPHAKCaYuBQDxzs9oGKefSDYPvoqWi5/UAOe/OtA2BOSU1w+BWq90vv/5TVqilXD3f7i63l5ebzWa7Xg05LWKKWpZxuvvxJxUIIZbjpKrDsFr5evliN49l6CIobft11rLUUpJ0XUhTIbRpTqtuVYv1PQFA7HzXhZxTKguiz6V68vNxMVMlAs0hBqA6RJdzReHD8aBgyzyfxpHW/sOHh6urfjV4Qne/vwm8dj6epqOLsdZ6mg/DKrK/fPfunYi6wMRwPI4+UGec58pGrz97ddjfffy4cPRVa0rFu47Qn47JjN3Tnd8Wf09lrh2dJoY5P7igZtpwhMYzYfaIZ8efBrirytMXhEeqgqo6x6qNe9NgetYnPjygGaSUc85EdL/f//jT23laEJ1Vh86YCZFvP30aT6eXz968/en94eHeUc3zaT0MqiIsIqIol1eXb15/6TgEz2b4cH97HPcp5aurKx+G9aY3e7QvNKsiKS1mj0wyAFHbbDbr9fpwOD7tyBHxjMlJFT3PLiklRGHP636VS15yNgCtuUgFs+vrZ6Y6TvtXL968fP5aTWsV08NqFVSVcSnPXz5H88fDbrgqpjd3t3/2xVfTkvh5mKdklrth4JqnY33x+Ytpnt6/f++8e/7yWV5QRG5vby8vL2MXp2nyjrsuLrPUJJmrGjIFZCKvjByiXw9B1d/f7Z+/uma2kjMiPtzeB48MOC9L8Byig6qrdTeNmmopWnx0XNI4nhyHYRhyLfd3+4vdZpmXWhCM1+utWb682nrffbi50QxDv2LyPgKAEpJj5ta8Pw5o9tRbyDnll82a1EKYz49ya8VaWfh5q0s/M0l7ghLgvAdsulRtpmoi5+0kEdQqOSdEMIW7u/0yF2TfPlAAq1U+3Xz43e9//+rVq1LrP37zH55dXf6nv//bdd+paalVGcX0zctXrz5/492GyBsoAALax08fa10M6ueff92UQu1bIMRhGE6no2mrd9CskGOMT8Ng2xa07+Vp5rBHzy0iZGY1AyYOZ5FIlWoAzeS9FlvS4p03s1p1u7kOwQPaxYV9+HRz8eylkc85s3evXr5e5vnm5kYRAjkR/+nunevi5eX1PC/zPA2xv3y2BVeWVMys67plWbquAwA1c85JySiIwCo6T2m16cwJmoFB7PqUyldffw5kqv7206eh66eUh855pjRP3ndImsuyGvpYQ10Ukfo4ZDlO06TqzayU5dnLy6Ff3d7cT2Oz/5s/fvy03XQhxBfPdvvDURSnZckV1oOvtbr2QgFgnueU0tNReGykWpNhIoZAqvhUB733iNasXdpBbFugp/P0c0iC2ZmJGvjApZxF8c00RoTbuhoRx3Fc5tR1fR9dzuXD+0/vP90sKccYSy5a6Z/+6Zu7+48P95+QecxaZRar03RyjpSvXrz8LIZIzEr1NN5N07Hm5fbjh1/+4svNetNkuwCAaMxwbpKaL5w5JEZFx16KgLYoC2ujpYjUlJHQzn6+zdaGU87BhXU/OKRa67ws3A8iknJurpPu8UYHwJxT7MKSUsp59+x6CO5it3v3w0+H4957Dwbeh9VqA6DTeLq7pfn+2CFVhWka110PXPaH01IhxrDe9CLGzm3WF9M8OY8+tpaGBURVT8dp64OhMPkGOANaWjJYSWk5PCwxMKERYE4Ca0S0Yd27wGlfHjEjWcZK1BHy7c1Dv3bEcnPzSRVqUWQ0UN/5uFq9eLkbT4ePn3IRi7Fj9A/3Uy35XKqe8Hd4lDK31qo9siKS08JMqvK0gW5NrnMNCWu5F9Quoac60tq1thMkakb+4PjnB+4soFiv158+fbq9vf/DH3789rvvShpvbm6HfjPnErreO4eI79+/Ww9hPXh2LsaLLkQ1ub27Xac4rFa//ud/fnX9rO+iGaeU7u7fffub39Q5BUJUcUDyyMkh4r6P4zS1cKVWjr3zglBy8c63e+uJ29PA91xLs8l8urAJUVVzzrXWnPLPS39gv99/vLi4+CPszEhEOed5mru+V6mhW738/It4v2bGaZwohGG7+va3v2PGl1999v7HDyqlFA3euw7nvCBGxMKOUyrLXJZlWa9WV5eXSx4BjJjTUkTEs2su5j4QkZ1Ok6GepsPlbnV4eCCCYe0RyQcSo2mEq2uPYLWIdcbMqvbs+fO7+zupEpzPqcYuPnu+VrX9/sQUu95rsRD8r77+09M0/va7H0+niRw9u97WUk+H2Tuqhk5ExnEkohCC/Yx210reU4sdQjADojMb4o9BgWcintf/StMM4IMX4XZGzcw5L1LN2rTV4KGzCHFZlr/927/9q3/373/88T0QrFbDZ29evnn92ddf/2lV2B+PHz9+9N796p/9EsrycHtznMZhGC622zeffdH3K4/wu29/z8ETUCmLaZPVROedSvn8+tW666ILyah1Vw0N2V1cIEBaFkQ0RQRwzq1WqyaLsEcFR/sG26ahYENDnDaFHKKZHk/TsizMjExSiqo6wHlJ//RP//Tll1/Gruv7vnUYh/2h73skqmA5ZxXptxfo3Luf3opCBTuVaffyWqTeHu+vXr1wXG9O+5xyrngaF4f9NC4O6HScAUgEmulhLaCmKtUU0yJM0g0dGJgJM+ckoeerF9ua5u3FRuTQDXHOGoZQC/crP06jd+5qt2NyMYb2RG1Wq3meVGCpSU1jXN3eHUwRCGPnMHAI4Q/f/3R3d2uqXbdmX0uZVTDnstn2JTfxJFG7h9oir90xrag1cMvMnKenNxrBqamBxhhbSyZSiQkNay3MzQ9CS83OeTNt8YANPfLeq9b2N7bv4be//e1f/dVfffftD8fj6b/5b/6bv/iLf9ENnYrkXBDBwO12F199+YVIUUur/uLZ5qLrfbspDTB4b0SAtMxz70Lnu5uHh4fTQxFZrdYvnz37l7/+lz729WxWg1IKIhDizadPdmZwCBKIimodVqHj0PJqfz4si1qtioQm4IKXWlSkioxlulhvu647Ho+liuQsIgiYS6bg7o+HzzYX6NhMpQgRllJj33XM4zg26kQW7dYrMqgo2UbD/N333//u2x+//vrVeuOr5ApVSu243x8WVBcijzqRwbrvaq7QYUrJWpk3y6lER2rK5tM8mWh0G6saGD8d5hdXqxcvL2/v959u5i9/9blJZs/sQ9Vaa2GHBKI5HR8epnmJXZhOS1qyoj7cno77IzGmJYfYDUN/ODycTiOz77uh63halixgoLur4D2E6N2bN2/w8Upn5mVZRGS1Wj3uW6yVwkeisAGAWml9BjLVnInZDGsxJm6EaEADVCbfbNwAwHnuYjTTJntv14D3/ptvvvnw4cPr169V6IsvfnF1dRkiz9PUXpKIdB0OQ3Qc1DzzqmPWWr137WB9/9MfTuPSdT2Y7tYbJqq1Xqy7KbWvT11ccbwCcpITslMtpZRh6BuQ1tZKZopI1khhiIf9QfU8jpRS4GxDguwYidhxa95NhZkNTUT6vp/meZpGeUyLRcT/7r//75iJ2aNaXpI5A4B5mu6P+93l5TAMrTi8f//eef/61etn+cX7T9/94YfbzUX8b//7Xx+Od8dpPM7TNC/PLy9NIE/LajVoi0d0vjW1G9iIVkKqomkW0MYf8I6Dma/FPNXmPDgeEu62RQuB7XbdeDxYNs+EAp2PpnAaT0C4e7YTlW7TAfCHt3vnfC1LGtNmtd6fxpKVTDJmbqQ505Sy8wAGXdchifMKqmbg/vEf/7GU8ubNm4eH+5TS1dX1drtl5maG9oQ7IAIS2RkyAHaU88IETXkh1ayoaA0htqWvIiBAqUJETIyGUnMb7IkcO1bRt2/fnk6nZ8+eIeIXn3/tnU95OY1HkRJCCCF0XeeIPXsAdT4SgSMDdgjkvWeiV29e/W//7q8I+NXzl52PClZK7gKw1Q8f3qPVGPukZqXw2RMJ2keiqqvVysxOp1Pf92CU83nlUGr17ryYf2K3OsdVpOQCCMuymIiZitYuds45U4utCavSGnzv3GYbAaBkAQVHXFWYaLPdduuVC/4J1tntdiL1b/7u3222F/OyP01771GhkqO0VGDs+phzUgWHzaC8+hCCi0ue27cgVTgEMNMCnjjGLi0l5eI8mGm3c+xonpY8SxpLXLNzzteFIeQiDvnV85cfPn5IkHKqr9+8utitPnx87zzUYl3X55QDh5JqrYJIXQxkhEA5zdDSJkFyLkRUSvaBTQnBiMx9+eWXtVbnnPN4OBxyzvd3Dw0LuLu764fOOdzvD4gWonfOpZS6GLfb7fbiwqk5ZBVZdYM4AyhAQMzB9aUUAH8OhlRrkCMSOs/g6ebu9scf3t3e3q7X68YoX+Y0jqdpGWMIIYRWKz/77LMhxP39A6E26xjQ+rMNI3/8w7v7u9s/+eWv15tt54N3bhqn03SbU/rw7r138PUv/kWeMiKioxZQzkxXV5eH436eZ+99a5gIqbl2xxgvLi6WOT8Jis7rHYOSMilWUIPq2EtRqVBJuefWlq26XlQJm50OowAiOFRgxOBY2zQAzgVFXKYp57wsCyLN8/y3f/PXL1+//OzrFyLoXZzzoYBWMEWzXCvKervTI6FJqeKdY8+2GDHHvn9GL06nQ8td8X0Yx9ENHIMj4pxn58G7MC+lDy4OkchSSl2IMTj0PZNPdbl5uP/qizdE3fpq9enmZppLfShSrOtwnsv2ei1V+mEY03E65WHYlVpUjYBKraYiAQHxerud56XMCFh9wPNKBwAJabNZr1e7lErJlYi6riNyVZb1eoOItRQ1G3rLOS+zhKAypzQvtZSum5a03N/fMpOPAZSCD+z4cHgI0V9dXq/Xm+PxIKqXl5e3h/3vv//+8HASkd/+9rcXFxfX19ddXBFR3/UheGbquu7V61dXV7vD7T0zpOWkJkjgyXkXVPXDh5+++eY//2///n//F3/+F5frbXS+rQq6Lh5O6tiD8eXVNfs+OI9IoiJLFhUFFdXVavUEqZiBmtVavfeHwyGn8uR92WYXVUO0Yegk15pTI03QOYTWmojocceliOi9c67JtVVVCfk8YwI0v0l8HI8Qse87M/31r3+9Pxy//92PMUQwqkkQ8epiNy7LcdoHZkK3Xq8QbdrfpHmCri0qwDmHEPYHOJwSOSq5iGhADwDTND9/tttuLjbb9bv3n7qOhyF+/PjeO6+q0zj23YYdPDwc+u1GgWJ0S5ru707Hu3mZU9eF7cXmWceuoxD7Lq5OPx5CdAIVCaRqTmJKIYQudjG6Lm4Yu3fv7lZD8N67eZ6bQrxKBrC03CISoSslO+cbaAmkRM6H2PaAqxUSAYKtLtZ8uWUiVUtL/uKLz3MuPoRlnhzTNC1gkut0PN7nPH377e8vL683m9XQd7/6kz+9ubm/v78fVivHTlWXlNtCipmIsOt6qfU3//kfb95/LCl//923ZnJ5udtu1l99+SUi/q//6//y8eP7f/5nf/bFm89bd11Rs+T9w32p5f3HD10/fPnLf7a9fGYJiFkMTbKJpZqnadpsVk/zbwNDVEvXdblMuZzzKfDRiSlG7zxP08nEQnBmKKUCQgjBVJd5dt63du1JD62qpVTvz+rcJlF8nDTdMs3Haez6rg2hKS1/+Zd/KWIpzWLpt7/97e3th9XFuprWVD17K3U+TiR8vbu83T/0gTbr9XEemRwh3t7fl1IVyDOx49XQDxfdw+EekVbr1fu3+/1+DD29fH29pKmLkZ07TTMSO+cO+2MfhmdXV99/+y2THY+sJUqpplSKipXNZRCUrsfbm49ItrvelWzHh3FZisPQrbqLi36a0/394dnzF6fTFDveDBeOH9Wh5xbVGNGcIyRkh6VkPTt9aimj88453yIs1IiIZlE2AgUTVRUSRYJSpr6PZrDb+qvdRevyliV99vp1CBHBHafj/uGuFOm6YXf1TGs9Ho/kwjD0bVBoe4H9/mDVnu2e1VpfPH8BAEQMltum/H/6n/7Pt3c342nsY0AENQEBUzOzm/3tfjyEVW/A8zJLpYBojsC45NJ1q77rbu9uz92hCBG1jIxlWTbbVa1S8pnEQWffeUMAZkcAS62GYGjNo9XT2fmyuda2zj3XogCkELvOe1rmbI/x1c656TQ55u3uIufcRmNm8iHu9w99111evprH/PH9x2fPrtn5m9u/q7UuhxND8CEu3eKQjbHfhDGPH9/fWK3Hw2lYr0ERKsSuqzUB1FKqmb1//5GJUoWY3DBIqWm77mqtBubZEeqy5GWptbCK9RGCD8pO95BTEuOUmfLi+5iKhN4DUEpT8FFNnY9D9LWklBFAhj6wD7FbpVT2h2Mt4p4gKzADMARHyKVk58hA2vRH5IhYVUtOzjsABFOpAsyPCRXoolMzx+ecnLbTIaJSigg55wxsHMf9w2l/ejgtkosS0el0klpTSrJklVpj8J7Wm+7ycnNzeyuikZ13ntyZLhHcyjEZACJlcYfTd74bnPcACijMPsbokbWWOKyxoCX1zhOYaSW06Cn2wXkG++Ou6dHmhBBx/7BPKT1FA6sqM+VsatJ1sYxJVRVM7ewkgERGLbuh/gyeMDEFAwSSqqVIwzXa2QoxICCAohkxi9TVavjhp+/+/V/9u//xf/wfS85fvH7z+99evv3waXexCRwmWLrVjpXBaqmltaQIuN1uS7IQOucCiKHqercdNvHhoVQREQVDx2G1DsfjMTh32k/DEMdxmeeslcwJdSa1xq5nBu9dDLwZVvvDjIRGEIe4e3kNnOd0QoC+i1ophng6Tqt1l5NqXZjZueBIlmW5uflEQKeH0Xnnvf95SFNLwOJaRVWXJT+uI9gUmblqRghaGxalAFDymYtsCJnMAToCB8wdwTmwqSm8ENFElJCk1PE0GkdqVouqq2EY+uEpfmuz6V+8eL4sS8kJCIFaq84A5rxv8Yo5ZYF6c38XhzW5gC2mpRqh5VLzktM8rV99dnn5DJA8+yYQNVUCMymmwTnXbpEY47IsqggIw9DfP0ytEyICkTPk24zBSi5VxMyKlMf4IDFmGevFap0f16OICEwAgGreta3l/MhyRlElYkIEQz+spUopS4z88vnzGGJKybPPeX716urhp7t3794R4MtXr8ssmmqaj4hIjh35h4eHblitVl3O1ZRAwRMDA7JeP78ajwszl6wIVKSAIimFjq5268M01jynqdoQBQyQmOlhf8/O/+qf/Zkuy93d9/3gnF9fvrhatCzjXIvE4KfxsIqraZpT0ujx4X4PYtvt+rAfAyMzHY+n7WozdKuCmTo6dwZmpore+2XORP7sdW1SRQC9qmJ9dMMCLKXao8ld+9k7p6pqKgaKBhUZmzeCOuey5K7zBO7h4bA/HhEYCLzzpua7rlHtTEGkbtbrz1+/KSVPx7GPXQUjMeccEp0RNTMDYO8fHh5STuv1WgGmWhgRq2aZHqbjaZ6AAIlUtOs6Imr8gnYpr30YD0dRBUMVy7ggUs2lihwYt5uL0+mUUsm5tH2DiFTRgA4Qyjl+/Bwv1bxSTP+4mPLe11oll/bYjNPcxQCAMXZn4zADJMSnrV6tJEoM0bk3L1+i6s2nm2/+w3/6lD4cxwcg7NZxnuZhs+2v4+1HnU8jDjGuVg8fjvl4VDEWc+RLLYyotSyjTqd9yomJrRVZr9VzLbJed9M0mgl72l5ulmU57CfnGMyZpnmZf/jp4+eXVyH2PAAhM0Oq9e5m//LZtWpeRqnTFGMkh/M87i5WBvr61bP37z6VIkV01fUmgg5SziLmml95q1kpJyRskaSAbdv6x/gA731tSXiPmuaGUT0CXQgtsIvIwKqZRxaRWgsSTkWOh+OHm5tTTqgmqXh/jqVAxFoFDGMXNttVzWn/8KBSmfkxOpZaXGatFrwvtfzDf/xPxNzHLrIH0dgFEK1VEMp4vLn9+OHFs89evflKCXOtXQhqBo5LKTFEx27JBgAEqFLNBFC52VEoLPMMgM3hoz1vZjbPY4zeOee9l2Vpda0R19QsegdmjUfUDlaDdgGg74ZmBT1NEz4St4maJ8ajfSG1Xlavrq7A4Lg/sg/TabSmXFJYrbbbze72w4c8zTVlIAi7HRODArNHwM4hYHc6nSI6Jod4KqVWRQDarFfdgKf7T6pyPNqw8t26s5VzvF7mhYhWq1WtZZoWIvf2pw8713sXDTXNy7B2luomdnmaRQsp5QpMFp1HBmT37Pk2Rr7YDad9CoHRRGQBLI7QIbuGwTxZRYbQyhwREjtHjCLabNsRkJlElB6dIBFRQVGRmJqLVvvHBV9qJWyAqpWl7o+Hj59u81JqFgXbrNa51EYrbZ9E3w1XV5fr7Wo5jFqrcwxm54RMAjUFNAMax1NLqyslbdYbRsJm9+G4yGKQ0cp23X/95Z+sNjsmJ1WrVCDwXUBCQIhd9J27uX/QIiZnOTa3PN8+nubFe/8oS7MQAjOXklpJbHWzAQ1tF9QM7KTXzWYzz7OqNhCuMZG6Ljb9Uim1UR0RSVUqCBN579Fg3I8pz8S4Wq1vbm5eXr7E1/yPH/+WmRw5RHd7czefJjIgpM4HI3dzc+OYaxFitxq6+XSY5kXAxlPu12x0DnIDoHlJx4cyH4uZqhTvceP6TMs4jjFy1/uup+OhrFbDPBVG3h9OlfEwjkuaitRlnoP3iOhczPNckmzXsTXRpeZUpk+fRi2+5Bx8BDMVyGUBhT6EM0W4baDNzg4++JjIBEBMZ5xGREUrAJiptjg/cqbnZGgfnSMmA0MgJEeMBkg8TfNhf/h43I/j4p3v+qHxnFjt5yqrEP16s6oi8zI7z8xORUjBkTJUQBNUQvv2u9+9fP4mBG8QQtd55wAgOK8mWfLbd98v6TgMHSLWWlzkPri0LGZAwTMRiZVSDsej5Cq1mlrr0xHZEYTgOuuWlEyhXT+qWmslcsF3hAygSNxIMk+XUMPAhmFoDLY2GLY60GIZLy+vfvzxp2b6QGdjutAONCFuLy7fvTuUuXax//IXX236DdonRJWSf/r06dXLN5t1n+Y0jvPFZrcN/f54AKpzLUtK6+2KwOZx0Vp/8csvEuXDfAMO2ZFWBJTj4VjmSkBmHJwn8LXS8TCVXCVL3/fqTQUd4Xo1EPD+eIyrQUrdXOyQkIsG71NaLq8u56mY15Kz946JOeJq252OdTrl3WZAkIvdesllKcUsL+PoHqno5/jTp9GmtVPwM0V8WwK2XXVjvPxcHlhq9cTb1Tq0YBxiRpynecn5uKTTOEcf2wT6FEH9KN6Hvu9fvnzGjMfDaGaA1NyI6XGjQkRqVkr50z/9k/GYSpHtxa7v+zaiEomIIJaHw91+f3Ox3qW8uJwIsetXSLikVNPSxXh1ffn+3XtRYWaRes65tHNRanwBVZX6XxjjdF3XfOfUgImKFPzZD0JwzKWUUsrT5v6R1aTLsoTgXr58Vsq5Pj6Nh22CdORfvHhJRIBwOOwVJA6xH1bTae66TmuNfo2eXnzx4vRwBLPVegUpxVWYxyRz0o77vl+WNM3TmI4VDYyCg6wt7ohEABAZkdgZ8ng6iYgpLUuqeQq0XY5JEL3r0bR3xMyr1crHoKY8DHmaACDGIFK7blCV/X4ZT3mz6aDSPKZarYoEBwaiKrWmGINoPTs85bw8vVMNwj4TZpqBmjSdHT4x+OhRy/UkrGAiUVnScjgcGkghtS5pGZfxlGbiMz0m53w8HsdxbHZnRBRjvLq66odumk7zPCHhmQDN5IM3gFzyu3fv3v70EyLc3Nx+/4fvV6vNer3puiHELnRBtc7T4Z9+94/v3/+wzNOrl692uytEVJN5mdrrR0STKlJ88OwYUNuw+XiL1Bi74Lv9wwOone9Rwp9pdURESs5yBuv/6IPP3ukj5k6PdjRPjCMAFCk+cCml3X/tF2bW5oN+GLz3peQYw7ff/UZJ/uM3fz9P9me/+jer4XK/P6269deffdW77vnl9dD1UkSzbfrNZths+xU1+Qnq/f1ec0XhOruymKqVDNOooAgAhhb6rlutWjmuoiXXUmo6JauY5jqNSynifPDeOUe5ZABwSADofTiNJxHd74/OuRg6qbbM9ebDNB5zWvJhfxrHtOSl1BSjNxMDPcefxo6JXIuUE2nuyNzusCoFAHJJSPHJyuFs3PAouPDexxhFxQBbQFIpZT6cHg4Pt/d3qSg5L1VaFej7XlVbg9W+mki9ublNy+w8F4TIrvPewFJZyjyh1b//j//xp7c/ffn1VzcfH371p7/uV73voiKCFESVUj9+fD9OBzB9/eqzly8+71cXi1YwQGQwBcOHu/vri03w/vLi4jSN0zw5ZqIzN9oMY/QqSi0hCJG9c97ncmZUmgEgpJQQ3dMM2M7cUtKS09X2ohU4eBSSPLJVERGbGXpbmD7Nj0QoVWoRpuB8IcbTclICdZBzIoOc02p78ebVm+vtxbsff9peXMyncbPd/fbbH+Z9hgUqC5oxc66JFu1WUc2KgSn5ELJIWkpApIiI4qP7+OkjGMTQoSoIIIJYqWa1oHNGkVKpUfOSJ0O0amWZU8rDeiBCIgaotUrs3Re/eJFzvb/bI2IIhATsWNXYc888L6lKdSKiKs67xzv8zPVuXGF4dAJuB6i9m08PKz5yAM8BqgbEFGOspnf7h4e7/cP+wYe47jwgTtJMm7F9/VY12jkDQBUzIzBuaSmMaoBseH84/uGH3//u978BxH/7b//tn//zf73dbuKqcx0zigcQkRD52fXu7U/dGLovPv8q+OGprLMRR373/u00jm9ePE8pHQ9zlWraIjD+mPxbS92sNy+ePb87HVSMkMZp7GPXGnnvXQzhZMaEQCT1bNjc9kIA0HXdfJpSTvTovtx6hnYnOudXq3UD9xvgXkry3ivgsiQf2Km7u3+YUvnrv/3rJY1LWpj5888/P5xOzHQYT+RcF9cOg0tLYPfh5kZQvHM5FzBaUYBgPnhh5WqX6+vTvJjVfugtZeeaDspSSt6F2AfvAxMjIGoWEVXbbi9qTVVVJJpZLXVJSaR65wB0nMYQfIzDsOqW5bQaVl3fzeNCiKVW5/DisiuSfIiefc6FjJ3ZmbcuUl2jpEklcmbWPK4A0DH7lTczFSWiXHLX9c5xWwcxc+NyISIhprRUs3GZP+7vQbEuiUqtUlHMOee8x8eQwTa3xxjH05hS8tEbUKnasalWVQPF1TCkJR2PeyR3fX39/Plz55yPjshMixmB2of378bpruT0/NmLu7uDowMwUheGfgWI4/GgmrfrwbQeT0eR5snRAqnAzNr80ZZIaZnUU9veVxH1VquUWlUtpbk5vxMSPGZItWtbVZd5mZeZiOzxsDaK22q1SkuZanrx6lkrDs2gMBcxIO9917tSp9u7m7/5D3+zP9589eWvaq1/8ed/kUshpJLKP3zzj69fvHxx9RwQRW2eFgQsJVVc+s51XaxVow9VKqKqSKNLHB6Ozjkm4i6CSRW9u9sPQ/+rf/almHy4u//8s88fHk7z2xtTc97tLjfv352uLre11JJLLVKzEJNzWMqSSlZhAnhIOed092kBQzM1ZQBgx973auK9NzUk0ipORZ33ZsbUtKmKQCVVQzXj9saZNToMVau11rTkvu8b2aZ9JF3XnTtgM0Y6Hff39/fLMndhVXIFZ2oamIpUqGfj5Zxz13WNq6mqIQYRARNynpAZLNdFTfsh/vmf/8sQ3JKk64fnz553fc9gnojIqdFpGufp+A9//3dW7fmLN8+vP99uL4gxWzW0rBIiv379PDpfRO4f7oNbededYxGbYlYMFABgHMdciwgwoagi8DwnAGi5d4xIgDkv+dGRQB8jEYgou/9Cntm6KO+9994Rt7ay3euq6hyvVitEIKJ5mWL0b3/66esvv/xl9/VpXIbuYhyPS176OOw2IqLH6XR9eQ1sZjBPcwz+9es3h+k2RtfF9XhqLmWcy0Louo5zzp135EPXRTJJSwUlEIoueBfe/vBDEjngcTyNJWtg9sNQSwKDw+G0XvfBOSnGwb14fjnPhyKmswFoTjml6gNreUyNAAUDRJ+yqQEhTXkuqmkpLsSIoM0pX9VaMK+BqVhOqeuDqT29g0/t9jIvBmfloPd+HEfnXIxxnuZpnD/e3tzdPxiYigACGjgksbPfhguh67pmXtpGJ+ecjxwhkmkzVANA55yaidTT6fTq9WcxrD58ujHD4J3ntiJSgeo7YAfTdAhuePnis+fPXhsYoCGzIqmoWTmdHmZzqeRpnt+83jG5MakRMIKJISEjr9fr4+lUUE1BRVs8jHNuaYio8+v1MI4nKfLkKHauoS1cbl52FxfzsjTo+GkM8t6H3jPzOE/t+z3HczOZ2fF4/Lu/++t/+a/+vOu6EKMxXl/03/7uD76Pl7vrVy9el1LG8fSf/uEfv/nmP/+rf/EvL3e74zJRdHZ34+KVaCm5LPNcRYhIVFzn0eHV1Yv1ekkp930sZQErWhRNDnfj7775vl/3Yvnj9+/TUrySdz5N6QjFsTseZu/RRWeWLna7omIIItIP0bswHiQn8UQF1MCaZ8dqFYFNUL/46vO3P/3I7PrY1UWcSG0CeQAEA+8dIiJjs2Vv5sfwszwSVQ0hVsmtT+q67qzSEVEVIkpTLksd+uF4PIIDQpRa+74rqGigRdtg1bjFZxI9k4KQoUMA0yJJpCA0WYvM8+ycK3neXVwS89t37y62XT/0683aob7/8O6HP3y/LPPVq+dVa64LAofokalUIUBFvru76Xj15ovPRZWI0rxUUSRGgFJy9KHWOo6Tj2GcTmCGCMF7ZtcqJgCUkhGHUouItiRfFW1ZKa0HaGOUqGYpaMBISNiEG+ZciCGV3HVxnucmWKiSzMy70PdDyXm92aDBetiwY/9Lf5wX53z0flh1p+l0d3s/n+bv/vD9/+l/+MWrQH/z939zKKevXn+ey3I8Tgbu4eFhtRrY8Wk+9UPcXV503VpqnaYjsS+ZmGJVZWATBOWaRdWqmidwxFOaNMaSTQVKri9eX7W7++HmLnau1nJ1tRn6zf3tJyZiZCY0wGq16/nrP3mzuexPy0Ha2CDSx87tOndmu1OIkb33RG1ydt4TMy2LIGE7Me26QiQRnefUd506zTl77wipqiGRiOZSmV3NNYQIgCaV0WmFUpNzLsauC4H+aApCBooMZNDi34xIakYCBCCEcTwdj4evv/7Tb3//08V2g0iq2SSCQi2S0+nT+w8P9w+7i+vYufWq72LnXPDBp5KISUSS2f3dQx/Kmy8+IwJCXpZJAEPwSBhirKWYopmFLsJ4bLCtgdZamv9qrTX40JIXAIGQyRCJxBQQzjwiMVPNORVTBCgGpBTYE8CoCmZVxDkXY9D2n4oBQBe7z15/MU/T1e667/tlzib65ee/OI6nDx8/laW6NV9eXv6bv/jXNze3Wuw0jb/5/W/3h/1xOt0cbjXVkvN2M5j2RMTBb+IFejOyJc1pWUrJBgUR2TkSYUer9WaRuizVsb+86LsQp/tTDFxrLdlMcZ4KYWWOh4cRqpF33gEiTdNUcmYkA1KshOwQv/7lq9efrYvp7cPoiHYXm/mYcq45g2t4HZFndrVWkcLsVKvqH+NSn+72ZpSIZKt1UAHD6hx4TyoIgKfjeH//MJc0LnPKKQTPzLGP3nWlVHYtewlCjH2M9VFelkoayJMRoBCzGTggAFUzleq9/9Nf/er92/ury6uXr151PhArOWdgWfJpfyzL8vz5cyJbrzdDNwxdZ0ApJfbcdV1KS67061//q877Vl6ncfbeg5iZSa1oSMSiGdH2D4enPaBzXKtJ/aMGrtbaD0NJBTxXyQDAhGZaoBKAZ0ZEPStdgdr+CAEQgbCKroahPUtt88NMCOD7/uWL19NyJDLnnAqlOTUBu/dxnlPsgpKt+n5P/N27Hz5+/DTmfHN7jyQfb285y3ZYOZN1H9YXFwX5tMzkrWr1gfIC3vuu7w92lAoEEIIvRbphUNkj4na77Xwcbw+IiAQI5gAZ8PCQH+73gNAHdo7MuYf7se+D8xicryqbXX91PRwe9i7AcTmIWIweUHNJpVQiX0pyj6sGV/LZfaWU2kKeSsmPUgLHjKJaijF7AA0RiTglqZItyzLV/cPp5uY2V3E+xL7zTWyr6J0nVjZdd9vmNdp3nfe+TFPr9ZmJzKILBllqISRqKh+RZcneu/E0idqwXiN6jJ49WjXTst/fHI4PD/sHRNxdXj1/9mVcXUyllFzMlIVTSiICQMOw9awpSUkwTzWEjki1Cjv2fJaQq1WR6pilMYJKAWM4J27CkpaYyHmSp3AXBDQyNe8cE0fnikrXdYdpdMzOO1MDgyoSgu9j8EApJVVJKXddaFzT0+k0DCvHDlCZw2YzBJ+qGIEL3nnfqck4j9/84zfv3r4bxzROUxbdbDalLEWXzWr91Zdfrdbb03jKUjl2H397u1lFNMw5rzdrMyt1npfFu8GvBiWbp0WnWaogwOl4nGEixzUJAzkmdi54d387PepdPZ5djOtqGK6vLpwPS06u88qlaPnppw+Xtet7nsYcOpnGuWYlqADqmhUHMzzpnh+bHzbTUkpbxAKKc8TkmZkdVklWKiIGH47H0+mUb+/uU86lVmIXQmiuQNNpyiWvQu99JyIxRkRIaWkfuWNGNC21susYAFFFQJWYUWGel1pr5Hjz6bYftrGLPnQIYgrIqGI155TTXGZUexFe5JJhyoAE2MTKBlLVtEg1k+5irfM0nmY1Wq02OecK4oInMZG6u7piJhNRRee9gWkVACTHzVpYDLClLxGqttYTUM5JLw2hQdXNxZacV63OOVDTWqtqSZkxCpwp7977YVgh2LIswGygqlXNCMF5jF3XEo1UKxI6RwTqnYuxW+bSxe7ZdmtMp/Fwc/9hd3W1212llBARDKbD3iTXwmVKWhUDLvNM7DbrC1VggiXNx4c9iFJ0gFSmlGoNLiCjicbggBmAayrBd8zguG3xtYsO1DoXXYc+WDEx41Lcxa77xRevxmmP4OacU05SgAC6fnANhqm1gVjQ9oA55yb/MrOWYcTkiQkMVFVL8YHJNxxLRfDm7u7+cHCIrRj3YGqmpjVXYLY+ipmIzPMsol0XmuTGAFTZOR99UFVARWt8JQTgvhtOnz7+w9//w+XVyxg6YjIsoqLWgm40xm61Wh8PR0P4/scfiFYXF32IkZhKrgiNbK6N2L4sZclCgdnwdDoxMzDWWkvKqlpJN/1KVYqaIQCRI0JARGVPSAxEXddNU7FHWRgzEzp9jERoa65aS6lz86ZHAK3SHpWled6f1f2diMAfG38lcnmZCauoBh8el2zFBweiXdf95V/+5bLk//QP3wBQFUk5v5PyodQuxiUt+/2eEI+Hh9v9vk0GJU/7+6OW6n2QqoxElucxAWNwXq0EF4SgHCc0QwdMlCWLIVrbyYuZhq5bDXw8plcvnm8vh4eHh/2nw8p1QFmru7097C4u/+VffJnqOE/14/sxBnIQyBEYdF10ItquK1MIIdRHJ+qm1SSilFLzaGjbfmZ2nkyxiOS07Penu7vTw8NxSbkLgRmapkrUyNQNLjpfTR27wAEBkyUDQ7DoPRDXdkYdkzWooxnTKKHb74//y//y/95dXX/2+coHr2A5LyEymlbLjuh4eMh5AYBU05LnaTxdXREAtBqEgMJUpLJ3l7urTx8/igEykGHzx6pmiqaghrbk1PlgBo3jiszmGcC4cWhNCaHmsuqHlBKqCRizQ8DmEHZ2EdNqi6a0hNBpVs8OEKRWFVQiNVWz4EOMXlXAFAHUBICYHCAAiGNfaykli6jzDGDavqzB4XC4vrqqVff7fbca1l99fXv7YeiGi82u1prSktPSx16YP7x/vx7WQ+xvPn5EMD+Ei4sLQVvvtkbAXUgPJ0aEZloPAGpgGLuhi8PxMPYxKvLl1q+3gyN4eDgc90eRLFqBWAWDG4z0Yrv5V//mV8qn4/5k6u5u5+fPNt6HpSyO+Pb2xrVVaQhcC6a06CMW8LTPaeyDZvZ6Bh2MllmOp8Pt7cdpSnJWzAP70ILXDAjRYgxtaTOOR/auqvQczAcfAkCFaiTqihJTleqdNwGRakgpZUTuV/1/+z/8H8dxYR98F0LXuWbV3FyOpR72d3/39/9hSQs5vLy43G43SGBgLdw+5UU9CNhqMwiCKiKTtnhNUQCtqEqGgGrq2eecHTtEAkJF8I5FoBZVraoCqCb95mIV2eWclXBaFlNjRNWzBJwdI7pxPDHXGGNVMTDnXa218SlqLsf50A+dtrS64Bt9nxi9d4AKoADqPFcpZmYGIgXJVE1qdcTk6PJiRwTs8L/7y78sSb0L2+327q7E2JVpRoJNt3boxjyWvIjWft3vnl/PJamimY0P93WZt+stSC1EIAoKZrDq18uSVMAzZ5Vc8umkZSmqsN+PIkoE3gcpsJiWUrp+wOiWjLuXr8bpu82ldysWlQIChgJ29rh5EpifOTCltPjJdpjaSJhSCqGxxXWa5of7w+3tA5Hr4oo9dX3fBNOMzTjqTIcX0S52wQcTRQOoQh0aoLHqsgyhj8NKwMyMiW4/3CLTZnvhHeVa0XFcreOwXm+3nfcGIlVMZNwfp/nUFrx916+G9ZuXX15sL53jKppLUQNBUTFF2O/3fV/MrBVHUWMFQPPBo6Pj8UQEKlLVmBmBDEGhUTaoEYgea1MysyqiZlIlMLdYOjBg7x7V9/C0nFYxqdU1drBqUVGwYppzDsHPOTMTMYERonjv5nmpxRBxtVqLSDMaOROXCHa7nWRFpFqFmcf5tFqtj3VMy0JMjh2hA4VV7DfPNvOyiMiUTuRodbVTx8usWnQe5/v3D7vOq4qYkXeEWkUR+dOnOzNYD+uUUoFSa/nVmy+WMd3fTZ47UVOT6ElE0lJSyvOUf/P3v6FAX/zqqzGnuGLnsRQ1rH23sQoO0XzwtVQVa6DlGR93rjGu2gUWY2ynDQCWJd3f70uRGIYQgnOhilUV55yqBH8ORDWCXFJH0MXonCM2D9TFUEAVbFh1isieiQ3MpBZESKV+/Onjv/jzDTLN45Jr6bttN3Rn/pIaoj1aQI2Hw+HZ8ysDfvXss/VwzRSbiS6hGSgHNlWrdbvdxq4/3R+lqhGSglZkgmKCDhHMu3BxcTEdj4bmvBOV1uw9btzbQYFaylNOAiMZaHNGNTUQrLWq8bDqvQ/LsgBAyUVUHTsDA4MQgoCi0JKWLkZiFjVVISRmcuQZi4gCoVklBmbSc6CrERozgyN2ziAvSxGx7Xa7WW3++q/+PxeX234YLq+uLy8vb+7uxukYYzfNIzG9+uw1BP/h0+3dp1tCnE/Lq8tnq849HPfkXN/3mksZF5Fac/UxOudKXtg7BB2PU1qWGGItzZvOHl1Cz4nG092y5BLCp7QIEqMIiXllDy6PySFC8AGhkfH1yWo75zwMwxM3rR01MxORw+G4LEutyuyZnapq0VSTmnnvqlQRIULHngmJAQlrrWSKgAQYojckZwbRMwFYATWVogi762dtt61g85IdNY9uxwRViomK5pTmYehfvHg5zQ8P4yfTsLt4HvwKkRo9jxANqYK2oFckdM6F4FMpgNguIABTaftiyCmnOSmAgIIWZmZkEWmuOGfGnyE/+tEREajBmWFrAGLVDBFErOrFZvPx06d2tT/1EqLSdd1l3KkpiZkoOiQmUKuloDkABMXoPDCM09jWiPA4yBiWZkYyTePhsGeOxBhiX1Mmhrdvf/r1r//5ZrNx7Lbb7dv3727v7lKa+qHbrNf/9N23b2/23mHw9Px6dzWs371/b4QMkOaFEAyNkaL3gFRFstYVd9H3H9/elSLODWYZsXFiVVRDCKp1t7s8HHKpdtofUYGa4XWtm9UWibOIM6NpSohsCrWWZVnW63Xbwy/L0lAufUymMLOWkyZSmZ2ZlpKD7wDV+2BgtZQkEmP0wQMatVkSFEDBIISIiE0RDNaCn7FF6CIiMTOX7fYi+LAsaZqWGNfMnEtBUkLQampSaz2dRmZW0ePx+PrVV871SKjUWDCGbRQEbTuWWuXjx4+1lHYTg4Ijp6QIyITtOy2lhOCncSmlMLuu65udmve+lOocMVFzYzszYEWf2FcASMwGgGaSSmNZPfUSjekgVdKSzjO1aPDO9wHVnHqppdbaRIpVqorlck5WjzGIFDVtOpUQfKnLNB+HXkMcQgjH4/FP/uyflbNtJO4uLpjo7uH+YrsJ/hfm+PLqyv34QyTcXWyev3wWkD99/2OVguiRKKWpJXci4rBazSmZqSN2ztVSzLxUrXUxIzPoujiOp3biQ4g5J7W6WgXETKqRAyOt1sFBmE/VOXbTlE01xlDPZBJalhSC996Xp+Cklq5WiojcP+wPx6mW2kUOMRIhIpEam51b1JJrrc671qC0W6dWQzz7ARGYVXOR2+fyuJplNfPsiNlQHx7uvYur1aZbdV0XmRUBzFlVHsfTPC/7/cPvfvdPV9fXr199rgYm1bFvHYmJSJUiBcw8kSd3yqdhM6RU8lyGOIBihRy8L2e5EXvv1cQ5bvfEzzmi7bZjJrXmoANqZk10DSANeiBqDohaxXmPjznFDbprB7o1FWd2g1/1XahzrVLP3CSzru/UoFYVTWBWa2myDgBk9OgAgfp++Prrrx9dpVwIYb3ZmEgpZVmWeVl+80+/Gadpvd5cbDcYgwK8uLiCVLu+02WpzhlYYIdAF6uNI/7w4VMMARCWcWbHYMBMzOh4MM1SW7YeqMA0L4Cg1WquKeXqKiL1/SA29ZG11LkyAVxu+3mZEJwj5FRrzkeiEGPnPdZaUjrzDhrjsf1iWZab+4f9w1EE+i4gNQNkmpclpYxE7ROKoUmljR0H7xAQFNBIa0laiMnabtjO7UtzT2hNMhE5wmmZ5zkNw6rr+r4LzjuzQgDEUEVUpOu63/zmnZo67PqwbdR1AgRiMQXnmYDniojb7cV6GA6HPXl2ZisaOh/LIrWA974tiRFRRFKenIvt9OvPbMmZmdkBWClZTZk5wPllE1OIobVgiGBNiUpo+F9HpvtzSp40Ppaa1VIYnaAU1VoLokXiJmNpm6AYYoOsiQia7Tk2+pf3PrSzdXV1lXP+7qcfd7vLFnQ1rFb0CG5HdCktX758vetX+9NxmsaKidhdrNc1l5JSqYWZPBEQQFXnIjgWUYe0Wm2W+fZxlWfMLkaXliJFaoZSIM3VBS59XV90wePh4ahSkHzOMk+LKbnT6djQO+ZCxCJlWeaW7sxEaUmAUHIhpmVZ7m4eUm4Wy2W1HjxArrIsyzTNMXa7Tc/elZobMyR6JqaqFdQG4AKSpaKZYzf0vWq1x0CRM5cLjBiN6XDKMW6GoSdCtaqqACZmpdR5HD++/8kxXV/vqqQhbB1EQ49nYT8goDGRuRijiJSS52kWkZ9+fNv33Xa7BlTTSgZt5dCuE2ZqzLNaixmEcCZXtWNRRUxqOxftP2unpPnMOOfAAMzQqamlWkrJP0eYHx8efKLm5pRi7ImplJJrYefYsLlM1SqNd9qHHggaQ6Ke//KqWn3gJ+QMEUspt7e3tdYYu3c//qSqwzCs1+uG+4yjK6VWNTG8v3+oUr336/X67tPt/f09BGa0ztNmvfLBf7qfkioaQsHjcWztdVsQO0cAknKuYqaGrQctQj6uL69lyY6j1hJdN8+llMoY3JJKy61Ug3Q4IEHjSC45WaOVegcA82laltRqDaDlWjil5m4dY4yh884zO0ekiKYCiqpIiExEgCjmySkKKcauiyHmYnoOUNFapdZCzKnW+7vbUnCz3nkfua1qm+UNQpFqWh3TzacPSPjqxWfPrl4jMpIDMAAFMwQkRQRSJERzLvz29/80L/PDw0O/HlbrPyMiRFuthmKWcgKAq6ur2MUlTcToKTSasj56jWJLjgVwzE8HSx8NV1u3gEiEplJM1Tkm5pyzGeSUcAPM5ySsBveNp7FRUovknIuoEgG7oCJm2PLrmoCbmIi0ionWR4d9QiKtdZ7n4/GYUnr//v39w8Pt3X3XdWlZmOjFs+eXl5dEOM4zLEuZl67vP97vR6mby61TrQSnknOt61XnAS42q9fPdwB4d5wYyCocDyffd3Q2+gciXNI0uLjZrPf7sRYyM9/xZre6uOqc5/tPR0JXUmbUZVYwFBVXRRuZ3XsTEWIwcFpqrdUATDUA5Jz2hwMTOx+qsAKp1DbZl1K88+vVivAspYohGmizQSdHZoJiWaSRYvo+Dn2HAC1xuRVBVVmW1Fg0+/uHYbNDIueDdwFJEcxQRGVapjRPV5e74/42l7LebGM/mGHTOiiAVAHkGFrzlIk4hEAkzPL5Z8/jsHXON7q6POYGmFktpQ+eAaQUZEcEiNZypOAxVBEBci6NUfMkWG2SEBExE0Q1yKpKHNar9ek0qgAi5lTUUmOtNREKIMQYTak1SSllNJynGRHX67XgWcQLAN558AjWlkuNOejRrFEIt9vtNE0xRhML3vUx9l03jZOZHQ+H3eVlH7tw5dN689O794fpdPXmxfXrF8fbOxEdLjddH3LNu/7icreNQ1jG7ByDD2WqU1286tB1p2k0A9G67vq+70VlGHQ8VjECrF0XkXguuYoE5VqKG3pYMiEpoDscDq0kwc8Cea35EomC0bKUWnMt5qJDpBhYwVS56X0J6Sypc060MjvnfVOOtzZdtdRidcoEuN7EYRWJtBnKG8BTsmEjNx+PR3YuhhhjbE2MgZrZNM9I4Jw7LOnDh3eHwxEJu64zRAVArdpMjghNFRFVRFVj9MMQP3vzRZUCIERxHidRZSMT4bPmG0BlE328frY/TqWKGbBjB74V1oaLIlrfD+zw0ZoVnrp7VUWkKlJqIgCt6r0XqUzODKVCkdJaqyc2s6oO/er51dUwDIiQc27mtDmXEFzf9y0TuboawTvHzjWuANfalt3SRkIz2+12kf3peCQm5zyJjeNYSnHer1YrY2vbw816I07f/uEHUMnjLEuxWreXu4BcVKwPSWy4vBSj+9Odna0AWGpFIuciMU/TXHJFZOd4Os0Xu1UMDpXG/VFLKcWcc44DcXZMudrZ0U/BYFna5aHWdgtQa3UcAQGRYujOFo1EudYQgnPciEdglnKqtYTowjmlMkV2QICIogpojNZ1YRgioFUpzZ5PVUkJEB4FCHA6nVbDqt8MYYiIJjWTI0AL3hMxoWNHJWet9fmLl46DWet0IXgPDrM0NxJ8VNLiPM8iBBZKSd6bI0bAvOTYdQTgiIGVkbxz7KkWTaWkXNDYe2rMdyMEYCJcr4ZScquSes42O/9AbL89EzRyoxugqlAFAYNaBIHAUXvNqiWlchqX7Xa18oTHkznIubSrqUniGmDhuPVzpf3WjESSCqrA3d0dAMQQ1pfx2e4y1zIvS7Nj6rteRJa0AOI4LvOSQvTs3Xg4lSUFoGkpPvovvv4yT/Px7ua4pB/ub0/3GZROx6NHj4hgFQ2iC0OMnl0qWmubalmqeA5oZlXqaa5zVgNEVoBsVUzN4OxxKEXTvLTpzwfP3PBmRILgAz9aPDh2asbOOUYAYMdSxURLKTFGA1LAUmspJTIQoHNekcwheBv66By1EbMFa8FjFW9tSi7VkGLXsyMxdQBmouoAWoqaoYJWPR0PN7c3188/M/ViaqCd75idohgYEyFCrTWEcHGxu729qbWls6BU67t+XmZ2TIRo1oUgzIg45bRMpyKYizI7U9BapLGtq4pAF2POyXvfAaAjK+08YRseW0MWfCe1ekcx2BHG9m2JSHMDEVFmFDEmj55VtYgAs5Ta9ytCrKVY8z8AaBuONhnU5tqd8+OUo84FH+D169c55y5GpwAAy7Icx9E5h22hrzUtCzvnnU9p2d99evXm8z//Z78+7u8f7u5Hc1dvXgy77ZzmSjglubrYlf3d6TgxUAheqmSsV7ttP/Rd59aXm7cf3j/qItmxu799QNxyZ8uiREzsAXCZ07IUBDYTF0IUbS7oamrOucd9FzjviMx5ImR/NodwtQqTtcGngYRS6jAMfd8zc8k5AzCoc+iZEUGBahXfdb5Bt49KhFZ828FiJhCapsXQo2NQVVFwBCgigGCEJlWtSheHro/r3WpZ6sPDvYtRzfzWNx+mWgp6PBwO3vvnz58z47LMLe4VAERMlZCorRDaldy+i8N4Wk6TD6uiyJ6t1pRSi8VUReYz5t4UlArGxE+Zho390ZYNqggKxN4eI4YQqfGRHl+DPP2clpRTKiVh1RgdOzTTItZgsLOOAxxiw9JCa7yYz0mwbTgFRHE4nsaaS9dHtcrOLcsCizDifDztLi9fPb++vfsQEbDkoettXXHJDvBwe//dP/120w1OwDEyYghhvQ5apZYCgOtt9+LFZal5mkaptfV5gDAMwzSNx+PYgWP2fT/UYt6703GWWokREV0MLmUBg2rqiJjY8Dwht0KraqWmKtW7s7N+84jyzjmmdjd0sXMNoDdovAYfI4mAKag6xmHVOUa18xjVRvH2DiKiAeSyTOMUY2SK0fchdiYi1Ti0m9MTlqKJkfrY68X19uISCQCByTG7VHIFRXIAqICOaZ7mGJ2qqRbvXd91JUutBY0QgNqWCbmLXT/0RDbqidUAecmF0LR1Anj2zVbTWq22YgDnbIt22bd+6AlZEBF2LrCvRVpuWd/37STpY9xhQwpySdO8OIack3MtLgUAjQhrVVPLOauV4M/A1XiaYhecb4UVmZvYWEV1nEYAWK23SMaOV6tuve6XcQnO1ZrXq/5Pf/l1XnLLkXrx/AUpzWnqI/Uc59MspxRjDIh+tzHTNJeIzqyKFu4sT3Wa5pILO0fEKUsXYxd7563rwvMXVzktdzf79Xp1PB43225ZpKq6LgbRWnMVtRgYEFrSZrtXGvhbay01IZAqmWnrrJvbu6owe0/sWrg8EjMGhzVXRlApJS99PzgHIrXU0g5ie3/bMN+SksbTZKaOHZNjjs03yYylioJ6zyI1l2QIq9XGhb4fBiRvZj4E5x2YVhU0ACRDSTlrEebN5W53PB5Xw6oRFFTNuRgQFM7OetvNNoSQy+JDADAkhdaVUxNMoKkBWmvWG4BUamknwx4F9fAzXbiZMeKzy6vb/eF0GolQ9exh5JxTtZxzKcUHr4rLPA9DZ6alnCNkEcEHVtPaYotA5mVZr0Mp5ceffvj888+6bsXkALAKqJ7/r2EYQggh+hB8exXs+HQcu2FIJddpev3q9WG/H09jWz/62PvO3958Cs4T0spH5wOX0vIYV10/jVPN5fnLZ7WkeV5qKUPfFdFWZnKuzrv1JvYrP47Tsoye+enKEElm5pqjC4t1MeaUzCx20XmaxumsFjeQKs1CuJQcY3Nij6oVCZzrAQRUVNV7T61DqaVYroDTeCLUiwtnpqLypE2Axw1d+xkAxzF7H2KMMUYzrdXAABFK0Sp1nkc0m45jjBGZr7bbod9WAVH1MVaRpmmuKhW01iq1ukAtcu3q6kpVU0qiBoZt4PfBOefGcXx4eNjtdsuyqKqZVC2E5NAVEe9ccFSrAkKDoOFnqWYppSewlH6Wc4aIana928Vh9f7DezUh5CpKiP3QI1qtT7JVv1lvc55bE9IwTwN1j5bNwUXRknPKOQ9D/9VXX/T9ykx9CGBgUEMIrdC3XVkLKzXTc2l2nl1cD6vTPKvq0A8I6HyXc7268inP+/3DF28+64Zh3B9O40RVSGFZqg9US1GVh7u7eXKh8+yc865Oy8V2VfIhLQBUVheXq4v4/e9/v92svI/HcQQ4u5oDkDtO42M9slwLqIUQSn66rgSB7DHGkIhCCK3UUrPkNlUV79hEkRAI8phAMrRCG7iLPRKrapun/CNs3R5cZmSi43FUw67ru+gdUyPXgTVllWmVw3goZUa1LLOiEfkYB6cgdjYFVQQCJAATRbPg/ND142lMaeljMFBVQUMVEDEDk1pCDGCmIp4dxJAXX4p6IgTwzN71gOAYEQwZPTtqCArik1/D02H643L60Qlimmdmvr7cAYBUSTkzcfAewBjaIh4AwBECe+CK1MSJi2pNCEYMgmiEJIyWc9pdXsS4S0lKEW+GRNio03p+PkUk+MH5SAii6IC2F17EDPTZs+dpmT3zel3HafLe+13IJRtqzTl2cTwczCylBSASMgKIaJOqnvZ1peQCE3KIfrXrbx8OXReLnrqVZ8YQw3q7S9MUojOzZc5EjpBcqZUQc5GcMhMhYWMdhdjseMzsMf7KufMRPJcAQrJSspl6dsyume2nnGpZVptViy1h5xCg5JJyJiL3tMBRNVOioEgpi/MdO0byDYlGNAMwMAVbJKnVDx9/rHnabC6mMYNi9FtkX6SY6mkc7+7vnz1/wURm+pS2WFN2QGqASIBKBKbgmVo4OBg0qqtjjnFtCiXXXCsiBPe4SNaCgMHHwIwIxGyAKNjgmKc62Ai3rT62NwrMlnl6zD2WFmCcZkGA9mfBeVMdi/gQYteLVCJGwFpMVJNlNjI2/v929WdNsixHmiCmm5kvEZF5tnuxVGGqpyl8JkX4/38EH5pNcmZkpqZQAC7OlpkR4YuZLnxQjwSaKRDIEeAsEe62qH76LQIJ+kNEgAd4grSlHqzMfd/f3t6GYcgM2whAljqM296ImIh770Wm+lTBbLH729vb6XQiCiS4PF2+/u239ce69z6Mo7v3hr/79ff39e16f3P3vvd92wHj/OV523YNrYOUoQyncd33qL5rq0Pdtr3tmzuGUynVzEspoqpMlNN4gvgHAwlRhFU1raT+WWCYpEpmBsy5h0UEIBI6qxFFGWpi0wdbcN+TLP/PV4a7m4Vp3LddA89DrSNSDSJAhOLpg4ABsG728vL97e3lfn3561//Oo7noYx7W+owQ7i5v7293a+33//ye2K+3xZhwPTTZnQIAAQPAnFXiCAW4kPvT0T5Xdyj7btamBsCNI/8gubaevcg44YI0yyESGIFyb0m1OkPY8n3LZca8TyS4yG+ADtMuY9ViNFDu4YLPo0TNYiIWiftyISARgAjD4DuUcpQiMgc+EjKyKxkAoha6/l8/scg/xFT8O3bt3m6TNOZGXvXcEN3M7vf7/M8J3DQe4/wQPj8u19QAb98vr62YZjU96fTed/vampEquZmnz59/I+//PnvX7+ez+dt7fe39bf//DYOEhEeQcQ/f9yY6y+//PL1628RIb11qKLqAKCmGQpX61BKiQBVy9zK/MQ5pZeSofMASAiZxptrBSVw29cMFGEkCDAPjVQfcKr4c9yo3YqwA65rL2XIypOrEJGbtbaWMgMEh0Zbf758/evf/jKOxc2JwawBWalkO5jZ5Xz+lz/84eny9LYsRESU3nFo4cAZG5TG4Kju3TpLgh3oDkTgELfrbd3XnDQm158JAcIBM77akEotrbc6MLEj4DBUREybHX/YffEjB5SIVF1VCSE95RFB1cNcEdQtCAyAMNq6zuczgB/4OzIgcXiVwqUggkckMJL5wmnHAgGEJYgJHSbM1abdIo7e8/n5OQK37VaHguhta6d5ltL+7d/+LWeQwzB2sw+fPgPiME8/fvtqqsS2rq/MPM2T234UPMJhse97uKHH29tPdTqNZ9qlmUrFWsuyteWmUuPH9++m7qZi4bpt7liYyzQCAheexokIswF0923dTqdTbrUIl8IPq1aMHDMHIHg4BME0TSLCxKn1NFXtDQBIqts/LH7Shft638zifB7HcSqlkEiabDlsvan2/fb2/evXv/a2579yefrlfHo6nS7jMDCL2eYRUsre+7ef3/UBAjGzh2EEBrgpIALVgJZjb2teSpj5tq3jON6X5Xq7Rng4MFMEBEUgqTsAZniHB/TuLFhBII4aCx8uKYnCvCMOt9stZzgIBMkARWJm8+imTmDhYBjugKiqvbWplnVdCQXRA5wAhVlEgDDUetu6Ngj+h9sFUkSEQwSmXR4AEkmmISPix48fW+ut7Ug8AVQpADBN8zyf8qBFpq56Pp2J6O169XAIOJ2ml5eXdd331ty8SCkEPaLdVwb45ddP0zS9fP9PkfHX3335+vMrMhQo67ruu2aUhLl6OCMIMFlX0xhOY77yoQ7HAhIpRdreI3ZEHIYhjSbDw8DyXgPEgYTBgTxCu8c4jg+7RHQ309a2bRzGvEzffU2ZUTvvu6Y+Nim476kW42nG1cmg7cvb20tb1rmMpcjT+el8efrw4fM8P93vbd92DyehZp1ZWARV3Y2YTqfTel9cFcIDUBGSgchcInxdV8Q4nadaBlV1MyJKX8wEAQMhmMLScerILnTnXrz1nlyD3jV/f3pxP3BlaK15xIfnjwuzRVrcMgAHsoYiUMate0SoAoC5iYzDMCBwFvbmRHy0exHuTgBOBP+cghuHX1J0DYgopTCjh7/zfvMgcHdw50xfQzxWPCIXIeaI2LfdWissa1u72rKs+94jYBiHy9Pldr+3fQ0IIDxfxtt1qQNb6y/Xl3Gu43l4e30tVcxsmqZxkgB1d2GUMA+P9P9VPWqs3jsQ1sIYJCzZ9ZgZArIwBIWjRyABEgZQuJv1cIsASU90Ijc3MzevKUl9GOamlzBxuV+X1ns9TWku70agPRNNkiyvBMxU69C0n+Z5rMN5vpzmcynjsrb7tnaIZjrX2VJjkynzQFXqPM2Xp6fX65tweqAt6aFj7rWWSeow1Pk0E/H17QYASARuve9EwswUQIT6SAU7UNLA8HggogmTBkCOJjGPjQhnEm0KDqd52noLC1U1UBTspqFHeZc1hAeEAQEJs1lgLhc1DVDoLJLjgoDMEIFSKjj40X6GMFIlMxOpgN16tD1n4RqAzLzc7gBQHiPwd72MLcs0jGamrZ/m01CHl5e315fXT5++IMLLy0u4csH21rv5+enyyx9/7XHX3moVo9j3+3k6C1Nr7XI+v/24qQXzxYwI2d0kdSZEGSRe87BFxEAwcwICQGZOgCBBrMT1PRzUC7ADhmqAYXj2/Ai5mVLUgbVWYoYIB0zrH3fv6tf7DYmEDrOo8CM/kwAeHWG4+zTNETiOp1+//FKn52EaI2hddw+XWniskT60QBjpUYPTOCUIOY6j6Y4kSAGQTjVATKfLbGrLstahMhMcRmJZrKgqAwDYP8rhx2yY3JOI4AAYcdiTZnpK/jeROHqidh+enzxi35v27hAGMQirm4UzcSkFASxgrANA5CcXKUkLOICMB/ELgUQYkQCQicPsIHQADFL2bXd3pFiW+75uX3/7Gh5cy6fPn75/+8bMnz9//mcsNx7UWSZ6fno6zXPvTWQ4zZdwu99fRei333778f07MV4up6ePz8i03TYmRjQWnGQotSzL3d01YlcP8G3bnp6eiGjbNvn8+XNifUQsUuBhheUQ1vRdmpJfT/joq1mQyDGiRjg4gIcdpviFJMzVUxrlxIzM9tDG5Enee399u6rbPI6VGAiRCJEhKI3XSZsjSpFpmn78+HE+XYZhnk4fp9Mni1ANQhaBTW0YJtcgZopAwhzKicjLy8uyrsQUlhmBYKZpe3nM6VrLD4NE5oYOEcBECSllu/deReXlUgrvrZmaW3L3Mdw87B/rIB8XRBC2vqqWMNS+b20PiFKHUaozdlNETFMMBxc/1nRAMFOOZe1hg/uO7+dM2jPPp7ddtZYSEXvfWuvIpLbe73eEECm1jBq6bdvtdk/mzzzP755kOf/IzwyHQzhcLjQO0/1+XVdOtPZyvtShUiFn/v76om19sOB5mudah3VfpnmK5mQodSCitAOOCMmv9yjM4VE0KLgDHYyzTFsYx1EqRqgHojFXKhWrQQQbxd4dmYSZEZIhmI+GmC1FuJkCEREB3XXZFylDNmERjzDKbupcpdyvqwibWa1jgH/59GWo5+n0zDK4useODMMwLq9vfW8YyTDuAOBqZSiqutzXQABIIDHF7FEKE3E6quW7HIahSvHW3u7X1vXpfPnw4cO67tu2jcMQ5hnIMU51moYIWvfNzBAlvebe66pjQAvgERoBCGoW4G+3Rc0tHCIAtAFEBwTQcA9MQR3W0kKDQtJ+5JHQmX9nXpqYFzkgEmuER4DZ6oYAoa5hAoKI8zAWoqnMIlNIWPi//dd6e7sWkXGaWu9jKTlhJGYLt97dvbCkc1OoDoXHaSh3+dc//YsU+u3r3zzM3JfbWyr5ahlJ+PR0atoocBjG2GAGYR4VbL3eCDmC3l2K+DG/M/eHR3KAuRURrhURmJEII4AQmaUAMgAXIhC1MGGRwpwCs8OHMxlcqd+NcAQgZg+7L7sFDiJBGBmG5a4aZurUtfVt3QDivtzmWeowneeTdnLDAGUSKcO2b+BRSUwN3A1h2zc3d4hxmJe+N9VSS77093yzIyw9T9P3XwNIHeh+B7Vt226327a145A2DwASVuu1FKnyUFggQPgh1YH/v6lOQICHgjuhQSQerynpAYiMbX+QBHM+3boz4lSHjGfHfxJiiAghutm+7UpdagkAFmm9772VRwI8AEgRMElP+tZu9TSNp2l4Ol3OZ+sahKKFAN2MEInTHNSzDMih+rav5iYiX7582fd9a8vl+fJ6fb3e3qZh6G4iiNyePp2WbbWGQ50A4r4tjEjdTbuFtt55GOT9DI9/GLYaIqnqvu0iMo4jIgYYoL9/1VqraPfNYko1vZVyZDmHx/sxngdhOqW/Pym3vu8dZXAkZuoEEtHaHg4IZGSGnZksbNm3pTUusxmYQWtaB3Fw72aGe++pxepNHaKDEdM4jB+fntdt624cDAb8CEo9aseIXOIPkNZer9fbbVUzKqLaX1/f0or8EWoMqMREP+Ht/HTCw5r4qP/yqqJ3Kk4eLQFquu77sq27qXoApT8zHhBBOAFmkkVAtNbc7Hw6GZBaT5uMf1ysD6fWbdsAovTiCJBBaBHp0kuHCi+Fn/v9fm9qn4bfIcx51RhpDyMia52Zgdm1mykgMhMC9q0zlTIMuh4JXOM4Avral9fbzSM+fHje2m5qVIkm+vnXt/2lT/M0neYIIGYzB0Y0ZKGIOHQB+fL3fdeu5prTPUAQ4YCotdQ6IsLDcZ8IMDLjyzAwCJBKQeIACHwULmrJ7zTziNwZaKbX+13NncUcwB3UIcBCIZAAnAMZ8g6dpunf/+P/+Pzxj3//fq1l2rqWdTGL1tUh3KNOIzHubQdEFi6lfPz48WmaRin7su9tp0KH3ub4iujhkZmfHsQEEdvemrp6SBUIgG5uyqVEgNRix0gQtm0DChEOB4s+DKMUcg8ISZ50ZoY5RF8XCprGOgzT7banhAoCCPEoBxAiANUiEAVZxABaV2Y21VLK7uph7GRhPTzMCjEya+/R1cLVTIZSZSSi1FwmXkMsZSjF6ufLE5fJmxmFFHEC0Ijwve95vt7um1skHKmmTd1skcLUizlkAlwgvd3vGm2YxzIwyvTz9cpArz+ubfN1VcB+OuPEw07NR5igLItHoCY1OR7xOK213JGlIhENwzDNcypPxnFMpZyasRBSYg2ZwANMLIwB/5hpuEfQQaXPF5ND09b15+utGyM5eejeQRCAIPTI9waCCLNsefzt7ds4Vhmn8+WslnQuklqAsIVLESKKCbTruzLCzd7e3izRqXcNVjxsGLKRAwDE8AiAfd88QEoR4aY9CZuFcBxGQkKm9LQFxNb6p0/P//rHP3778RMyaYEAIlpv2RCJyM/X1xQ/Mk9DnURufe8c5ITvh0p4IFPFlGPoqUxUyiEBYmHhrqGqgWHm3XWoNSyadnNLhxbtnSpfPnzorfnax2HMVhxtJADmcjrNvUMAmhoiqFlre6Iq9/udWSKwqwkhIEQgcTHXzLbZ930cKzOvtix9HeowU3392zculdx2M7Xt+WmE3XtvYNC3bmbT07heb0Da99COsixL4uB5ACZMgKpDnVNtx8xJwBImgfDCwRTqJMCIEbbv/XwaH85WnnEEOStEovdCBBEBcbltvWMIJrMAHS0UkcJ7Vy3DNEqN8NYbcby8fH97e/3y5Q/n5yeUIoyllnAKC2QaEOWhqdppz6qu9Y5Ey7Ko6jCOZoYE/9yyvVdFqTp8fn5GCBZMxFK7mqqCcxwkvmDMDtA9aq2au9u9qwKAMLt56z3B1VLKfbmnXGzf+uvLm5piAAZkMk8Cnplml1hULTWOhwOqWoj3vQVFTqYYALo2U/QwcEMggsJCTNo13NZ1LUFdNZsgZgoZIrB3BSjMbNYDspECgHh5eVH182kIdCdwBgwQEXJs7fby8rate3qh9d45ZC6zAnvXUaZf/+X3395e/rf//T/2bf3d7z6J1N72vvS2N6riCPdl0z0AKMIPy6v3kJxsesNdHj+1DhDi6q4KZIjW923ftkBABqKoAoRxPCuIcEjeFTLhI1srj7G97bf7KlTDArp7U9cG1s7n8cPzh/k0d92X233f+315/fbzt799/Zu6tT1u121ZDZC5jFJrMDHzQIWRCTn9TxApHGodqcr5aUYmZDHASMjtaE1cH5SDNI4uLGE216Km3RQiujtRoSIK2sHMj0zDbGhb23++vuy9ublp3/et9Zbs6aXvt21Vt9Z3MwWE2/0mgWl35NYjjBkpjWRNm7XmHQEIqUqZ62iq7jtYJw8pwkxqtq7bfVu7aqin7KWHUy0esS4bIhqEQxBiqbUOZyJGpPtyT8UKEGdRMc/j169//+23v5VSiAoBYQAQIZMcc+Eg4i9ffvnl85e273//7bdTnf/46Q8TnWo9f/rXP3WM221FQw75/tv15eWGgdu+NejDUzE1UwiHZHPIMAyPEvtIXy4hafhuZgRYRABCtYNjkdmsh6qQwMN+bxxqrs5kBaopALyHZcIjIgARl/vi3QAoZYAZZzPUMk9T3oL7tq/3Bbzuvb3dvv/tx59LZSInIimFWRCJmNgdgALQ3CFs2w/b/ggbxkpMl6fz3ryZ1aGEmnukNSM8UK4IP58/ffz4cd8Xj/BDhhpBZG5DqbVWM410t8Wjk8pbdNdOLIhHC+2A/2jMAJCIiISpq4rwaZ771rZ9BzWuIKUgGqEjHDMW3xsDiUiGDJo2d0DitMFBgHmaNJw9kDmYclA+DXPvHSKezxe3DSFNotC6urmaIhEXMYhaKwsA4LLc/vM///zrr78vtR7HLTEShUVaP5zmy9PTZRqm7b6s221d158/f67rum97CL/e7uv69v3bDwhgLvtmfcenS+lh9TScP55/+/bNPYgRezDxQYBMD+o8utLEZ99bxoETAJJjoBTBBIgDxmkkBrJwsHhQNXJWY25EREgHQzxBSMRt296utx0DAiCggzHieRhb6z9//jyMuJCIaFlWNf3rX/7z9v3lX//132qZkTDvjxSrmBkyOoah+0PAeaAA6N+/f7teX/fdMp6VDLUrvktPEfd9F5FpkjrAsqiZtTAMZEBFzC5YVSPc1IMO0GgaxvP5vLVFIQph+oI4oQcKMYa/f9lhHDHAPczMIx7Z7IXwiJCphcxUxBGxAhUWCmvbbm1nZhLWAET0iJxbjETeUit/OF5kibIvyxowTyUCWm+BSIc+sQG6Y6zbSuHjVJn558+f7p6RWM2VgYgoANxtWxsAn04XqWFNIyIdh15fX9dte319XdtePpzNelIMRagUAbBhqq9vt4+/fCij9B6mAQQK0FwPD6d4CAEeRhTsbiKVGBGcAompDoW0EQSXygEMjOiIHu6B6RCJHi6Z54GJeOr7Wdiabz0QyYEcNCJqHfat3dd7qULBRDgMVaju23a9v337+vXl5fW//ts4ljmwuPdtCyQUKgHYVCHBagBkIkRTO08Tqf/2208AB4TIHsLT2wpzcERpSOFurr3dx1qHKvf7lUKEi7uBhwzSW9feRQoz1aG48TAPtRbVQoFJJvY4+j2LAxWzNDbI3ArtHrGuq0R0DREONXfTACY213GskZcRIoAhAnAQo5SB1bqZeQiz0/EtwQMwhMWbLve1lhrqwQGGCLjvi5rVUi1czUk4DAiQkAH5tt6Y5b/+1/9rqSWAkCEz9NKbgAVrGbqqWby+/mzLTYh++fxl2VYiWu53INi29Xq7ny4n6xrQ3XyaaT6PgTFOw3mcCPz0dKoj3W9tufXjxErZ4DvuICLZ4nk4AUZEKYzg7kaQ8/cOEEhBSAH/qGDer4MspbNezlHj39/ebupx1L725ePl+en87//r/369v5n7UMeh1tYaEhHS9e1tvS3zOI/DAADTMJZ5VvM8DrMirLXubTlABI8AGIcpzAmhDmMSyAk5JPwRVlBKWddVijDLcluF4HJ++tOf/uXbzx+v13XbO0V4V0OsUuZhPJ1O4zDVOhKHe8+rDwMzjSLxdlVFliRdxcMt1o5ZqWnv4zhu++puIiJDFc5UOuj9kHO1iFoZIpiLO1r0nHAhIDMDRdtaWgxiQKi7HgTUUiT/YE5gk6MsjONpRmaHkCIRYR5t9/PpudZha7sHwN7UGz6k+xmeqKoIDoitt2Xbmejjx48fPnxwdwv79vKjfiinp8v379/31t0xHPJaEy7TdDqdplJHhV5q7f1Vcp5jZhmjPU1TKYUQPSAj6eEgaJuagioVAQQCB+8OSITo+OjiIzyEhTBbdHvHSN/e3v77f/9//ny7W+/MfJ6fP0z/ZWH6+v23t5ef7iZ1fH7+cL+tSCo8rrfXeZg+f/58OV+KFO+63ZcyTcScJui5jjEkPNwNAdIcwJWIgQXTNI+IMGDZezB5SirMxnEUEdO+be35OQYsHy7PArWPdr/fK0vXXlIzvW7edcVrHaon9yCt/OKwYcnF9X6m4JFvZY89hvu+F0J3TwjQTAFEykGcIqJmHR1JRu1BKKpWBiQStZZ+XchYTrKtG3tkKJObH+I8AA9jrrq3PBS2beOCLALhaV0RAGYuPDEXIhkqq2nheodr7613TUvsvTVCYuaPHz+ex3J7ffvx48ePlxcROZ/PAL7u231ZXn78aK0h0L7v1q1OpqZ/+c+/PV1O58sl0MwwzOuJhR+ZlAk0D7USEhOKVOLDYqUAuSJAEMBxyyez0QOBCDmnvHGUT5DKO3zQwLdt+//8b//r/+v//d8Boog8n89PX36ZZ2GxX3/5cBkZAX6+vdUScS7aVQjK01zrL58+fpYyBlZ36G1z4VIqEROBme37nnWNuyMEAdZate1ERAhFyAwLi7VOyRdnyJ0DR/CEny+Xfd9//ny937fWFJH3fSViiONpMLNqB4jedgQgKchs7kySczAz83AicvPDi8LMwnOsx8zadngg9JuqMBQW06TjQWBkEMZ928BNICC8yMRVHMPs0Pww81CrsxQR7Qc0X0px17EOQCRDqRjLumz7JlBLIAs5QFclOvxwM95hGkeMGIaRObZ96T1yYNr25uFMzESLmxKUcfil/tJ7H8fxfr+VUorUfW/RnUXWrQsLRLjh9WX97etPnCM8BEuMyOOWs+d456SbWRkKRcjhbY9uAG6hwMw5Wk4nmXePMiQEOtbQu/VFbuXU7/4f//7v/+2//bdpPhPA73/36/npcn5++vL5yzAOv3z6vN3e9n273lZ1H6dJtb293F5/fCU8TU/PUmcg9jjMqKZp2tveTUWYAZEZCdWMAb9cnoX5r68vRNRAAdAde3R7mES+e+25u2of6mAeLz9+3O6rHZF6XUQSp80c1Mf9HvEg+4twqdK1ezdouazB0fZtT7zGIXJyn5X7kP2DKQqbdhIECTM3MyQUoDxpVBXCWYQIt72PIiLFLONPHR8WgUyER5vCIiUc3RzIs3eZpql1Vcguws20yOjuXTsHYQ5LQtV2MUaEeZp85KQ51Frv97v2TiS3+1JKff5Qlvu91rpt2+vbyziNZqFdfVeSwki1spmKVCI283MZW2sOVof6/PwkydeGxyg6aywWAYB9byeZz/McrQkhInnarB9OwvkLdHcITPUI/BPHJtdWa+1/+f/+LwD4f/+//T/W5f4//elff/n02a0NwzQNI9Q+1wmBdl1b292tdX17e73rDiQwjIYyTOO5lm5KXEphM5iFWKS7CQJBFMobSOMISOKElTOMBMKTUoaIUkrb9+Sn927329a7e6A6MBGoEjPAQW6Og0xHAAdUEe61lstl/v7zh/aW0famgAAe7moBQcxVSm8NIGopH87n0zi83L66EyFRPJCJlKRZCEuifRAYxB7welukju/gSByKphCRIrKtay41dzPTQGbCZMJk44XEph2dKaAcdxwGBBLWWpHs9fWHnXUax0AIyDUdLDIMgyKZ2fPTp1L5/vpiqmqGiKf55BARWEqRWkz1w+XMA1MJ4enGW28dbAxzwCDkeZ4l74VhGNIaOc2gDCJMI6D1jUhLBnwwYEa1Mh3qrKSDEkUctdQ/iq3Hlb8sCxX+L//z/+VPf/rTy48fH87P53kSPlEIeLAIEro7OpVS3X3d2o8f3673qwb/4V+IiXrbQp0QUey2vW7bDoRSrLthN0IETtI9PF+eE9Ee6xDQmsVUB8FIw6sgbNrzDCgydG3bukXyyTyckCTBOYxQeAi1RdgCLBwBE9/4/PEJMDQh+oB973HITOKgHpkOw2jutQ5SawjXUsODRboBdi3HpAsESBB7DoYB+9ZFpJstbS94tLGJAUHEWCoANFWHQEhLINKm4gFAqeYLM2E2c5JaSgVkAEw7+cQmAQzCwZQgtCsJ5HAkBW0pUjerXbfvP34Q4ul0aq2dT2eLQBKf/HK5fP327WxahlLmas0xtC/r3/99MbAy8zRO2/q4Cunxk97AzFxYjChNCQkwgITlve/75593bP2ff7JM3rbtt99+O5/n3//xj8z84cOHcRhKKaWwN1iXZZorEXn4MAxt35N+Pgzj59OHoHquJwnWZjts4zj21pZ1zaMwPLBwEAFSAEQ4EZdaHuqG3QNqqYiorh7BUmodm/a8qe/LFRAHEXNnLgQHL9E8aqn+MJXIU1eYtWs+KFXb3/Z9VwR0gwhAYHN1C2LOzGxzcNeIlEqYzDMTNe3euwcurV3OJ0QMjyJcSnVz7VpLVQtHD4+v375epnkch/w6+767WWVJszgpknzoWqs7997M18R0aq0BNI0yTIMBLMuaTR8HMHJawz4/f5zqyMJJlSMER0AkZtiWNbt4DzczqTUJw+v9XkuVWvd9771DABOjBjsO83iZRwk0DzRXbW2B++tN8NAqaTwE4/+YrDFHoLt6mBs9nnXKbEyIzf/B3M2L7120mRDGjx8/tPenpy/j8DTUYbxcnk8nYQQI4KMZzvIOIJZ1/cuf//PLr7/84Q9/6B8tZIRSNCgIcuumnUQ6+yJTnefe2r7vjAyIuSXmeV6XLa+kcRz63nbtxGyt7b0DHcxCEZzm81TGH9+/Y2FwMzdEVPVaDnzkfd9k1EuOsQPi5eVqcdilAACRgD5EGMC1jqqWaYy9m7tOpYzj0FoXFvOABz21iCRgcT6fl+U+DKPHZmYsvC/7XIZ93xOtLaVEHnIQzIwBByKa8z+IXPdpMGnee9daym7aXZMyWokZKQBMAYBVY93u0zTgoaz0cH+3di6lMNE0jUXKMAy9NSLStlvE2/W6rauZEdPe2zw8jwNfzlPfDQF0M47opKZ4GK+t65rdQS6LiFBTDiQkpIKBzDOhOVoWCvGgTFoEvw/tH8PmfMHbtv788RNleL6ckeU0z+fTqSIChJn3HFdSxoocbMn5fB6G4Xx6fvEtSHbrHFJEAGPrjSHbeuCcQdnhKSKVkUmEi0AV3CCIUKQMguRoXCsXcgSCYagRcLmcRHicpvvrEkDeVQoSICKNQyEkDX2fWLtHmBOzaVcILgIRiEd3aWbLsiBmVkF2GDSO47qulNY9PVztdDq9vr5FaBGOQHDDCHdrezddpIzCDG6FyVXBYuBKD4/FfKQOoG4RkO8eANLEJsvBBPbGgRFQDWAaDQVMS00hZxBD2+9ddVna68vP8ExmPA/TKMwJ7wrx+XxW1WT8jsO0rxtYjHVYSmkvL9ft/vcf3yOQ0KEAU86q3SO4MmjOa1m9M4Vkmvz7HZcXYkS4W2EhQpIABSIKsICIQLWDo/Ku1sp2Eh72wO6+rut//udfArAOM9ZCRbJB94fBATEnWzm7S0Q8nU7TNKv2g3WT1gUQw1DGUt5eX9wPxCyh133bFA6yKwrXWpNnJcJSigf2val1JDA3AAY/CA6q/Xpd1Kw3BQRGCY93D7D35oMexsnukb4NFJYp0aqaHU/v3f8hED9+mHmaJndnITB282EYLpfzvu/MlPYqIqxq9/t9HBlAauWAIAZiLIVLeRrHweOwRs6PpGbJ+YzDU+SIXS5FAKC1pr2IIAaw0N72bBOIMPuz1veXl9d17aUIAiFiNxUzJuJCe0/mKokUhnANj3i7XQFxmkdVW7d1b+s4VY/QvXNQ7/tyfdPu17dNiqTVRK1ifScCSan1+5GTGq8sY5CiDvJQKHhEEBJhWtDkJeiBx2vO2iUfxPV6/ctf/vLy8iJ1LOMkpZKwu+/7xh7xWH9ShNJkLScvcaAY+YK3vXEpgwzYTcZxHMa+78dnO/oqAIBxHNve8sD7kUPT3fbeAVkItbcYSzrZWm/uxszrtr2+vpTr9TScHycTPFQ3Bx001837j6kxAXTvraUbuz3Q/FzZ7x3x+0MYhpEITsPovRPRp8+f7vf7uqyqKlJykggAzJKgORKYtgj0CCYiQtNY1zVvwwO76QoPj7Fsw+/3ex62EdFaL2UsVfbWIslIjyJYVVVtHMdpupgphDXtBmHuhCRMA/Lr2w3TjZMIiJ6fn5Fo27etNSD88OEDLvH1z/8OGNN4uX+/mepUyr712y3zpHoFkAEJSZglS/Ws0WqtgiSIDsCAAEHoHEgFIXZ3IKYIIJbEKMM9Fc/v5X/Wan//29/+8h//IUMlLlxIKMbCiGBmRcp78wiAjmCe0QHyOPz4ft/absIZkoChvt5uwkJl7G4p3oMgBiBGJJZi58u5a3t5vSPw6g0cpqn0bq1rIXYMLKQeL9ebSFHXFiFASHjwSAEIET2QAFJgBQIRlGGWEFLYLIRoLPVOKz7YXblD8tzKtrr1Rpx0HjQzBkBhQnp5++lu+75v256etog41CmCtft9ecvgzlJqa31b2zQNl6dL3rb0UKgyS9e7qrKwgzGksCryJe7dqjkj7L0REyN1Bc3+nREQRYpQbQHq4GDdFDps+/48DTlVcGtmvciAEeM4ariFA8A4TeM4/vnvf133LkTzyEMZOoBqFCnjIADS1Mxdu0oRApBpGIZxlFLyPJ/GQQDVjRCkAEBgIlWHVDB71/wQlk0ypcOnWf4Nb29vP3/8vN/uF6njMImUeZJ5wMKUDIWEiN4PA0SMwPeaZtu2+23zCMnAF0AgjAhCJBHYHQEVHw4cAaGGiNM43t7ubiAFk++Urv/pGscZDOEuCajuaubEPIzDtmyl1mQAERJgEBG4pbA23CHgPJ+kcNd+HkeRgtc3gCil7vsG/8SmL6WoaVfliPfVFuFZDLW299bzfzTzWkvGUamqeyAKgLFQ77rv+7ZtZjpO43tiT86jwiPjBc6nuQ5iGswUcMhQ8/XAO00ePe8iEena9m1FQKzkcZgJu2FI9K5f11XVai0stNyXLjaNBfCANvOV9dbGcbqcL4RYa60fyrYualZK/fTlc1v6vuMgpG1j5giXeRj9iOSLYailoCBhIEMwA8IxYn6ItxAoCcqKABlJ+Wiewt33beu9I+EwjKf5cjpfyjSOdRQqDESEEBAPXB4R8p/e952JkRARWzOzGIahlpp7EZEA7QBjEXJmxywAEGoRETVa69fbMk3jOE4dHuwaxMPpgHJvQD7lrItLLefzWVC23h3jsLbBICIGNjUi8ggEmOe59T3nClKklLK2tq2Luxuiqbo7C7/b/MkjDTlRUO3dPeZ5/rH+MDN8+M4lqSf1S0yFOAeIVkqBCYmptTZNExExEyLc70stw9En1oJkgCGCSLXWmjufOQCi1qG1BgT24AEgQKkDBuS4moiYRQLd3SP+8tfffn7/9i9//MMvv34qtfRm66pEWIrUWrftoMn/8suv93ZHAELpvQ3jIO5MEljE90IwiNxc3dzMZZwG99AIMC/IVcgNCFgAyALJAJCCEzNEEHQMNCLkR7+dsou0ObDWaymn02ld23x+piIU4OlCIYxgmBPGQ/wEEWyq673VMg9Ddfdl2YBlnucIV+2AhgRhvq3LvueYBY8Xppq+yuM0rOvq7iwCCFykIEBAMxVAh2NKzUJNO3MRqcw8zSMXDgDTrmAJIRoFBZla0igYiRD3tr3c3vbe3PXTx49jLW3l5NlN47R2Q6Ts1+DgpjlGzMPo4W3VvbVl3yBCVYVEISycgnq3x+AnkB2BW+8eQSxcAADMA5HnqRJ6LeBRh3J6NIbh0d2QkWodiCBCScIjjixcLEZwBJyn0bGcwsO9xa65togge0AeaD6Nb9cXj/7Ll1/Ol/N6e73dbmomdRinizCY9c7wX/i/vr69eHflnrK63vtYqKGsC4LHeTxdb29dXUrS+HtLUnRvABBHyO3BIMAMCXK31E5GBDERoj+Ik+Hh7uuymFmplUudz0+n04lF6lAJmVAI0gAtfehcTR8APU3zKdmnrbXXl1fAhJHiHz3aw0lRVYdhIJJIOluEmX3Es6mr6rZte9t37aaZQGdFJN6prnF8zsyIO51O27ou93s3dXALAwiNYGGPsK6AwCKFZd3WiECA+22tMpxOp/ttaa2nxkSkbG3ftq1FhwACDBJEFCbDIKIguu7ruVQ3LywIpqqMlJOlxx47kDCR8u4vkhUIMUH4MFRz3LdOREjQe3NoHJLO4gAOcHjvmln6X2zblqRtd4e07w9E8Ef5cVxUiPTrr3+Aj1+W2w3JSq3C7GZu9vb6en768Hx+hlAAnudTHYY6jC/fvltXfFwIDFSYnp/Ofd9uP3xrBccqAMCEQShc3F1tryIMTMhwGJ3gI1AtiCA1qwAHkRwfhEbtPYH7btYt6jgnoURYSqnMBQOIc/QWcZhPhrsL8zgN+75f77fr9e379+9Up2HoiPGwVAxXMzUpNdfWPJ8DYFnXoZY61PE057t3d4S07AoAKFXAj3XshwaGj74dQnvv6960hzvioSISyDzUrOWhOhKCgjFzAJATAIa7mU7TeLlcAPB+u0dETzA+oLKEmYe/3O+RAx6zcZqG05mZ03Qpx0rvfSWnYd/jDoVH5/vwSauEka64y7rN8wwYiJ7mu7n+WA6LDTr+QiGSte/lQcHo2g+UBxzioIWn8iXXLqOUD3UcEZHDY3g6yWmYLxezWO53pjBTdY0AAhqGIdwRUE3neRakLImk0G7bCb1OsyAEIBEXRER0FiqECFAY3MIspbLORMzlHbBBxIfhyYEj762VInWedNkBixQCAiIqLMJi6iwdgpgkSTfEmbMLZk1VX9YbAf34+fOvv32dpqfTZaaHDrOUkm6k7o5MiFiHsmqTOtSBfvn1Mw2y3fpQBxmH1nZALLX2vQWAhiMyHGoRFkIMZYxAbstm1jtpBHBAIUHC9MQKiiBPJW4wtTDvIEERDh7h9uH5Mo1zni7bUDQZHxbTPH78+GzqP378aK2l+QwVLAXRo5ay9mBkqeRq2ZQ4hDCBuXY9YFbzY8ofcbvdz+epFG7Lvm8ZH6kiwIwAxQw0AMyQKYCSJQYHlgaVCiBzkYhAYI+uphTODgAWcUyrjl6eGQiZed+Xt7frdDkDM5QK4ejbnqSawmrm2qc6fnz+GBEvLy9ENNba1rWrsvCv0+/H+fbyej1mOESc4+Q8pogPQBwe+Wnvg5oEeY9bDA46R3pszNOEhLd1CYChVq6FijwgU8t96GkX8jBW3LZt2zYzu96vEHhd70A4jdPlfC712Nm1FuKUHrAwq2pru2NM8xR9Hcdx731dlst4VtXWehlqQmtSRLeGREDEZiLl4/OzoP98u96XhojJLE0p7ZG9goAIxKQKQeAI4aammWRmbm+36++mT+fzRIhJxzif524egO4xjFVEmGKaptSvzvN8vsxmmsolMzMMYQyzo49L/48EXR7muRHHYYY5dY3aWocA976ubZ5OjtERfNdC0Jtu20ZMB0lVuDcTkXGaVS3yroEwjwjq3TypHAcif5A4AIGIHQiJf/vtt18I5/Op9RYdUrm2r1vhYzDTte/7/unTp6xP5nEUIgB4fX0d66RzfP/5ktRkJOJ0FiiZ1Z2svbwKiRDRzJkPeP0AppGyukrwZhzHYRiWrf14fS211GHAImbaextLpfQZYnA3A2+9J4/2fr/nX8gkry+vXfWPf/zjWM4sKCLpJ2juhg7CAGTuvXdnDiYuBCFMFN0hoLfWIfyYJscxVSziEBAxDAMAbnub5nm+fHi7rwcJGRAgHKG7MbFTasQgEILQEVIXmVYchHBfF7Wnve0evtzXPAgjWN3doF/bsgAA5jTX3Od5HqQEc0cFhIAQc7BQt3ecAgGRjzRvePitHQ51RPf7UgNVVRAjcmJI4QHuGJQcwnXdiHld18v5PM2jal7WM2DvbgAAgQiUqVtISCwUDqp4UHzJTIlJA+o4/8sf/2Xpe0DUWtXcIoapOCXPLET4dV3WHz9++eVL2qcXIibKme+ybExymmbxw7XRmbyIUARghHuK7B5V1D8whQQ24nHkuFnrzSCmWjzgx+tta3qZBiI+TafKVEvlwgChoaBBiBjYt/22roBgB7kSLuNzqxoKhYdwcu0NQsYhJa+5vgNsbVtABGWQ4RGpFbuWND9Kw6Jm4R6M6SIBBHjwNfi+rOu2D0OdTwOBNlOUimAY+Uke8fWHxJSIOeGy/JgIDgS3fdvud1Wz1lR7BAEyCRWpqhbdEKDtewIc19dXDBfhWsvlMrbuphoY7zNZyKhZwpQXJGdBiFOFQMj3+96RsnxKb4i9dRHBAAMDwFKElHvvKMRFINAttGutyuyE3PdwdUJi8sDj8ilSdzePqFIgHCAQQ6QUkT/8+sdv1x/MUqRuuC97V99FxqHSy+uPdb3f72+32/12v2WQu7sv+04RHz9+fH19u92WKmPOYby1VkUGKUlTAAR3S8yTHj5d74vpWGQQx3HVmrBIKWtv375/JyIWYaaBy3maa61IAegPqzpblmXdNjOrtabG+nw+Pz09SalBkvJLJ7GA1pqZ5jGZKFfCSEkG167JWELEmsYyEdkAt20DNd337X631r112/t2X/Zlffv58uPr14Ip5Lf3zZM9iB9ZvQyA8rCkJzo8iYn56ek53Ndl680IR6YJQCLoAQ9RbrYcz+UmbK1///7y+vrGImqWvSk9Wqp4cEPywQ51yD+VTz4hqNabP8J5ckyZde3h6fMwPHqfdeZPFi2AhmBDxXmQeSgAqtH3aO69MI7DwCJSqFRiAUZHsN7X5/MZ3SOilkophvOodRqGadu2aZqQ8OXlxczcY1mW6/X68vLinrw0f3o6SZZ7TMRI4BktH5aFeRojE6mqu6X20OwIuXyfi0FAqYJMb29vFjHVmrdnB+/hAklKyyQtba3t205MOZcGgFrL6XTuLdZ1JSnvca+Q+u/8JHBQLovU9NeINKMFAICnpydm+fbt27bvOaUnovM8b9tuXSsLM0sp27oyAtc6jsPz+cm9x+HiAO/nR57/pmqP4XqGMRHRy/11vpw+fnjatkVVCQvWQAdCQWZifNikRTz4F+M4ns/naZzDXzMqStt+Pp/vy93CKg7ZHufqgchhVfSuKVWl99N6s+l0SXglHpvH3M169ulZkAGiqSFHWoLte5M6IMRpHgCKWXTFoDEAPJyAp1qljABhhgEE4La3bVnBfRAe67A3DceAtCGK+301i2EcPzx/2Pe91gqBb2+vqvr09GS935f7OExPTxcAkFoHcBdAcjDTqGmP6aqGkOnIh0I6fQrh4VDoHr33vfdhGodal317fbuKlEfmHqK7mzfXLFvSuvOApxEMY+37KHWaB0T6+fOnqUspHQwRAT17CSIAIHcPT9QD3YMZAwCRXE3D5mGsWoahWhgiFq7MlLrKeR6PiLYijFPSD0V4GmprSJjlM7inLVEQIwOaB0KmDFDhMg61dSei83waCml3YnDzpuYeUiRl0+9qKgCY5tndA4BLMXAqBKDzMH3+eNmaLcvqodYbomDA5gsLYmCzMAyWgqm2IAqIbdtqoUHker2nh0ciCGvfA6AgihEhOTo6uJmCI2KAt66yycDEIg4GaAAoUPK2cbOuzbqlRisJUgdwaOrmhThKLFsDQkI2N/PuHuP8oRaapJRSWBgeeoLz+WRqBFirXK9XyU1/TE7A3MIeP0z0TgB/P4ffD1tTW5ZlWZbPv3whLm/ffyz3hYfZkUsZxnEgxHVb3RXA4p89yhCBmUkKy1QHJlrXtixLGm5zdg6MbqGqwzC908XgYWOZE5sHD8yv1+v17eoEdRgizbPAqfL8dL7f7gkb9jDQA1N1s9RqJex5fCpACI+Hu7CI+IEJE+T4vJTWW2ul1uHLly/Xt21/sCrM/GF6ckSwZipHcmjz0bu2fvaPnz//9W+/pe4UAMw6RCCAGyICCxICklGJ3A+35c4lprkiOVKYeUZ0ezreIhBz652PSxMPHPhxv7fWgJCMgN4zWry1A5hVs+jda0XEsCCicBOReBQ8VARbm6eilW7XFSBqGYY6bMu9t75e38rnz+mj3lsrpYzD6GqZRyHuzu/tCVEas3s4iwhTer4SgT/Ioll2RETXvm17qXWoQ+/6dl2IJAIjMMJ7713VzUvliA4QGZtGxKUUGSoQMnF4aPf7fTsU2ECBHICEGEcQF6RQ5HguubYAABECylCv16t3barN/ZDaeGAAGz/NH7a2r9tu4IiM2XAzZyg5IREfxBJ8/AcC3IyQMrQNIqybMQaEuW3bFjEx0dPTU2+RAcSPEgcAKInwOVrO9fru3ta7vd3uHz9/+PLr59NlzsEUPGiS7oDofBhiQECIFO163mdAGKQagIcyZYATUgakJL1G8uqDQ+NKnDshXQUMEAN772lNkh/2nR8bAPYw6HYzJCqFsJSIAEQWKkPtqgWllOLRtGf5wa52++03Nb18+DJPkwgvy/J0eUJKM1eQx0jyeFsUQugBKeoij4Ry3o+bxKK8taZq43iaT1NAvN2u6iA8BlMlZERVM1VmSf9RIjRDAKh1GIexSHG3sFAzs1iXXYSZBQJBuOsDJYfY9j3raEQMd3cLiFKLmzmiSPnx+lOYpBQ3TZ9FYmRmNXt9fV3WVdEBQYiQQagawmJ9af1cxqkMt33DwEJyuH+YR1OihyyWkAgrshKyyDRNRAyQQnjJABwAp8x+RIjw9+rzPbPpKICIWm9uOg4lHzYEkjMxpUhOted4Jm/Vpt6dREYiACQRnOfRGzIXEUp3/zpP2bObaqgxi7sxMGLO3SPCM3nZHFsupoc07X2UhIiPfJ6a0je3ZqqEGOoE5IbmzoV8dzMFpHCTHn27/twX5eHp8nFd9/vtOk0zAHTT27IcfKx/XjR+JPRBBFgY0+Gw+N4kuvu2bYh4mp+KyL6vr6+v7i6MpdZ5ypkopA8ioiMWJgTEUkqp5QDl1DzAwzNAAR5FdFiAehFGJEQJhMQUUn2f/hyIqGrTOKpq7w15SiZPbnd8BHQtyxIPF8yISMI7Yxr/ODMN42ABrpaOc/AYIdF7NAviMAzjOKLFMIxi7SBBAkJErTVbjfc39G4MBg+a6zuwzCyIEGDmx3slZDUNDXcnxG3dwSG/IyEu27a25m5t35Do6ePT50+fl2vrqqUID0QiPFQWiuiqYIrDMEcAuEF4gGhv4URACEhEGVaQN9C7a2Ze8cfzyefvBgCZszdOU5btANFaJyIpBQDbuqGH9ViXu27b9e2mCtM8ZaWUz0SYgHIiiRAQqh2PJjeLvCNJ4j3jJGssMzuOZcJ1XZd1pTIN41CngZjcIgm47l0EIUqtIwum9x8i9N6btkQrrtcc6EopwiTLfYUIQUIgZmrWU70TESJFTY9oQtVai5q6RyB1TeF10JEF4rmkzudzWtTlcjtaBwCRwqXM8yxctGsrpZYCAKWWjLNT06Q3lSokchoRCaBVQqdjhOBmVutAxO8E4mTCZHGdz4of0VTCRxYWBJkFgnfX9d5YiPZtGIYe/rYs4RgWgOBmphZgbuGq67I+f7hcLqfbfWEmQqxFmmsoFcEiwnxYkjtk1eIiDId1Plasa2vhjggiRCzWDRHTrOr9Q6r21na3nnVYa30Yp8v5tGzrOFQvsO27aYBQDHJ97U31P//PP//tL3/78PH5j3/4Qx7VX79+FSlCpAQcIAAaoIEmRBEEDghAJIk6vAstD74KwDRNUoqqvr7eHHiQgkVMAwAEUJCOrMNwwqi1lAIOgMBZn6nq7XpT1W1TVat1qHVEoFLLkREDqL0jIph7VwRS7QEeQupOTKXy7WUFoGkcI+J+195tmkqotrZD4YE5hStZ0b8DPABRSlnXpS/ra0Ik43iap58/f5bCAXBf7/lNh2HYm73er+NYf/n4ESuEAzo6GMmhGQGg+/2WNyAzJ/sjHnb272eDh1u31togZ1UjdETAWqlwyWFHik67YwAx5QkRAVyEIoZxIiQsUCprN2QCdF0XBJ4uT/lvZRAsGBBiDjUjgoAASEiEuIUDugiKDIvvhITkqpaZZPmZS6lLV3MspUSQdluWpY5jnQsz3+/31vogJ/y3/6lHxOsbljKMU2/t3//j//jXf/3Tl0+fP3786EYC/8MPpsO8mWZRleMqeIfeAVT1fr8PwzDNE0S8XW9v9w2LIIIAMTMwMwRClCIRBOjDUMtDfxRB/TCj6IlwmmuKb9zV3Yehupu2w20r4Z1Sipn3pkyAjqaNCFVtXdeuh61FwoPpIeyhhJhNWWttWdb0ryvC5JGhatefP/3h/dBau16vy7LclnuWIJlaneBQa+1+v17GcZ5mDwAPIDjNJ3BKtCvdNM2MmXpvuXzb3vLg8Yf8ASmIqNQi3cwUIGrljAfHADWfzqd12f24PhIrFxFurZl5220cy+V8uV5vre1SUIjX+3YDqkPNTuIgj4AjGlBkIYcOYUqITFyEk4ciVQCJe1q/Ut5iCVX6w0gMEfd9Z+YiTEhDHdDDat9X1svzxy+/fPzl91TrMI6vb99++9vfvn//fp7Pl8tTOKdOGCLSISj9cyBvVjqsm46OKR6MWyKapgkR1239/uM7MBcpRGklwo6I4EUYgMJzQUsaye5bi0jsuJlpHSsTf/v+7eDDdFPbk/eRQIt5i1QbubfW3XxXrePg0UhEu7bW1b21JqW8uwpWkSJiEK212/W2txbuJAxIEUCAjOTuO/huDRECoGlnosvT07qtiSynnqL3TsypDrjf73kFn8c5IkTk6flJ1bTrPE8PHpWrQqkFGdWNmbvbYfsGkUmcaeqSzY26ArogDaVqb+4+lMJI275zrShSEEvOTJYl3L98/sSM375/v96uz8+XcZ6+/vxRXl/P5zMRtr3fl6VW4XIIIpC4ipcizMiFwcB6W5dlMC11RkwUNrJ7HcfRzN7e3vLozWYkd2wRgYAIKyJts/W2m8N8fkKWrSuJDPNcSkXA1lqRGoGC6pinNUBOexE5m533mUPe3qloS5Am1/X1+na9vY1PH4pIHQZkCAhhqkSFJQtl5rQntt763na3I03ZvDNXB1i3zZdlqO00PyEBEZRS7/0eETnkX65LHjyllHkexhE/nT+PdXq7LZvuiLRs6ziN7wcDDSMiWN/DoXcjZGAWltSuRfhUx0BqZhGAwplRu/YmtRDR6XSa5/l2uyW4XEoRZiiFuWzbYgQznRCgP9CgOjAgpyoAEJCQKoOG75EyGRIMj2ZaUSDYc16uzdTS9BYMg8B3RfMEwIhoWRfrnaXsezNzDGh7a627t21vBrjsTYaRmFVtb20eh9aaqW6hglMAABiibryVItM0nYYR3H/eNndYehuMz/OZqHp088OYJAt5ABARYUEEN3c1EOEqZtu6b8va1KOWWj4Oe1fFjaWM4/zhwwdEvC2LWkzjJPDAhBDB1NDhnc4Rj3Cid7DhOSPdjAAAFjtJREFUXTCds7DvL2/dY0QkZhEhYhYexnFkZnTEHAG1bbtbuHbtXSHeeThETAi0ruvf/va3jx8/+ad4fv4wz/NR7QqlaREAtH1nIiL6w+9//fLlUxlmQlzb9vHTBQDWRa0rsxgYALgdFB0WFj5yaZg5lWrZ227bvq3bPE+Jhfbew10jAuByBJYeo7fEh4mo7RpgdR4fVQMApMcVT9PQmrc9aq3MhEWAGoyTJZoCyMJj4fM8D+PoEWauqto1T4K9tWTkJd9PVauUhqxu6bzFzFIYAoi49yYslSAi7usKTIhoAOogw/DxdFr3vbm6dTz0nm4a26Zw9mkYWBiVEXnfG+Nax5FlsH1/X1jjOOb828PBjvGRup3Pp9bajx/fMUpmH0/DiNx3c2YmHn794+8zq+N6vW7LnnwsBwA3zzTtpMzmIA8Rc9qc1pduFpE2srGs27I1LjXFhoiIBExUWJjI9RCAL+vNQRNTNXcmPs1zOqKZeu8uzLXI58+fLpcLi7TeAkBqQQDmIiLz+bzuu5ghQBnP8/mjWUOAj8/Pzx8u277/8LdwN/KApIhBtrC11Cyn8nxFJmbmKMkzJ8TIqQtLrYP2rq6ZkZR47DAMaVXQez+dL7fl6mFjxHmcJJt4JDxGdcEUw1ABYZpGjSDic50goLW9qwZAHYd5moZCbkGEvXdhOVwSwtve9tZSa3Wa50GK1trdcmbipombRkStoqbqxgT35c7MVUoA7GoezoTnp+dlW7dl4cMwAXPRvF3vrj4OIxJ1dy+0t6YBT5eT2wG8Lfe7+z/4m9p1Gkc3X+9LKbJt63/8x7//4fd/YhkB2dxLrTMAhFt43xsSeECZBkAQx0AzJAr3d1Jv7tGs2cMtYZsw94cWPgK+f3u1iDqMh3AHD42077pD076Fs7uatSD0tLgNYKLyuLfv98VUPzw/DXV4fvqIUowxdUAozEC1DoGo1qGU7EC/vb6cni7elnkaP54/bL3ttw7uyEfuFxLmzMbMqfA7/GZmYUrMqFYvfF97SkYfXVtCX4bM27ImlzIHRwexEUDBmrZYsbWdBzHTiOxy3FXDnaR4wHJf3IFZgtlUQwORihTq4GxQUBhqlbEO7i4idRwcQu+bmUEeUAF735HBw8ADLBDA1dW07fs0VxQkkwjFAPBInI+ZlnW31T6UYR6nnLFEHOOBpN4jsZTStW+32/l82gHCrK1bPKoIU8N8+0Lqni+9MrtIeKj2Zbm/vPz8/Ls/IJeuht6B+v1+//nzx/3+ZuGbNgZyN3nvfeBhVZBqstzlEEFEpgdH+/1yvF2X69u9TCWrEEJyMyL0sL2tYbtbhxAPE6GAYOEiBQAybKyUAoFm0buO8xNwb+FkWpiHcSgi27Jv65r/XI6NAXDX/na9//k//joK1N8XGmK/b69vbwBIQKaW7VTy4h95ZkcLwszLuhLbgARHJmonzgFRxEFIwghXVRJOkXFSWE/znFwaXVRITG0Df3lZtrUlUJwxliQpYWjp+09E2rtlbTsOujcp/Jk+zMNQSp3nQyF4muZ934O5iDQ3/ieOLhN3U1UdOH2XYdv2cS51FNs09BBjAsAwVneNcLNYluUdlzqA3wezvvfeKMZx7KqFBQk1w0rdH3cOhvu2bdNpHsfRWCGgllKnsWtPbPbl9XuZRovYtv37z6+32499661psEHmugARkyC+k/cPrJke2tHEUR7sGN/3vZtO04yIP1/eiHmeT3UaaxkwPB5Mra6dIpLtCQAshcKzb45H/mIEanczWDcnHmQQ8/1IzgXsXf14zdF625Y1OV5DuHZbllVOo1Bp+/r177+1tskwwCEuDUQy10Sq3B3+yUvHwkzt6fJ0Op1e3+7h8MhUDlXNtZuHsT1CplLCpG4vry/qNtbhPM+Xy/nl50vb7TI/9d2b61hKAO6tiUhGAz8Gm7hu2+VyQQBz112vb1e6AFEZx4GZVHXb1n3fe2ssMoIkQdkhIoCJ1Q9G7HHqhBHRh6en1l6MQ4Ddbdu382UmolqqggFEV825JwIQ8eEYENC0I9g0jR8/fNjXVZuGmYar9lKFCfft8DjOzU+IkM5nlDA6nM/nr1+/Xm9vLKXpfjqdni5n1RYIwMDEQy09tXaI2dj/w5QbjjH4g4AGqZsyta7amU/rui3rerqcBilICGQACA57t0EozbQCABmQKIARoUiBdytAgDDsTe/bZgSBIYyAnFK31rqZpTyhlNKb59UMEYMURm7rfrr8Ustwe/txvb0ZRCjtvffW8g5y83R7DAgEOKiCCNY6ApaPhZnXdU0vAwhyTRRADpfaMCJ8z3smJkOIMAAsKOdhYqQ8yj1wOp8YGmicxul+99Y6ERMdhpTI6AippUEmN+g9aSNCzNtue9vV0t85JDGzMIOggMKsXTlAkCw6kiAxUGzbOg0nopt6MCVT2a7X16FUoWIQjyQNSJD5CO0lyoKyh7emtYrUuveOAJ6dLOE4FuYiRZBpqBXhQZdKhhKAWZzPl7///esg8vzxIxCyMDMHxt42QGEoQrRu+7atcvR6cMyP4KHoeswoAgBaa6nKFeOI+PH9NeMkIwIhum5hCEGBgaWCH3UmESVPsgy1FOn9f+Cpvb3eWu/Ah2FpKWMO1vKfLhklysRFpmm6Xq8AMI5jbqbz6dTVfl7vy9qQSNtaigyFl/va2i5S93Xt644YgPDh+YNMk6meymDmnz59AgBVU9N128wOUpCqTtMUdgwVmCWloQZhWetEREBT7UFSRoDtqss4jbybYmveSimpXM1ZeF4A0/nUw8AR5dB4jeMIgeu+3243eFeqlRIRaoaZq4aYl+/e9oGH3neR4oQM0HYbxgPcZ2ZG9ODeVOh47P4QmqcZ0PV6TW+OnKVqxPV+Pfs0jOPlcnGzpe+9sxRiRq7Yel/u99R3pIozzypmmsbJrX/6+EstFVRJuPJoqZnAUmXoPVozDKoySLKj1I4Z5IMmakcTAtb2/Xa7D8MgpZQ63q7rtmmp1cGICiCBRQSwAHN192SiBIS512EYxpEEmzYGDMhAFN/XbV03GljdHsTgg4H5zrUFxG4aEe9Rtr13D2AmqQJMp/PT734Xyfeotczj8PL2uq4rMgV2PJgnhoTM5I7BpK7btl3OcynSXjbyCIU6FKk1a3zmGqrDMEzTnBf3sm8EgIyhNtZ6uVwA43Q6X99uXffw4u4OsWyLhIzDqGpAoOoIMExj9Ka9d1MDKFWIcV1WIt72tu+7lBIAItK0ExIRmVsKpHp0yS7WIhyICZmjW1j01qdh0N6ZKaVcwpKxLu8rFR9F88+fP3vvf/rTn0Rk33eK8FJKrdu2qXZmWtd12Xe3hkTh1LXvbbvf5MPTB2K8b/fMF2FmB5jn8x//KKo+DiMh9O7qgYxMxbrvy87E4Y6RCk08gPUsgyLCTNvWRSig7VsbhmGcJmZW9de3eyA5IhCWwu5UaORRkDyCrSkABCE41mEYp5GYzNx6FCHV5hqK9rrc0o8lc7yQ2DQZmPFwGQEAcPesoGutqepxAGHxCGA6XS5Sa3isy7Kt27q2tiuxbGbNsQiP5/P9fr9u99hupjYMg6n9+7//+3/5L3+ap/HLx+dffvnl7XW57ysSEvG2bV8+f9R1y8P4fes/X57b3hS7lDJOU0A3xzQGanuDB0FNzbta4hrxyGFA7Uhk7h7Owkh4XzaRUoejZRuGQVXBQcPe2e7ZmiGAac8qHgIKkR3scfpwPi+3u5lnsR8Q3hvCA9AmSm5FrfXz58/3+11EAqBbJ3M3O82ao5/X2x1JCNkBEaSrCQsOxQ2aKSMEprWuI2EQFyzzjACMSK7R+46qEQGMrSlAsEOPsPAjCJOY3oHQVD0AxW9//j9J6Pz8zENFQlV9fbne7zfimjk1SJQziuN48xCWykwIJDRPM1EyQww9zLR3c0dF6OpTqcd1EaC9PzYZ4sPEm5lzgJXdU56jLPJ0uYT79x8/7vel98ZEtvd9393dus3zjGBDre5+u92y+i5SaCAz83BXb739/g+/yL/8vhTZ259fblojmKn3frveQlWq/Pj5Y9/2rLF0360bPHSIAOjurfdUO2a337uGYXZh6JHi0SSfYBKAgMlAI0BwXe7PZb48nXr3UgoElFJcPduX3FdMVJhJjh4IEIXFKSK8imPhDx8/vl5vCYQCgHtmR/4P2Vh58+aI2iGI2AN797fb8ulynmd5Xe9t3UqpiYoDBCILD836tu11qESCYAHojskcQQApBYDWtiICCztHmrsGHkNGpuMIhdQrPj5QMFPf9W9//vOvf/xDKZWqMIlpvF3vvdtcGQtKqQiEBAYeqszkEEWklhpmtRTE6H1Pkfm6rIBepCBytD6gqJvtDojEGX2eFln4z62DiOQc6b2xQIDL09P1ev358gIIppZ2xUGo5kDY3YhZBKZpen19tUc6RsKeQx1koHEYxlqY2TyJX4crSx0qIqzryozWbVs3KYWMWlOuJfPlXl5fLpcJAcKdODkGVkTAHZHCAyld2sgskEKSXwWIAQRoHsu2QVitcrlcAHjbGgAwshVL+4mwY7yWnhjEzESAGOYRmhOmCD+fTm/XW1fNeyZ1LQhHHqCHpWzN3QNi29Yy1GGoBtC1b70ZHEWFag9PWx14ADQyjuxuyfp31wAEB2Dy0IDQ3hGJiTuombm5MDsAciGPCA8AcYskQMLBfMeIuN1vP398JeGnj891GpAFA5etXW8rUWURKRk87gjoGH6YY4VaV8BaBCG29f7y83UcTyJi4Uycgptl2VvrDczMpmm0Y5ae8b6HLWB+mN77cQYc7igkzNNp/vljBQAETJXsuq6ZSxYQgSDCFHQ6nbIsy9r8YLAwFuRxHDEwg+zPp8s0LUC0bhsRDYU+fHgWEeECgcuySC3PHz6u+/py/TkO9eu3r6X+Qi6tbQNN6ZhQpcx1uN9X4EAMdwgEogwnhGQ4YLBhREDbmpSsZeN2vf34+VZKOc1zaw0QMyLP3WutQdD2ltYPTKS9d23jNA7DOcwxXLXxQ+Cans+IFBGlSKlja23btgj3ULUeLbMwILR3j/u2Up0IUJLPapmN5wBYSkngN8EmAIjM73MgAnfn0H1tp9Pl+fn55eUFDNDRwt287S2vF3of6eChrcFjuDYOf/yf/02GIU//7vbt5/euHQCIUJAEkAVLYQGCACmCYISO5HVgpCNcs7Xj0bh7mve/Lbet749zCNKsl1kymiaHZe+FQk6sE+uLiMvlQsmjeKy25HX84Q9/mOc5SRZE9OHDh/ezKiHc4x4MB8S8XCicwZiIRbT319fXt7e3+/1uqjnSSRf4/DBVZBqG/DrX2/Ugdh0EphLm4HEItjwyNsejEUde7vmvq2puHu2+ruv9vuxtT1WFu6spM2e6exGRWqNyHcdxHLX3tu95IW7ruq7NNQQOXY2IpA14Tmyzi88HmL8QlnfLLmtduwLA/X7fth0R123PKzvXgJnln3of7ORjTL+u3lUdLQiId22AeDlfEHHbDiplXqmEyeM7dEuPmid8HMe9bzwMa2vBgiPfl+3Hy4uQAAFLGnvAKFLL4KoTlmEaAGpKXQNctbtZLUUVTBUiWm+l1tuyrtuGjHOZh2HovSf2k1dwBDJLUjhKKXmX4YNEKyK1lLcfP67Xt8TWU72ZdIAc6r1727UDruT34UxW2bftpvYZh5KaBTNF95R6mWnT/u31p6lJKWvfEBGFzWxbtlomIPty+jwMpI9JaG5FNRPmL1++3O73ZbnniD23ewYZj8MgMlzvN2IBIne/3bdpFAg8Pz8RAnhQ5xwDA8BO4BimNrAgQt83JsJIWRztW4siTPL0dP77t29DGYQZw7ngNE15t+77nqknOYEQEcxaLYKJ0gJjW/dhqGavuXWT7tda8yME8rgZa60p3RNOwS0AAkoxiLfl+un5wxNexnHo7n3vIQUIAOPgvD8a/ngM13gapoiQMhYSVfv27bt2G+fTOxeMCL07kE9DlUpEqJ4mbLhv27qsGOEWEBwOrWsABMJ92wIx3fty9lKKMMu2tYgoZRgGyoWS/29+JCIiJCYqxLeXHzmofgAE7O5//etf/REHlFTE9/33AOQOq63T86WbuikTR8A8TU+n6WW5ffz43PY2ThMc1n4wjDXP0XngYThBgAw4TUNA/Pz+I1Gj44IuVRNiRkQidzD1OmRuLTDTvu/DMHc31Z2FCbl7/HK+tOYdEJHcjUjMNPe3QlQmDETCQKzz5KquaXPqRMelf7mMyzatm9ZStGkRaX0Ps2Gaah0NNoBLa5oPKiLShnSeJzNblrU3fXq6ZKvUWmPmtAtMFoKqESVfg9NdHIkSfS3JGQlb99t9vV/mkwgvy1qnMQK2tgSGvEeVvB99rfUIKDISkQVU5pfb9eePH89Pn4Y6vbvThntQ1KGWIuZtWdZ924ahZv5l762KiIgZAQR5EEHvHQGen54eZjtBRBkjkDxaMzXDUmqeRvl7AHJa4+dxHofhZ9cIYDnG5LkEe+8Jl7wvoMvlks/rfUKVv+Hjhw/MdL/v8Bi3P13OzRsSz/UkUohIMO+UUDUPDVBAY+FSxggjklrGaZ7rMB4Hqkfbd3+MpABxnme17f1Uq3WIcBbuqlykiJzPMzMHx742ICHMZPFImKOUkoUvEWlP5XBV6CzMXAGUiAkJIX73u1++fnu73W7hhoit7QVJEODIGPfr9ZbKdUFytXEeB6lBvsem6w4AtdZ1Xd9P/aOoOt4FiciyLLmBt4eUjZggkAmY+Ha7PZ3OtRYAJyQInJ3XdZH3rj7vQXr38iIppaI7BC3LRszjOBauImJqyGBu5LLvyV/f1u3e94YIHoHIdRgpUxsydRfMWt9Ux3EippxjvJ83iFBrCYd1291tHCszLeuqbnn0RlioPT9dAL31DsKUbqIPiOR9upc/2Si95xHTI+lzWZbr9e1yOv/49tNV6zhIYUKhQDczV7BDM8Ms27abmZoChTACIPEyDHQ6TXWo4zhKqcuy9N6ZKMNUszQpUp6enn78bOu6lFIAQ2oFiHmYWtF93dyU6eIOSWzvphwH7woAze3EJQjdwsC6al6RKLxs+yAVEfbWCU2hny/DHz5/ehV2U2KS8gm6EmEZoDl5yIenGQHXbR/Hwd1P0zSOIxEXRsCowlVEVc/nS2t7PKaEj8X9D6dxUxORzKMiACJsjyp52/dpHKd56HvbljtRkDbJ4TY/nIz9Ib8MSEM9X5d2v29Ih917TgaSauwW+9aEybynvUeqZYQJMSzcXSFY3bdt7V2X3i7zkEOrvHN77/nUiNiREgVlxmRFNlUzpyAPwIhSJMDNgRDT0zeLevgnrVUurHeu4jvk23s/YM+I17e3bd8LEURsvbdtzbTSUqXW0lpzt77b29vtsP+RlCtjW1ai077TPEla/MBj2hwIpgergojWbc9ZgnsAWiBaqHbdtq1rZ46+tQV8XzYZRwenw58oEEm4AJg6bOuOlJJM2/e9lNJaIwdi3raNmcd5sG5CdD6NmCrfCENCBEIrDDiUp3l0j94MhDS8orDQ3towliLY3S/n09vttO+7u71X6/hPBM/jKiMHC4tADwADijw1m+u27/M0IYJ5N92Dwvfl/we7BXyn6lybRwAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<PIL.Image.Image image mode=RGB size=200x200 at 0x7FBA87B7D690>"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "example = ds[\"train\"][10]\n",
-        "example[\"pixel_values\"].resize((200, 200))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 217
-        },
-        "id": "-p7R9KP0yUOa",
-        "outputId": "c0487523-1ffe-4cb6-bfe7-dec0033a5d67"
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAAAAACIM/FCAAALGklEQVR4nN2d25ajOg6Gf9mEpKqnuvfMrHn/B9zd1V2nhAC25oJDgNgcjJyQrYtaKULAH5JsWT5A/0Ejak8AYAuD5fKk/d+xBav6s2UoCrj+pKjLR2urI/sk4Dp2/OsoZe9JVWhSRKQaqJQHOtHalhPXMTsADOJBkQksUcxpSQCtFfVvn2a9u6cJse08cqXZyWUB8PDh2/jKAAAkSNKrg7TPOv/pBIwkA9UWkqQAFdeXYgCMgUrYjjiPpCS0cxxVaV5/slYlBDBygEA7qqxRe0DuJx7HTrguacEoc5VoIgaDixRKAVDqyrsbjqGXuM8SF18NlZQMAJYBewZBVSWwZVKV0w8yPMzjZFKi2F0AqkybAYDoUr0arr4YFu7y//B6DHsLo1PwNH8dkK6wcT9f5TjGzJ7HFEESX1OmqKqFhjLa7FP1h5kAOucEIAWm/EZEEp9tky7hAqmPuEp2NCBFQKphSbEBQ2sCbgTiEwVghmWwYQAoDoeiaUZP+mD5SVkgSQcKj2dpfpCkGLtrotgwM8NUjTxnh6J97uaU4pwy9HVbG00SXzxHSZm7NLKr3VpBA2xRtzdky+JyJctkz6Abcjhrm/qLJ+d3puyQk27bEz51qwEDMHY3CrMA1A/WJQT3N/bj1HFdKlsfyLvaswB2Id2BYFFPOyL3k/NZxtdb3v6Az+5zbGGSHTCrupCRqhPiRPHVmWQ+myieitxzkjGuYDSiNH5ARA7NkLNfRPZcn8n+bqtHzdGkb8f9m1PCibKZAQ++odGaGQCgnjv/MHR0ExtzSNoDhL1la0pbdi2tiWjJ+MrHvQuTgvdMIZmqWRikCQCX59xctznG50jWXK6sQCC6MwhQxxXJzhTHcr7l27bkmkLyS0tlfl3P6pCWWWkI87I7LchtauAljRZTmtosM1AHNRn+mVwTqnrvKkMUQ5a1vgx6PmQfRXl6SonGykSn08sOYKayoFvEKl4Q62kimJ7Tj5M5a5XsNPnzdhavCgol2Oj/eSM6OfGCePq0BGD3fIK1yACovSEy7LhOacCg1DLwlHAvwRdFEn9Osz1Ozb8WyG1RoIkUiRUYMKauowdCddf3uH8y/aMR3D857jwsdcks2QJcwp7BpuqyEynUtZKBYTDATZqoL1WDbrMnx4WFJfmld/tkf3EIRlVh0tnCGpgcTaKXQFR1xBjMXNE3FlMqjTrR2wny695K0SSAiaPFYAnZLIPWB53SGUCZA2QtcIkpiAhNQMktwVAYXMdglDZl1XVerDA7BkBNsB2jYUkAAqzJoQZ5AiIQNXbOsD6CWhgwxAyAz6rqyZDi+pJ52s3Sx/GR5tq9AYGagABmCzvnxkY36WIwV6NGuv3dm/2m6vswc1bsnsVRqFfFEwiq1oHfiqYloZJBCZVtmJL+OwVbzs2ZreHv/xIHqUes6udfDSKuT3WWAKDpchXKPw4mN2yrhzU1/hUgiWr9AGDLLBfj9ZyOTkd9uVGEPFFSp0rmusJ80YMRUmpHdqFigICZpRkAgPQwPc72kiCQr7aSfPqcIFHXQ9ZRh3xixaWkHc4Wc8QnFsjQQyqpSZIId40EQg7LAprg5DmCiUUCcSsEYAuAdhFMLBKIRyERMxFxQLS/xBYcw0XigJDPsgDA6O8x7hkFRGEEhA9R8vQxQEiP9p3yKG4Sy1z9WVIqoiRUIoDQiKsDgPUNDq2SSG3s2EPnbOTLVXeVFdIYTy9QFiM7Lw+iMBUdmuwhQhSFyXzP8RFCFE2YmjxLeSmvEnkQTE4CBp+k7yoPooFpEJzkbUsYpKqypopJ5VnctoRBZqZ2+Sh7W8QBmQ5B6CzelMiCVEPyczLF4k2JKAjNc3UggruLglQXmwNCeSGsEnmQeUG6lY4cJUHqqbHzTj4J90okQaprzQOhUrhXIgii69GVeWdLhymCIPNdHQDoJDvaIwdSe8jsatXKhilyIMsUAummRAxEtRM9Zopwr0QMpF5vsuApW9HIUQqkVsiixiGTbEqkQOox1SVFk21KhEAWewgg3JQIgdQKWdbLoJNg5CgD0ihkYYVqPUsEgoogcpUADwEAyakcIiDNtLXFLVwp1yaKgDTTQJYWi4L2AHCLBEiwQmA9yzNDCiFwjWYJ0/L2jeUmkAiANAoJmaBxFGvcBUAahQRwUCkWOK4HaT0k5OHKNe7rQVYoBEAmVQGvBmmnPgeVSC5wXA3SrroMe7RitrUW5KKQQBs5C9Vba0FahQSWR8y2VoJcFgeEPlipUfeVICs9BHKj7utA1isEELKtlSDtpxXNgYxtrQK5rBBYMRFWaBhuFchlhdia9lnGttaAdBb4rWoMRHKnq0DaT6s46HxnECXi6hCaibYGpP0UFMFfRKRNDAchKYWAjgKj7uEgnc1G1to4v55WkwSDdFeZrQ5g7Z/VOgkG6ShkfSBO5vfafknoitPuHnwy+cLnv1b9PFQj3d/JdLu/Xldt6Riqkc66NSuU9+TdX/sVIVsYiO64iFgmmunlJXg9XKBpdX4ml1AnvP8KTgaHgXT3E5Bco0PZz9BwJQyk+yvRWT5U/PwKIwnyEdXZqsK90ewaef6uA5QcpJHuVmjyi0G+foWMkYaA9HZMkZ+KTPnfAaFXEEjnc4zleMSvb4v36gjwka6HiLWGA+HDj4WrLgNAessIBcdle8Lq5WXRpZebFsW2rOou/PZ70arx5RrpKcRE3BKI0x8LYq/FIP09tB1bY8vJothrMUhPIfKtYV94/yOdSbIUpK+QmJYFAGD98m2eUpaC9Fc+x6qzOsJPP5I5d1kI0ldIbMuqbqL/O8e8Fla//dNjGxYAgMz7HI1sHwSUHWeYzTKQ/gZtt+EA6H3GRI9lIP2zb7WVL8zbdA94EUh/x8OVqesFQqefkzpZBNLfW/pmCgGo+HtqScASkMEWlDcEAZmpPPcSkMFm3zezLAAg+zpedy0AGSjkphwA8Pt9jGQByD0VAgB4/zPy5XyQYTBzSxepS/D56dfJfJC7KwSgD/940GwQGpx5DxDYD68dzAYZKOT2hgUAdPYmVOeCDBVyu3fW9Ivx7stCzgUZnncXywJgfTH9TBAaWtZ9FALQydMuzgTZikIAend3SwNB7qUQAObNqZJ5IMMdr+9mWfB2GGeBDD3kzu+ne3MlzueBDA/cz0UAwLw7Ds4CuVLIfTVCX45e1hyQqz3978sBp3HNAbl6e9J9LQug4uNKJTNArhVyd43Q8cq4ZoBsTiEA7NvwYU6DxHmf70qhfNjHmgEyPHC7fNaI0MdgrsckyDB+30CdBeC6jzUJcv3Cty0oBKBT37imQBwK2YZGQJ+9NOoUyPX3G+EAzJ/ufxMgV+HiViwLAJ27YfAEiEMhm9EI8NYxrgmQa4VsiAPm8/J5HMTxjsrNWBYA+roY12KQLWkE/Nk+11GQjSsEoLzN0I+COL7cFgjoqxn/GQNxhItbqrMAAPxeP9oxkK17CABQ8VqVaQTEFb9vDgSUVfMfR+aiON4ccJPJJ0uF0++HsTeWKceL+SJNxVwpTN9etB/E9SqH6POzAoWTFy8Iud6AEHXm3zrxOrvrDdob1QcAP8h1hwqPCeJSyOZaw654NeI4tmUOH4jzxZkPCOL0kE27iAfEeXTTClkCsslWvRVnkV0vyX1IjTyeh7jL7M6/b1shThBXY/iIIG6FxHyXoYQ4QB5SIQ4QT2C/cV93gLjf2L51jmsQj0K2blnXIB4PeTiNuMPF7SvkCsStkMcD8Sjk8UB8HI8G4hgyBPAAle8QxNeD/6eAPABHv+juDtUjuHofxFdlPQTI/wHFcdIicwcncQAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<PIL.Image.Image image mode=L size=200x200 at 0x7FB95352B7D0>"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "example[\"label\"].resize((200, 200))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vp-fIQzvyTHL"
-      },
-      "source": [
-        "Each of the pixels above can be associated to a particular category. Let's load all the categories that are associated with the dataset. Let's also create an `id2label` dictionary to decode them back to strings and see what they are. The inverse `label2id` will be useful too, when we load the model later."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 49,
-          "referenced_widgets": [
-            "c71c1a959c43465e9fa63a94e72e0681",
-            "22d86a1d282448a190ff5f81d5086f16",
-            "108d9a14e9bd46088a1b3526e9607c48",
-            "f53b548093704a4483f8825f2c7eb3a6",
-            "2be22416cdaf4ab1a48145dcdbafd57f",
-            "31288c6294644f4c890374a08c7ec1ec",
-            "abd78c14e61843ef89699b2ad68d970c",
-            "3dbd784ed0724b7b8f3bf3b5d3d87919",
-            "3f71c41ea8524623b129bfafddf293db",
-            "90d261d919a54a91bacba98abaf6b35c",
-            "d82c57f3e3484f149b5a8d63c97ac582"
-          ]
-        },
-        "id": "Op_AGsW0y5C3",
-        "outputId": "59041978-a8fa-4aad-ef94-80013c58c288"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c71c1a959c43465e9fa63a94e72e0681",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Downloading:   0%|          | 0.00/852 [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "from huggingface_hub import hf_hub_download\n",
-        "import json\n",
-        "\n",
-        "filename = \"id2label.json\"\n",
-        "id2label = json.load(\n",
-        "    open(hf_hub_download(hf_dataset_identifier, filename, repo_type=\"dataset\"), \"r\")\n",
-        ")\n",
-        "id2label = {int(k): v for k, v in id2label.items()}\n",
-        "label2id = {v: k for k, v in id2label.items()}\n",
-        "\n",
-        "num_labels = len(id2label)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "2Rg_WraEzMb7",
-        "outputId": "9cf28a2d-b433-4df4-c961-c987ba242ef6"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "(35,\n",
-              " ['unlabeled',\n",
-              "  'flat-road',\n",
-              "  'flat-sidewalk',\n",
-              "  'flat-crosswalk',\n",
-              "  'flat-cyclinglane',\n",
-              "  'flat-parkingdriveway',\n",
-              "  'flat-railtrack',\n",
-              "  'flat-curb',\n",
-              "  'human-person',\n",
-              "  'human-rider',\n",
-              "  'vehicle-car',\n",
-              "  'vehicle-truck',\n",
-              "  'vehicle-bus',\n",
-              "  'vehicle-tramtrain',\n",
-              "  'vehicle-motorcycle',\n",
-              "  'vehicle-bicycle',\n",
-              "  'vehicle-caravan',\n",
-              "  'vehicle-cartrailer',\n",
-              "  'construction-building',\n",
-              "  'construction-door',\n",
-              "  'construction-wall',\n",
-              "  'construction-fenceguardrail',\n",
-              "  'construction-bridge',\n",
-              "  'construction-tunnel',\n",
-              "  'construction-stairs',\n",
-              "  'object-pole',\n",
-              "  'object-trafficsign',\n",
-              "  'object-trafficlight',\n",
-              "  'nature-vegetation',\n",
-              "  'nature-terrain',\n",
-              "  'sky',\n",
-              "  'void-ground',\n",
-              "  'void-dynamic',\n",
-              "  'void-static',\n",
-              "  'void-unclear'])"
-            ]
-          },
-          "execution_count": 12,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "num_labels, list(label2id.keys())"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FmMUQVLXLj_I"
-      },
-      "source": [
-        "**Note**: This dataset specificaly sets the 0th index as being `unlabeled`. We want to take this information into consideration while computing the loss. Specifically, mask the pixels for which the network predicted `unlabeled` and don't compute loss for it since they don't contribute to training that much. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Let's shuffle the dataset and split the dataset in a train and test set."
-      ],
-      "metadata": {
-        "id": "7iCzXnImeWle"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "ds = ds.shuffle(seed=1)\n",
-        "ds = ds[\"train\"].train_test_split(test_size=0.2)\n",
-        "train_ds = ds[\"train\"]\n",
-        "test_ds = ds[\"test\"]"
-      ],
-      "metadata": {
-        "id": "MC4OBSUret9N"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4zxoikSOjs0K"
-      },
-      "source": [
-        "### Preprocessing the data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WTupOU88p1lK"
-      },
-      "source": [
-        "Before we can feed these images to our model, we need to preprocess them. \n",
-        "\n",
-        "Preprocessing images typically comes down to (1) resizing them to a particular size (2) normalizing the color channels (R,G,B) using a mean and standard deviation. These are referred to as **image transformations**.\n",
-        "\n",
-        "To make sure we (1) resize to the appropriate size (2) use the appropriate image mean and standard deviation for the model architecture we are going to use, we instantiate what is called a feature extractor with the `AutoFeatureExtractor.from_pretrained` method.\n",
-        "\n",
-        "This feature extractor is a minimal preprocessor that can be used to prepare images for model training and inference."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PJJQ4s9S0Iag"
-      },
-      "outputs": [],
-      "source": [
-        "from transformers import AutoFeatureExtractor\n",
-        "\n",
-        "feature_extractor = AutoFeatureExtractor.from_pretrained(model_checkpoint)\n",
-        "feature_extractor"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "F7kWNDgSzzBo"
-      },
-      "outputs": [],
-      "source": [
-        "from torchvision.transforms import ColorJitter\n",
-        "from transformers import SegformerFeatureExtractor\n",
-        "\n",
-        "feature_extractor = SegformerFeatureExtractor()\n",
-        "jitter = ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.1) \n",
-        "\n",
-        "def train_transforms(example_batch):\n",
-        "    images = [jitter(x) for x in example_batch['pixel_values']]\n",
-        "    labels = [x for x in example_batch['label']]\n",
-        "    inputs = feature_extractor(images, labels)\n",
-        "    return inputs\n",
-        "\n",
-        "\n",
-        "def val_transforms(example_batch):\n",
-        "    images = [x for x in example_batch['pixel_values']]\n",
-        "    labels = [x for x in example_batch['label']]\n",
-        "    inputs = feature_extractor(images, labels)\n",
-        "    return inputs\n",
-        "\n",
-        "\n",
-        "# Set transforms\n",
-        "train_ds.set_transform(train_transforms)\n",
-        "test_ds.set_transform(val_transforms)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HOXmyPQ76Qv9"
-      },
-      "source": [
-        "### Training the model"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0a-2YT7O6ayC"
-      },
-      "source": [
-        "Now that our data is ready, we can download the pretrained model and fine-tune it. We will use the `SegformerForSemanticSegmentation` class. Calling the `from_pretrained` method on it will download and cache the weights for us. As the label ids and the number of labels are dataset dependent, we pass `label2id`, and `id2label` alongside the `model_checkpoint` here. This will make sure a custom segmentation head will be created (with a custom number of output neurons)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qMdkERPg3ab3"
-      },
-      "outputs": [],
-      "source": [
-        "from transformers import SegformerForSemanticSegmentation\n",
-        "\n",
-        "\n",
-        "model = SegformerForSemanticSegmentation.from_pretrained(\n",
-        "    model_checkpoint,\n",
-        "    num_labels=num_labels,\n",
-        "    id2label=id2label,\n",
-        "    label2id=label2id,\n",
-        "    ignore_mismatched_sizes=True,  # Will ensure the segmentation specific components are reinitialized.\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "L5umptad3k3g"
-      },
-      "source": [
-        "The warning is telling us we are throwing away some weights (the weights and bias of the `decode_head` layer) and randomly initializing some other (the weights and bias of a new `decode_head` layer). This is expected in this case, because we are adding a new head for which we don't have pretrained weights, so the library warns us we should fine-tune this model before using it for inference, which is exactly what we are going to do.\n",
-        "\n",
-        "To fine-tune the model, we'll use Hugging Face's [Trainer API](https://huggingface.co/docs/transformers/main_classes/trainer). We need to set up the training configuration and an evalutation metric to use a `Trainer`.\n",
-        "\n",
-        "First, we'll set up the [`TrainingArguments`](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments). This defines all training hyperparameters, such as learning rate and the number of epochs, frequency to save the model and so on. We also specify to push the model to the hub after training (`push_to_hub=True`) and specify a model name (`hub_model_id`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6K0B3oqs3PR-"
-      },
-      "outputs": [],
-      "source": [
-        "from transformers import TrainingArguments\n",
-        "\n",
-        "epochs = 50\n",
-        "lr = 0.00006\n",
-        "batch_size = 2\n",
-        "\n",
-        "hub_model_id = \"segformer-b0-finetuned-segments-sidewalk-2\"\n",
-        "\n",
-        "training_args = TrainingArguments(\n",
-        "    \"segformer-b0-finetuned-segments-sidewalk-outputs\",\n",
-        "    learning_rate=lr,\n",
-        "    num_train_epochs=epochs,\n",
-        "    per_device_train_batch_size=batch_size,\n",
-        "    per_device_eval_batch_size=batch_size,\n",
-        "    save_total_limit=3,\n",
-        "    evaluation_strategy=\"steps\",\n",
-        "    save_strategy=\"steps\",\n",
-        "    save_steps=20,\n",
-        "    eval_steps=20,\n",
-        "    logging_steps=1,\n",
-        "    eval_accumulation_steps=5,\n",
-        "    load_best_model_at_end=True,\n",
-        "    push_to_hub=True,\n",
-        "    hub_model_id=hub_model_id,\n",
-        "    hub_strategy=\"end\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Next, we'll define a function that computes the evaluation metric we want to work with. Because we're doing semantic segmentation, we'll use the [mean Intersection over Union (mIoU)](https://huggingface.co/spaces/evaluate-metric/mean_iou), directly accessible in the [`evaluate` library](https://huggingface.co/docs/evaluate/index). IoU represents the overlap of segmentation masks. Mean IoU is the average of the IoU of all semantic classes. Take a look at [this blogpost](https://www.jeremyjordan.me/evaluating-image-segmentation-models/) for an overview of evaluation metrics for image segmentation.\n",
-        "\n",
-        "Because our model outputs logits with dimensions height/4 and width/4, we have to upscale them before we can compute the mIoU."
-      ],
-      "metadata": {
-        "id": "T3gr2e6ggAn0"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "from torch import nn\n",
-        "import evaluate\n",
-        "\n",
-        "metric = evaluate.load(\"mean_iou\")\n",
-        "\n",
-        "def compute_metrics(eval_pred):\n",
-        "  with torch.no_grad():\n",
-        "    logits, labels = eval_pred\n",
-        "    logits_tensor = torch.from_numpy(logits)\n",
-        "    # scale the logits to the size of the label\n",
-        "    logits_tensor = nn.functional.interpolate(\n",
-        "        logits_tensor,\n",
-        "        size=labels.shape[-2:],\n",
-        "        mode=\"bilinear\",\n",
-        "        align_corners=False,\n",
-        "    ).argmax(dim=1)\n",
-        "\n",
-        "    pred_labels = logits_tensor.detach().cpu().numpy()\n",
-        "    # currently using _compute instead of compute\n",
-        "    # see this issue for more info: https://github.com/huggingface/evaluate/pull/328#issuecomment-1286866576\n",
-        "    metrics = metric._compute(\n",
-        "            predictions=pred_labels,\n",
-        "            references=labels,\n",
-        "            num_labels=len(id2label),\n",
-        "            ignore_index=0,\n",
-        "            reduce_labels=feature_extractor.reduce_labels,\n",
-        "        )\n",
-        "    \n",
-        "    # add per category metrics as individual key-value pairs\n",
-        "    per_category_accuracy = metrics.pop(\"per_category_accuracy\").tolist()\n",
-        "    per_category_iou = metrics.pop(\"per_category_iou\").tolist()\n",
-        "\n",
-        "    metrics.update({f\"accuracy_{id2label[i]}\": v for i, v in enumerate(per_category_accuracy)})\n",
-        "    metrics.update({f\"iou_{id2label[i]}\": v for i, v in enumerate(per_category_iou)})\n",
-        "    \n",
-        "    return metrics\n"
-      ],
-      "metadata": {
-        "id": "eZeP3LdtgBj-"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Finally, we can instantiate a `Trainer` object.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "aki6vBMbgHJ8"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from transformers import Trainer\n",
-        "\n",
-        "trainer = Trainer(\n",
-        "    model=model,\n",
-        "    args=training_args,\n",
-        "    train_dataset=train_ds,\n",
-        "    eval_dataset=test_ds,\n",
-        "    compute_metrics=compute_metrics,\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "DPvhqbUVgIhl"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Now that our trainer is set up, training is as simple as calling the train function. We don't need to worry about managing our GPU(s), the trainer will take care of that."
-      ],
-      "metadata": {
-        "id": "y7ebFys1gO25"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "trainer.train()"
-      ],
-      "metadata": {
-        "id": "MVTWgGeQgRpB"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "When we're done with training, we can push our fine-tuned model and the feature extractor to the Hub.\n",
-        "\n",
-        "This will also automatically create a model card with our results. We'll supply some extra information in kwargs to make the model card more complete."
-      ],
-      "metadata": {
-        "id": "I96TvX-KgT56"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "kwargs = {\n",
-        "    \"tags\": [\"vision\", \"image-segmentation\"],\n",
-        "    \"finetuned_from\": pretrained_model_name,\n",
-        "    \"dataset\": hf_dataset_identifier,\n",
-        "}\n",
-        "\n",
-        "feature_extractor.push_to_hub(hub_model_id)\n",
-        "trainer.push_to_hub(**kwargs)"
-      ],
-      "metadata": {
-        "id": "m8YuKExogV4P"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Inference\n",
-        "\n",
-        "Now comes the exciting part, using our fine-tuned model! In this section, we'll show how you can load your model from the hub and use it for inference. \n",
-        "\n",
-        "However, you can also try out your model directly on the Hugging Face Hub, thanks to the cool widgets powered by the [hosted inference API](https://api-inference.huggingface.co/docs/python/html/index.html). If you pushed your model to the Hub in the previous step, you should see an inference widget on your model page. You can add default examples to the widget by defining example image URLs in your model card. See [this model card](https://huggingface.co/segments-tobias/segformer-b0-finetuned-segments-sidewalk/blob/main/README.md) as an example.\n",
-        "\n",
-        "<figure class=\"image table text-center m-0 w-full\">\n",
-        "    <video \n",
-        "        alt=\"The interactive widget of the model\"\n",
-        "        style=\"max-width: 70%; margin: auto;\"\n",
-        "        autoplay loop autobuffer muted playsinline\n",
-        "    >\n",
-        "      <source src=\"assets/56_fine_tune_segformer/widget.mp4\" poster=\"assets/56_fine_tune_segformer/widget-poster.png\" type=\"video/mp4\">\n",
-        "  </video>\n",
-        "</figure>"
-      ],
-      "metadata": {
-        "id": "dFzJ8Xb5g1Vi"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Use the model from the Hub\n",
-        "\n",
-        "We'll first load the model from the Hub using `SegformerForSemanticSegmentation.from_pretrained()`."
-      ],
-      "metadata": {
-        "id": "QXY3erc6g8LP"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from transformers import SegformerFeatureExtractor, SegformerForSemanticSegmentation\n",
-        "\n",
-        "feature_extractor = SegformerFeatureExtractor.from_pretrained(model_checkpoint)\n",
-        "hf_username = \"segments-tobias\"\n",
-        "model = SegformerForSemanticSegmentation.from_pretrained(f\"{hf_username}/{hub_model_id}\")"
-      ],
-      "metadata": {
-        "id": "gfbdz9Hpg9mI"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SQJkEqGxQwz6"
-      },
-      "source": [
-        "Next, we'll load an image from our test dataset."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "R57X_iNkqv6H"
-      },
-      "outputs": [],
-      "source": [
-        "image = test_ds[0]['pixel_values']\n",
-        "gt_seg = test_ds[0]['label']\n",
-        "image"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7m7IfMv6R3_5"
-      },
-      "source": [
-        "To segment this test image, we first need to prepare the image using the feature extractor. Then we forward it through the model.\n",
-        "\n",
-        "We also need to remember to upscale the output logits to the original image size. In order to get the actual category predictions, we just have to apply an `argmax` on the logits."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "8nNSSqEUBS2v"
-      },
-      "outputs": [],
-      "source": [
-        "from torch import nn\n",
-        "\n",
-        "inputs = feature_extractor(images=image, return_tensors=\"pt\")\n",
-        "outputs = model(**inputs)\n",
-        "logits = outputs.logits  # shape (batch_size, num_labels, height/4, width/4)\n",
-        "\n",
-        "# First, rescale logits to original image size\n",
-        "upsampled_logits = nn.functional.interpolate(\n",
-        "    logits,\n",
-        "    size=image.size[::-1], # (height, width)\n",
-        "    mode='bilinear',\n",
-        "    align_corners=False\n",
-        ")\n",
-        "\n",
-        "# Second, apply argmax on the class dimension\n",
-        "pred_seg = upsampled_logits.argmax(dim=1)[0]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oyHddde_SOgv"
-      },
-      "source": [
-        "Now it's time to display the result. The next cell defines the colors for each category, so that they match the \"category coloring\" on Segments.ai."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "Ky_8gHCRCJHj"
-      },
-      "outputs": [],
-      "source": [
-        "#@title `def sidewalk_palette()`\n",
-        "\n",
-        "def sidewalk_palette():\n",
-        "    \"\"\"Sidewalk palette that maps each class to RGB values.\"\"\"\n",
-        "    return [\n",
-        "        [0, 0, 0],\n",
-        "        [216, 82, 24],\n",
-        "        [255, 255, 0],\n",
-        "        [125, 46, 141],\n",
-        "        [118, 171, 47],\n",
-        "        [161, 19, 46],\n",
-        "        [255, 0, 0],\n",
-        "        [0, 128, 128],\n",
-        "        [190, 190, 0],\n",
-        "        [0, 255, 0],\n",
-        "        [0, 0, 255],\n",
-        "        [170, 0, 255],\n",
-        "        [84, 84, 0],\n",
-        "        [84, 170, 0],\n",
-        "        [84, 255, 0],\n",
-        "        [170, 84, 0],\n",
-        "        [170, 170, 0],\n",
-        "        [170, 255, 0],\n",
-        "        [255, 84, 0],\n",
-        "        [255, 170, 0],\n",
-        "        [255, 255, 0],\n",
-        "        [33, 138, 200],\n",
-        "        [0, 170, 127],\n",
-        "        [0, 255, 127],\n",
-        "        [84, 0, 127],\n",
-        "        [84, 84, 127],\n",
-        "        [84, 170, 127],\n",
-        "        [84, 255, 127],\n",
-        "        [170, 0, 127],\n",
-        "        [170, 84, 127],\n",
-        "        [170, 170, 127],\n",
-        "        [170, 255, 127],\n",
-        "        [255, 0, 127],\n",
-        "        [255, 84, 127],\n",
-        "        [255, 170, 127],\n",
-        "    ]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "f4BzL0ISSePY"
-      },
-      "source": [
-        "The next function overlays the output segmentation map on the original image."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "G3HqZXyQB7gJ"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "\n",
-        "def get_seg_overlay(image, seg):\n",
-        "  color_seg = np.zeros((seg.shape[0], seg.shape[1], 3), dtype=np.uint8) # height, width, 3\n",
-        "  palette = np.array(sidewalk_palette())\n",
-        "  for label, color in enumerate(palette):\n",
-        "      color_seg[seg == label, :] = color\n",
-        "\n",
-        "  # Show image + mask\n",
-        "  img = np.array(image) * 0.5 + color_seg * 0.5\n",
-        "  img = img.astype(np.uint8)\n",
-        "\n",
-        "  return img"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-yEXFytLSkht"
-      },
-      "source": [
-        "We'll display the result next to the ground-truth mask."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vnSn2A2U0RMw"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "pred_img = get_seg_overlay(image, pred_seg)\n",
-        "gt_img = get_seg_overlay(image, np.array(gt_seg))\n",
-        "\n",
-        "f, axs = plt.subplots(1, 2)\n",
-        "f.set_figheight(30)\n",
-        "f.set_figwidth(50)\n",
-        "\n",
-        "axs[0].set_title(\"Prediction\", {'fontsize': 40})\n",
-        "axs[0].imshow(pred_img)\n",
-        "axs[1].set_title(\"Ground truth\", {'fontsize': 40})\n",
-        "axs[1].imshow(gt_img)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "r3Chx4bXaCYa"
-      },
-      "source": [
-        "What do you think? Would you send our pizza delivery robot on the road with this segmentation information?\n",
-        "\n",
-        "The result might not be perfect yet, but we can always expand our dataset to make the model more robust. We can now also go train a larger SegFormer model, and see how it stacks up."
-      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
-  ]
+   ],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "hf_dataset_identifier = \"segments/sidewalk-semantic\"\n",
+    "ds = load_dataset(hf_dataset_identifier)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eq8mwsZU2j6t"
+   },
+   "source": [
+    "Let us also load the Mean IoU metric, which we'll use to evaluate our model both during and after training. \n",
+    "\n",
+    "IoU (short for Intersection over Union) tells us the amount of overlap between two sets. In our case, these sets will be the ground-truth segmentation map and the predicted segmentation map. To learn more, you can check out [this article](https://learnopencv.com/intersection-over-union-iou-in-object-detection-and-segmentation/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 49,
+     "referenced_widgets": [
+      "4b1915eae45c4710b6a3f8495093956d",
+      "b42d735eeb0043e7b318004de525b55b",
+      "d1148b579b6e41af99f2463a799d6c90",
+      "501ff9d5db294d928f6367741bdd8f37",
+      "a494ba6485a14473abcff9a343e1038e",
+      "6fda21b649114145af09deb02b2d1e95",
+      "dca0b5e19b504879b6e821f43ccbed00",
+      "e9bf0dfb0a574cceb00953779da8d5f3",
+      "8de21d3ac33f47a39fbefa6395d703df",
+      "2da9282150f94994ad230dd70d9ddbbb",
+      "faa9ead661124af59981d5b0cb5d38b9"
+     ]
+    },
+    "id": "8UGse36eLeeb",
+    "outputId": "682ed0ad-b48b-4988-b8e2-aa25d216ae76"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b1915eae45c4710b6a3f8495093956d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading builder script:   0%|          | 0.00/13.1k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import evaluate\n",
+    "\n",
+    "metric = evaluate.load(\"mean_iou\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "r8mTmFdlHOmN"
+   },
+   "source": [
+    "The `ds` object itself is a `DatasetDict`, which contains one key per split (in this case, only \"train\" for a training split)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "7tjOWPQYLq4u",
+    "outputId": "cf7abc33-2ce4-40c6-ee66-e8ce47a1c208"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatasetDict({\n",
+       "    train: Dataset({\n",
+       "        features: ['pixel_values', 'label'],\n",
+       "        num_rows: 1000\n",
+       "    })\n",
+       "})"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Yt_phZQsxz5M"
+   },
+   "source": [
+    "Here, the `features` tell us what each example is consisted of:\n",
+    "\n",
+    "* `pixel_values`: the actual image\n",
+    "* `label`: segmentation mask\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nfPPNjthI3u2"
+   },
+   "source": [
+    "To access an actual element, you need to select a split first, then give an index:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 217
+    },
+    "id": "BujWoSgyMQlw",
+    "outputId": "59c0dc81-3be5-4b38-f3bf-037133024e57"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAEAAElEQVR4nGT9Z7Bm63IehnX3m1b44g6T5+R7zsW56dwLXGQQpGyAZDGBgChRLldZkgPtKrv4QyVX2ZaqZPuXbJfKVpUl2iRsmakEiwQE0YgkCJAALm4Abg4nzJlzJs9OX1zpTd3+sfbMPaL2VM1MfWGttdfbq/vpp5/uF//6n/+LX//617RWiAKiC6OrogTm137ore/eff/p9tHLr9y6OHt6+7XjDNz12QYYdi0nvbpY/+SP//T//W/9XWM0APzzf/LrX/q1X3nnwZO833zirU9/9d073/76n7z2yiv/x//N/xZL9+t/8OWXP/7qG2+84X0slPnl/+T/PJw+BTIggogAIILe93px+Kd+7K3PfuINNVk+3O2iLvyjB//P//pXlbaIiIhKobMaAf/4nQcvvvmjk2l5dTH77FtvvvTqazGph7186zvfuvN7v/E/+1//B0fXbnHOIpIyc0YkFlRCKEgAAggFgNNCiEqRMcYZVIiAwMwxxvGqiBQiEarg26EfTk5PTh49WiymWdIf/ovfff+9t//wi/+MSBuL9WLStM3nPvGnXnnljclk+Ydf+P2vf/OLyJxTECZE8nm4fu0aJJ7Oph988OF8uZjPCz/0bdesV5vB58l0LsgAzJIItbW6bRpn7JXjKxfbTVnZ4JMyCQC71jNzihJS1gilq5fLZdvtJvW8bVtjNRFsNtvXXnvFWnv//oO+6xUpo3Xb9lmEM1y/eaQIzs82Qx9u3T48PKqatlssDpC4rAofhq7r9s2+KhZvf+cRKbCmRIQQktaqbbvCuRRjShKGSCiuLBPn2bz+5CffvPv+nf22y0l0k/qH50+VUiiEQE7T1ePj5XSmiGaT6d373XTiX37tKlrqwq7yLF6Orhtrivt3w8X6otlvlweHAGAKR0RImHO2Sl2/dfP9u3f6zg/9wCl+9tOfqQ4P3njjk7vdbrNe33zpY9979NA5FFGAAiDMwpxYBEHlHJc2vXZYn/fwCAEABAAEEHE0lMLao3m9OT8p3XUU6PseEAB4avFzb336zm//8vmTx8urL3DOiKRIKWQEBKUFkDkDIgJWhma1BkIWSBlyBkAABGFE0CAAACAkAoycMpByTdvW9TQGsIVRWj98eJ8zhBBdUXkftdYgyZFCgaHv1+vV1aPjvutjDCICCpp92+53Xd8Bwm63ns2vOlemnJDIWW20boe2KDVksEZzzoRUVuV6t51Mah965wof913bx8iECIhKEwcWwe12K5ByDrPZJHPqup6IQghd1wFISslVDpBylsSZGWL0piq01pOJWSwWfb8jgv1+V9eThw8eLw5nXRs42d22A6Cc2LOfL2prDTOmlBAh52ytizELsI+BmYcheJ9i5BSTs4VeziYaUQGqUs8Oq1lZXL1+4CaU6lVxNLz147emxyzUPXh4Dmj6tgshTyZO6zy5MqOw223Xo2HZwuWcEzMLV7b49Gc/9vad91XTM/P56cXv/sk3P/1jP3h4PH306MGVK7f+8v/8bzR9++SbXyMCAAYEARYQYRbB7W47n5dWFS/M6m2hCAmeWReAMOeU4tF88nCzh3iUQ1ws5jknAeU4v3rz6EffevOD9959+TM/xiwgorVKcSi0AwDvvTWEQAiKgfokFhCQWAA4MUjOGS5dIyFgDJk528KQBiFYLherkzMk3mybP/iD3z87O+lavzw4KIvyfLtKUVIS1pRyTjmllEOIIhhSQkJLbr9vrdYxRmusKWi3W2mliLQiVVW1ccV6vyEkIru8snj08HFZOFu41HsiMsYIZ2OMVhz8oJxGAAIJAVJMIeSY/HK5UBogK2M0Z9P3/ejmF4t5VVbNvu+HMJ3VwxAePby4euXIFXazblarNalwcDTPzG27365z328Oj6bWMmd7cEDWlv2wL0u92+39gDEmrZTRBhEBIbMgMyEGH7/y5T+p6xIQkVDPJ66w1bXbixc+fvXoVu19H3NsY/OkWU+XUyXydLVyRrEoEWhazxlTyJMZsu0RVg+ffPjiy68BQOGs1tpo4wETpIPpoqwmoR2Yc9vuf/mX//F7T9/+3d//Vevstasv/C//V/+7N37ws/e+9idOawAFCMDMgBDT4mjx3ffvPnr6pJhXuqpWq41CzIICMaWolEJUmVEr2p89OAE5nLiu349mR4gG4VMfe3lVXemGXisKMRqOj+5+bzqdXb/+0ubi7PjKoSoKzhBzlCACShABlWBGACAEGO8MEACS7NrOFpOcIpG+OF0hqgf37gmm4+PlB+8PwrDe7NqhM9b4vgelnCtzopyyNabtOhQkIkAkRYv5winKHHPOgDH41EWvlDZWscqBfVFbiwZYCuusLnLOwfuisqhi4YhFiOzQRcmcQyqca9shRwicrDWKeLvdzmZ1ymCt9v3QdwNprOtaEaGAD6EoCwSNkHLCGEVprOtiCHFSO+3q85OnjrSxEEJIDK4qopeM/uDKlfUqxdjvmj55DENUCuu6IiSlFLMIC2o12hkCMkvMmax106uTN3/itfoaPVp/eLp/+uHTB6v97mK9f/jg8Wa9FdbNjrsmr8/3hSslU9/w9ixSUl1u/pvf/rttvwcA7QwaVCBK6ZRSVVfTaYnEmQMi3Lx5Yz6vTs+f9KFP0v69v/uLq8364MYtXc4ETIqQs2hSnGExn/+FP/dnsaj/43/wD//Wr//aF+/doVoxRxFkhpQkRg4xI9Nrt6/rPJRKHCkEFBCjtEKVev+xl1+JKaWQ+mb/wZ3v/PFX/+APvvDPnp7c+/Z3vtp2OyLFzCIIglFgiDlkjkxJiJEAySltldIajKbz86cxRhElTLPZLMZw88atGPODhw98aFnSMAzrdds1SUSsNYoUIYkwMxMRIipEZE6Dvzg9a9pdjCHGIMwiQqTatpvPZ0pR8J5Y+r7run4Y+tm86lovDNduTEllkaS14YyICoCiz97nqqq10TnnqqoWi2XXxb7PCtAa60NARK30drM/P1+HEJbL+cHBHFCms0lVFT70wxBSZAJdFNXqYtc2QwisSGllm12DLAJ5eVCHuAXMPqSqqokIAUSgbduyrOqqFgZEZGYRQSQiijHGGHU9mUwP3ePThyH22pLRulDFdhVCZB86Ms18PtEkikhyYjZa6bIqMuDeR1uob7z9R//F3/tP/yf/o39POyOQEQUAUspVVdf1/HHEb3/wyBl1eHD0+PFZOS2bLn37W3ecOv2//J/+b//aX/5rofO+2Q1d852v/vGXf/XXEGjoutKZzvOTi27NpxdD+/oLr57fPQdWCEhAIMRJUElRazFlVbvj5QEAAAABAEu/azgkN7EQZH1++u1vfOnBw/cBEDE/PXly9fqBqxaKLIICACAC4ZQlJVFKAWYCFs5WwFktyD72wmJN6f3Qdh0RHCyX3/jWviqrqpzttucAIpy1RmSllAIAEWGW6MPx0bEmfXF2BgAouFjMYmrrer7ZbK9ev3Z+frpv2qqqjDG563NMmjBkPjw8Pj4+6vp928TZbLZdt5t1XxRKUApTep+ECRCNcdaanAQB+364dv1ot9unIK62nJJWlHLSohDUyy+92Ow3Z+crW9jlcjqZTO5295AkZ1Gop5O50bprexE4ODg+Pr567/6Dod+uz1fVfKo0AQCSBB9ilHpSa9IxBGN1SsEYxZlRAAkBlFaKiJjFWquvHh1U1WS336LmIXJoGm3QmKJrOo0VQkhDNNoESb1nFq+yan139fqRTzz00U3Nr//zf/iJT/3gq7ffdLpwRbkHSTFU9aSoyoPrt7/5wVld1cX8hlEHjW9hgLOTi7Z5/O4Hj4+PbwiQmSxfev31t376p5y1//SX/itW+rzpf/tf/sueySTKQYfkXaliF1EhCgMYArAK0ejEkjkZawBICTEykCCRcAahEPs7d773/t3vpdzlFN955xs5p69/84u3X3zTWco5xUSIiEg5ZxFBTKTAKEIEBSoJx5S0Nn3TTeeaFAgBA967/2Hq9sez+QcxK6WjD5A55yggZVE552KMOebJpIx+0K6czScA0g8xcwohrTbb2WwSYqjqGkDlnNoukBjOrY85JUaUEPui1K7Q5YR6H4WhaXpncbVfA6CwaK1HVM7CpKQozMXFeQhhsVhwxpCGsqx8iCHEuiwQBIEQsK7Ki4ttCMEo0sY6Z5eLBXPshk5p1EY/OT0n4pdfvvnoATb7ZnWxQaSynMzn067zft31Q+uMQdRvvPGxzP0wDNuNSynljDmJVQoRjbWIqA/m87oonz55YgqjtRkCVsb2vSdUfR8Moipdigm1QjQIqiwLRH92epEhKScppqND/v/95j/4t/+Nf08ZY5QiIslCAsvlwQf3Vg9XrW3S9PBm5dzNwu535/PJjX2z//JXvv7Gx8NiuTRa9237Az/w8l/+H/8777/3/oePTv7k7t0/+N67rWTYtVVdhpB14fKQiUhEQJhQA4AiUlprRYXVQ0YAQAARycwhhgTchO7uB9+7uHgkHGIYCPV8sXz88MOLi8cvvfgp5gwjWgdOAFpEERASCnLChCI5phy7rv3db/3TK1euvvXWZy1pn+XBvbtf+ePfe//dd1hSypGZEUEpzAxEtFqtlKpIKc7cti0JoYKqLKyiEINSejKtJpOyql3OWWm937ZtMwCRCCOiMRoJrcWUQz2x9cQwaleozSZzDlVZGy3tridSTdMpRVprAECFKXBV2xi7ld9rTTmpvu9n87osy9OTk9lsprVt9l3XDcZYpVTfDdOZ2zYXItk6XVQGBHwYHj9+HCKXRR2GvF5vympy8nR1dDw3WnHMkjjmHFNkzrPZrO2aT336zRDCB3cf7PY7ydkWxmjtvdelcXVRaTRKFIlUk2LwvSEz+MHoomv2k7IgoGGIpJTSmgX7LgMSoOKcU8qr9far3/j9o+mNhTMIwMJh6Dml6Ww+xPzeO99RSjvr6kk9m81n9WQyX7740kvv3Tk5Oe9ff+Pll156OUW8e/fepz/5A3/13/l3f+/v/+I//C9/aRPipt1XN24QqvOL1bKegwCzIApABlBICCCcszZmMZ893TAoEIGcmZlTzhnk4vTk/jvfWa/PtSPO2Zq8W69TzE8ef/ix1z6XsyACs0KUiphQEyALAAhSJrJIRnI0hvp++3/9T/7uT/3En/r8539MK6UJN5unWXyMSSuiwuQUgLh0JZEqyzKEMRqy1qYfelTo/UBGgQBzns8mIfn9PqQUm6ZBsDnz0HeAUFgThVPKiLbvm3qi68lks2kQ0ahCa7vfd85pa7X3wRhnHaUUEXE2nRKSsWKM3u0b7RQRGFOVtvA+hBA3m20MaYj9ZKq15rYJIcYssQsNkeq2fGs2zXl/fHylMNB3cX3+dDFfKGWMUYdH05RCjMkZ04UhCQPQBx98eHRl4f3Q7h8G70McRt+viIaUU44aUq6LwigKwQfPutJFVUsWrVO79wI4dAM6JxkFBERiHpQTYFFK58xd39OkDNR/47tf/KGrn0IEQuKcWXLMkHMiQuY8hGFYDWdnZ4pUWVb1fHbrxY9h256eb159vXj/3ju/+etf+7m/9GcP59cOb7xUVGUcusLYYej3u+bw8KpROACjkAiIMOqUGCQSZEg+cYqMyCwoRKCODq9U1WQX+IMP379YneXOM+m6KInI+6hdePDwbs4RkAFBKa0ItEIiQkBCMKQICYlF5PHjs2/+yR99ePeO1vmb3/rK66+/Yq17773v9e3Qx6EfhHMmjUU9sRYRGYEAIEsehi7nrLXJwgTKWAeIOQXnDOesEPt+YMkxsu+7lDIL19OKiEEyCNx5/97yuDbG3rv3KCfYbUNh65RjzjlGIGMskFYIkJUiET49PS3LqizrzWYHhAKYOC7n8/22z3lwziHqGJp+GGbLhdZYz8xMVUbTfD4bur5UZmjB2tIo2O32kNx6vU6caleQoLVms2m1toKMikjQaDd0/XbdHF85eO/d+7NJkVNW6hJhxRAEUFtrM8tmu5/NZwKCIDEkrXC+KNv9LifyvTaExjm0oCBbS9a5GKBtB2ud0ZlQe4bT5mQ9uWqME5Gcc1WVwzCsVhc5eq20AiTCmAVAvO93T/fV7Ojhwwffe/vtru9+4ef+0uM7d3/lH/6jv/E3//2D199sSy0KrDECeTIp/RCrg+M2N1qRiIw5CKEIEMgYy0BAWESjKI2m0LYwAOrJ45O+95gh7JIGRhRmdjGfn5923b4s6pyZVCRLZBSnbLX+2pe+8K0vf/Hateum1A8fPbDWfP3rX7AOlwfl0He/8Zu/8vrHPhlSN5vN+hh8t1VKKa2d0zEGRCAFiIgAiOiczTkrpUVk3zSEVJVFVRUC2Tqdstpuh77zIHrMPLz3Wol1zvvgSoOkY4wgEGJ01oYYtSZESYmDj0ZrwDiZzIchtG3LObatjzGIgK1szpKiDEMQAaVUjElrrZSy1uUIVWGLpYshlLVy5WRPpm9D2w62hKp2jx89Dd1OOxNCElCYpagqY0zbDH3nERQhW4VuUimirm3Kyhlnj49cNZlt1ts4ZolAWgBuXL8efNjvG6UoDaycskaosFpTs4uQs1Yq5VA7W8yK0A/WlDn7wXd9H7QmrcVqFf3+4e7hMb0MgCBCSOvtZrNZPXrwsHBFWVXOWaWsspUAK4WKyFiVOPzmb//GweLgL/3CX//Hv/iff/drf/yZH/ns/Or1+OhBPyRrTNe3ZeFiAkSNAEgoAoiEpFAZzBJjBGERAAEBzhwyJgEBUVqXXe8/8fobP/IjP1lPJq4o7t27b0tz86UXGFJZmIcf3v293/61z37urYOj4xdeeYkFv/W1r3zrK3/wHVJ96rKksqq23W4yrU/PT6ez+sbNI2NV226ssykzEAJDCAGEUStjiUYqFyHnzAxEpJRqurYsq2qiC2djiBWqnIPWlBMDKICxdkQIxJJh5GcpFYXy/TBfzDcfPmIhIur7jhTkBMaaxWxxfnb6xhs3Hz58uFnnkeDYbPaFK4q6QJDBx6rktm3ni2VZuGEIMcXj4+PEXikjGZwzQ79nadrOh5Tn05FKIBCIMRpnRfBstSGkejIpy5ITncX94WJhMJdFKZz3bVOW+uWXX0wpJj+cnp+nJMZoEQFgzZom5UQCixYRadNgswVH01ofXzWVrc5ON6uzeOVavX66qyZHtihi9KSlrMq2y5khRTYWBx82fn9YSBJOMbAPcd/M53NCHYIfhn673eSUjS506YqqxBz6rgnSXb9963v33n3xzos//XO/8Mf/4p/+yE//RFHNjXFlWU/rWpElRdt2R8SKbM5Jk82SrXGvv/mZd95/b7/df+0b35vffkUEEamLaRciXKz7cjqZzEnrz/7gDy8PD0LvC21fuHWrqqYHh4fnTx5AjJbw/p13v/g7v+YK9+//h//7Wz/wmZOzE+1cFlBoyqJuunbow9l6HSHpyjx5/KB008K6ptkDMmoayz05s1HaKqOVERFESDnGLFVZBu9TSkrp6XTqLE0ntXBcr9ciknOcTSZt12dmSWKM6Yd4cG0GAK3fIbDWOLTdres33n3vgTBZRZEZUSmt9vstgJytzpquU4Tz2WLf7EJIxhrgrJQtCgMAyuiU8uHxwZPHJy+/+pK1Ombftk0IKYZALlqnUVhrQs4ovF7tCdX1a9d9ykPwRusY477Z37h2pMAQnBMgkbFlsdqsTWVni2XmEIPf74fVeaMNzZcT62zOSfcxKXKFnTXNfnk4nykdk58tZwQAKlYTPkiGgz1YTrqBtpu+qBSpqAzVM9s0ndJWQIQBkGKgx83pdrcdZpNmvz/QpeS8WC6M1iISwuD7rm/2q/1uvz/f33qp2W2ibw4XB69/8rWv/Mkf/dzP/9XJ1Rt379xdr1cxJkXKWjubzQ4OD0oXpstJVVAKiSMMAxstiXdOS2JzPrjNo4bDAIoudv1kdqONwnJ6ODOvvvSxX/x//O3NagUcCwXOWG1sAqmnB7dffvWv/fV/6zOf++zJ3Xd0jP/4l/7Lf/tv3t5v1lGSsYWzi/fvvt90O1TqfLet6iJHWa8v8otDUZTATACKKAISkXXOWquUIkQWQcScU4wpO9Zaa60Xy8nQx5ykKFQYhslkst00ABhCQMSxYhNTEpHMsSzcZHHQNl1RVIJw7drV+w/ONqsGDDlnbVnlzKv9WWZ4enI6qaaQwFgDAEXpqsql5BGoKAtmnkymhSt3u511Win0wWtDzCDC1lplNaEyRscmlfNyGPY/91d+7itf+uMY0un5qj8fiIiI2qbZt+V2u7dO977DygX2rrR+6FbrC+/Dcn4ITIiXFTetVUpRv/3u+09On7pCJSi6dphO6mHoQx/OznZHV6fO0uxgcnbaf3j/ydVrk7YJSIXSUtRQzYprpPfroEn5EOazydwd8sA555S573oW5pQzZa304L1Inszni4PDgxD6vidIqNhYk9rm9P69zeOzP/zd3//sj/7wr/3Tf3T7pcNi+slm150+Xa1Xq+vXDu68d3+1PismMCnc4eF8WlZOtQ+eXlQHy0i3Pzhdtd3JfrsDxOl0Vk/LqtzcvHZMuTfkfuD1z2y22xAaTeJc0XR9DMEqe3F69ru/989+8od/ZD6fiaT33/7mP/g7/+nTJ3erGp2Dk/P1vt8OIShSoelzTGVRBMYnj0/6/VZSjj6KgDEmhNh2nSucCGfmZt+4okZARTQMQ2kLbQxLKCo6PFyuL06FAZH63seQY4yucJlZcgACrc1+v/ehu324CBG6dlBE3/zGN3Pmsixi8CnlFDtjzHRaDn4ghUPfc84nJ6daU1UV1mkZUl3X3veo1HazOzw8tJaePH283++MsUrjvtk755hTZYthCM6a6fHBbDrVRt57753dfv9Dn/uh4Wtff/jokSip60ppyiDKmqouCmeL0obkO98jy27bFGXR9/5itVYKAYQFQogAoP/g9/8oSDw8WtjGn682KXNZTJMPs3oe/DAMsS6n2mCzJx9Ikn7yeH14WCKaJFzUWkRBppA4BdVu8bNvvPnVs203+KbtzzbnIDKfz6qyartus137IURKiFSXExJ48fZLICojf/OPv4k+NK3/4Z/66aPrL/7u7/+yZL+YzK5/5o35dD6fly+99ONN151cnJ48OVnv5PHj9W6/Rgx1tfjk5z6e4loEYg6M3K28bnDq6tDuf/qnP/ftr/zxh93Dejops1WaXOGgaDDLwfL45Vdem84mH3x411au3XlC+pe/8xvzeV1OS8+71W613e4TcKls6IdKF33jlTEKzXK+aM/cgxBFtPchxjyd1tOZ221bFihcmbKIQOHMYrG4du1KyEPTn7mimE6L/Q6bnT8+unJ+ttaGtNHGuSFFYbbWTWfz9eYi9Xxx3iyXc9CRc3auaJqdNS4nAkW7XVMVbnkw6/uIWeWUtNbRJxEhRSF4EZ7URfAdKbOYzxDTet0Uzu5De3Z2XpYFS8yRUFHI+9KpV1+9fnayfvho7Zz65je/eX623aw2r7/xsfmsDswHR/PVeiWJSVgVmHLaN33mCAA5Q996Z+piVh9fhd1m2/U9MwCSJtJ/5d/8c6Lkt/7Fr/uH/dWr87OzdQy5qi3lvkDttM5BSqta5if31642Oavt0wiHpQohFZnAGFPgAKWebS7asp7fvP3ilYODfbMdCHVBDx5+eH56cfvW7bquY4jAIsAp5V6yP03FZFFX9cROLjanMeRf/cf/9ec/96k3Xv+pL/z+b6+ePplPN03bWKdfvH1jsVxMpsVLn38rZ3n89OLb37p7en5RuhuoihB8TH07DMBZmMhLrfE7X3/nUx+/nlPoh0FyWl2c5RQPD5Y+hsls7uqKlJ5MpmenHw59H7wPGSDnw+OalAeJRaFYkEllGEutvN83pi5n81m/WyXhSVVvmo5jMIS3b9z47A++9s9+54tIKCApsYhcuXJ87cZyPq9W6wGxBlJPn174IRljnz49A0RjFCkZhr7QJqY4n82BKOfsrEUpuy4WpSCgzzmlHHJXFKWPSWtjy6qezrebvWRYLCcgiKAG7/u+hyGmwFW5Z0ZJ4rTb7zvnCuYk0lqrmTkGqCo1WdQx94vZNMZkLaWklDZDn6bT4uz85GJ1cXh0GJo2BB+THwaMKcyX89os7tx51xXKWsMEiLbvwwvT6cc//voXv/DltuuYmRRJzPo7H3ypnta3X1leu7lYr/YppYcPzrp+IGJrrbUqZzm+coypT50g5MzJWRv7ZGtKKROwM9qQOn+8ptR+7Vtf/9n/3s/+4Oc/95u/+RshxMODxdvvvMMhPX7wwesf/xhAiD4QOWFkIQuSu22C5EM6WCxLV54+fvqlxD/2Y3/hJ374p37p7/+dO+9+W5PkdniYzp4+XJsCjw7mB4fV0cHiL/35H921/tEDWG/2oonzwN4TKadd4kiCTuM3/ugLsdsvJ3UW6dv9dtVmH44PDyeLxaysY8za1B977a1vnJz5tBFTVItSFynEvh+47XoRFJ9ZRVKUUpTMybntZhv6pu27oe+QWSt64wdet1YfzKtJXREpIgJMiLjf745y1bQ5DpGjHvJAgNYWYUhDH5SmGFIMnCMfHx3tu912uz48PiKizBxjZMnVpEyZd/utczYnAEDmJMIh8eMnT40x9bw+ulJvtztrqrbtQAmRCcTOFcbIft9tLs4XixkixRhv3Lx5584dyNJ1cTJRRFA6t1ws9vsdS67qYuiDMcbU5H3vB1mvNmT10Hcx+qgIEEXSyenZpJ4WhUo5JUg3b9+8/8GDfbO5d8/vdnsAAkCjTIiskz55cNpsVr7vYkpROXClOCRhHQb2PqCYnHTfxJyzEwuQUs7Nrq2mE2GNinKXrS52IaS+feedd46WVz/1w5/f7doPP/xAlFnO5x975ZW3v/u9ru9ns5mUFTP74IP3OafMWREJS99cKEi6nDWN+/JXvvYXfvan/6P/w3/89//+L/7mr/8KxLBv+tK51ME2NDbk0itoQhJUeEiuRgPOLhYzSSkBAGcGoJdevH3z/Xf29+63Pty5OPMsGqnbb0Py56szp83MWLtb/8Wf+8u1/on/7z/6FU04WQCDH7p0cdGcn+2bdkBQxaQQxJw8KZeCKG02u3XnOyAIKWUBQvif/ru/cPPm9S9++R0QAGDOKeeYc1RG933nBy9EZaG7ZugGr5UhwsViuZZV8BkhEEFdW4HIudcWDg+PLp6ez5elUroZMip9MF/6IaxWW4WiEPp2r5DK2STnbrfrycJu7X3I3g/WmpSi9x2i5gRVPRlCL5hSzD7YzKzAlKVr29YHf3ilbra71cXu4GgewsCSXaF8GMi43ISuaW+9eK0dGqsdESnl2r0XUMIpJ5zUs8XCPHr0qOl8Pwybzb7vgxAgUfY5h6R/+MdfTilFr4YhhhD329y1QRtghu2mf/jhLgSYzeph2KzP+2EIZa2Ncz7G3dZXUycogYPVYp2rqHzjtVeXB7N93/3YT/z4O3ff/+Iff+3o6PjzP/IjIeXValUWFTMIJKXRucQiAtx2awBUBJH79ukjde/Oxz/5+UdPTj7/g3/mb/wv/ubpyeoL//K3taW+D6U2q9U+D50NovMBgPuhH/z81Td+NOSglTHakEKtSCtz/97df/6rfy+cvp+sfvXo6oebswhSVcWLL7zwrbffGcJw+3jxp25/stqfnP3qP3w/9CHn2HXFJJyeNJzVZu37NuUExgAippSYMyCXZVmVlTIFaBvZ931fT2Y//ad/qu/Of+f3visAxhhmHrzXWhOp1WqlCUBrDTmEtG+a0rmqKpnL7WY3my4GMzRNlziGGGazKZG2WufYz+YTa5HQCEejSxFRWs3n04vVhVJmNqtBEIBDDNKhrZAlD33S2jhXKkVN0ypN1tWHR7Wx9PTp6YsvX9nuWudcjqIQjHbOub7piQlAhehFhLP0vQ8xSjbKGExRhFKUXdNfu3YgLN3WF4XZ77uyKL3fxpRCSM45IiqKYjqrQwrTabk9a5RSOmXPwroYCtPNbX31xiSlBJBFEHHxoz95k1kNQ/jxf+3mZh12m2633w0+DUNcHFQP7q2MIa15uSyfvi3nH/j5ZH791uz+0y9PbfXX/s2fufnS8v0P7tULKCayvntqjKnrqXOF0aVSGYkFGACEIeW8223fe/eORCBTH1+7+id/8rXQro+PFwKSUkaRNmRD5BX2QwREhXj//sOvfvBbHBMiCZBxanmweOn2izdvHN64/fJ3nt5/cLrJT3dSLQwIWufBzOaHMxEy9Ef3Hkrfvkn6/OpCm1iUOkTpB0+g+r7PIoo0sMSYR3KfOQ++R3Q3bnzszp33UpLl8vDnf+Evvfba9S//4W8+vti0fRSRnC+z4WEYEKcAnHIqnLq42DMzi6SUODMicWZEtKVBS5ABQLQmjdZ3qW2b2y9eAUFnTQyhH/oY4mKxzJJX51tO6fU3Xv7e9+6myHU9DWnvKtXsYTKZ9X2Dio0pANN8Wbkq1+XkypU3Hj5+2LUeAJhTjOn6tRsEtNn4ST3NqR2LsCHklBMgk8pkEANut3tXuOVsMfRekfZ9qqtiNp237aAytH1fuKKeTpp9WxTlYjFrh26+mG/PG2udBhDmKBKYOeeE2mcOWmtFiiiDcExRFzgpYXJgFdVEV5lT5qy1BH+ra3vSbK36l6en5+83AMqVYdt9Yzeo2s0+9xPFx3/wBe/v/6k/t3jtzTeePGpOTj5U9dx33HWioJzUk8JNM2cj6fTk9MVbt8piev/D9+YH87g/+fm/+uff/IGP/4YxKSUCzJlRqyFIEEgs1bTO1n35934/eT+tJyQQJR4eXfvJH/707ZuTs9OTtUeslySUciKAzPj45IKUJYJsXTddHNTFWz/zE7/xz//ptE1n27OEsWl206KSrBMnlFEvTZBECBhYaa1NUVXTm9df+cC/96M//LlpBV/60h9eu3blyXaFiMJ5GHqldYohhUgARDCdlEoQgKraGmWMUVHYGIXEs4VjM+n6vUjuPTtXzqa1sWYyLYuiQMll4S7OLkY9oFIaCRVJ0+7Pz88QAFEvl4enu0AOJzOtNAHyZOL6fkDCfmhv3Hj54smKruDZ6X67GQBzToygrl+/Op3Nfu93H3WdJy0sgkzex6HLs3nJnJXBSV04Y43VtS7atnHOblXXdf7w8GCzaUKA0lV+GGY15kuFHOSYHz58kpm7vtciSEqzRKNLAEx5IAIiJALmJIIsYqwGxMxjv4tCxYVTLKHQXNQQk1hN1gmj9D4oxbpolVIefAJVTWw1g+XV4tU3b6agwpAAoe/k9GH3pT/4YHOxW2/Q2okrJsz5h3/kh65evf5Lv/TLzfb0ne/t/7MnD37+5//iZDrdbjcsQgKJwSeJOQ8hrE/PZ/aFGwfTzcq/dPOwKt333v7usqQ8rL/19Q+Z5fTkTBBBUc6CZKwziBgykFaVKdoQmth94Z23Ty62124cPz477VOMES+aJiVgzsikiYhoLBdVVXV4cFwUJga5euWF3X71O//id7773cWVa7N/8ftPy3qGeKCVQTKxC8y8mB+KoCuKnNIwhOzj4XyeOcUUu6GfTCaooOkb4Qg5KbLC0rXd4eG871ukLJJZJAQ/mVQvv/zaN7/5Ta1V2/UCDCAPHpy8+OIrfuh3u50B23V+Mpkq0l2nqqpumjNtLXM+Oz3fbbem5JdefvGD9x9uNm0MuXB6Mplcv3YdBJqmObwy3e53yasUZdQnpBi11da51fkmRrDWLJaTuq6nk6HrYtv0IpJSLsvCGKO1Hj36MAyK1KQsVv025KQlqZhyyIyY67rIiUlRylGyeO9BgEiTaKU1IqACRSRMIKDQipA2OMJPrQ0jhBRyhsIumFnSkFP0DKgUEUpCbaioQYjrBV2/vnjz059r9vH+vZNvffX07W8+9V7Kojw+OiydGhuzQPBXfvlX+q4TkbFLh0UAKA9R+th04d0nX6kntXXY9jsfVFlNdvv2H/3Kb83n9ZMnj0SCJgCNnHNoOQyaARkFAYZmo4zrQrc+eXT7+nVrC2Gds0pBMJEAAkRAIIVGUWndZ976lK3mHPNmd/7gw4dHi2s5ix+EuUSqLrYeVxc3bx0opQUxMyvSt166cbK6n/NgC6u1WsznQ9saa/3gR2mP0RbIEiDHxCSECISZoWk9ksQ8UFYx+8l03rZdWZYAIiCIRCh9n64eH+2azZ07dwCBRdTMBB+7rtvv1WRaIREI3r//4NqVZT/45WR+68Xrq9VdQTq6dnUI4d7D+/W0EgERcK5s9w0AzOaTnCNnUQLD0DFzThAklEVprc0cFWlmCD6SwsEPy8U8xJBy5hgyZwQ1n9bnJysA1HFAEW2oRMKhj5mD0igcfWKtjSZCQGRIIQoCZ46YEGmsYDBzZBBAoqytsKTgkx+y9IPWWpGJKQhnJRpRaWMpYUqZmUEDqKitmR3BJ5bL1z9+8/xP03vf7c5Onrz9drvfbz748MOXb7/4yuGN7e6MMWuNvvfCSMoo55C0APshPHl8YYuiKgtkyTl5D5tVv9nF4+OF1gogQJ9DLy2DAivsY07CSQAzGqMMCgRkgeyHIQTPkISjIk1gIpIgCeeq0J98/TOlKy7aIaacOXEeSOnBp8ODw4+98UbnT65eXT5+uFIa275FUF07tLv2vfa9F16+bgvJ7DWSYur2WTIZNfaWITNzzoAAAjkwE7hliUiotWjZ7vsqaFeYg4PDh/efxugRMWdGBECNFN59/05dmxgZEK3Vw9A3TT+b1sJoLCZOIubgcGor9fRkUy2W2mVXuum8Lqri29/7Xjmxi6NZu233bU9aFZUx2sHYB8kYIwMzoSVK1tF+31inQojRc1lZUoioDg5m1uj1Zm+NLks39P7ifFtVVNZl2/Q67VhrA6CoiPXUMbqUY8jiSKEoS4aIQFgRM3AEbNsmRlSkJ5PKGJNzEox6WoJGZmYWEGJg0CCMRmsUkCyAWSQq4xSWGYMhFfKQY2bJgmyLcONVVc703Tvx6f1H9VJ9eO/u8bI6OcGj46NPfuqNsnDvv3sXI56vNjF6sjPU4EOfcopte+3qlZ/5mZ/JOf7hH37p7t0H221jdZpPnRCUhTWsM+CP/eif+cQnXmrabU7xj7705Tvv3i0VEoJ2Sku+cuWKZNTKcuGy9wSKSHs/HF2pX3nt1gd37/omCNijw+N+d+oKk5gV0fn5+e/93r945bUrn/zUD7z6at5tfc6stbos9STfNM1BOYkpMUAI3vtMGoFARITRD6kNPoWYYhYBjYQs+93eORcgWlspxSHEs9NTwJxzPDq60jx+yizC2Zpis97nrJl5Mp2WlUs5LLTRYPqhN1lFkarUywNrSrzhFuv1+cHh9M1PvHL65PTi7KTp97ODGyi5npcC4JxNOYeU2AcAPL5yfP/hw8IoSRx9LKuZc0XOSUSJQNcPxurjoysvvnR8fn5RelfX5Xa71sYog00/WFtVZaUn/lCD3vdrYtMPUZeWhbQ2oIS0sqStpb7vJTNzAkBrXBj8w8enwafJtDg8mrtSxaROT/dAEHMgm1lzHzvlSCNRUlkiCPLgVfRVVSZOOSUBhpyt0Ykx5Xi6elyWxVs/tsg/NP2pn731wbfzm6/82K3bt5TSd95/7/69e6+++NLZ03NEHNo9Jr84KI69etjsNrvmnbffPjl9qrVabS6MKT7++ieIqKyc0oVHDUgFagYh0DeObtTT6v69J6dPt1qgdK6elIWpDpYHn37rJ8QVf/RH/6T1O1SsAX70Rz5x/frk7OnFxWqrQV85WMwqE9qVSJkyxxhTjPP59PR0h/rd69euGWvHkjMiAwEAnJ6eTabWKN02uzREESTSoGRaldttr4wSpn4IxCQSjXGL6WyzXTtXgGcE7npfWBLgbmjLunSF01rFkEjryta59xxFWEJISDKdls4Vvk3bzfbg+DClvu+7h/d31cKVlZlOZ7ttb+wwOZ7Mjucf3rmLIJlzN/R9GydV4XNerfY3j69aq0SYUx5iyn2WLCly2wxaF1VVrbom+KiVyjlXE623CgA3mzWiFKUtK4uku67ru6hvLT+mFHB906d+3+0kBVcXZ5snkQZdJ1dS8t5oSBlIC3NUgLOlmy1vpqD3++35xep8vR/2kti8+cNXl1PYhovN6X1tqZwUzhWlqaxVKJgjE0GCNmNkQUWQGYcogCCQFfFmcw4qIGVVm49//uCgPLt56/Xrh2++9eZnfAyr9erhw/vNervdbB4++IC58dJvv/7AubKcVqQgxP7w8LAq66pQzhXKZgDyiQlFSL76tS989+tfcEaDUSFmbfRsvnjp5ZenTp+dn508PX3ztVelqB38FKA3yhTW/Omf/EFUNLRe/qKxtnQ6Xpzcu1jfe+fRlrkrNF+/Or/58pWQ/GyhtQtkq5GVEI5k0XfeWZOGRJqUWBRURpBoSDFKGEIutRVGQk2IykDw4eGDR4vlxA9DTEEjF4VTyCFGpVUUvv/oPgOQ0sHH0K0nZaV1mbnb71vnJk2zjyEKY86yX3VlbVLOKYlvKPWxpf1sWux3ayrnzhX14VwAROStT392s9o/+PC9SVWmKPuuq9H53b6wNvkQAQ4ODoCoa3xZ6KoszvJGAIwp5guji1xNiv7BGZFoohhiUbi+9SiYctKGrCGt1MRRntormX3KQdu6D13Yb8OmAaWH3Lmp8hQiB0RS2ghEAjxcuvns6pUrR30v+HEsChtCd+/8q9WyL+pJGnzOiWZEaBWRmJSYvfeKpCpdiiFHKMtis2qqclpg6aop95CyBKY275r0bW7clR/9+G7X3n9wv+26nGRxcK2sFvX8MKah8d9p9uuf+NQntpvVnTvvvfraq7vd/uGTp0fT+tHD+3ZiU0pDHxEBlEIkDwAgo44OhHo/rLero8X82rUrKYef/yt/9urtW779s8PQ+75n4KFdzWbHRltiPXh/fvLeay8u79y19zdfbNqTl15eND1G8K6QoR9yzs5Ncko+sw/9fr8dhp5zbNvOLebWuLYdtDWdH7ohMUJi6bqOJVd1GdpgbUEQhz4U14rILMorQ9pITphTSin5FFOMSllmFgAkEoVZeBSsZmYCcc5uN/uyLPwQNHJZ1VGYg4CS9W4jsdYlFUXZNK0yEmPQpLbbZr3ehBBmhwsfM4iwQB99VRSAIEgHxwsi9ejR4xAyoFy9dmW9XltLAqnrGsF+NnfNrifUo+xsGNrSFoCgYxyUKpOIUrbQBtQEMFccJeSc49A1Sfx58xSBQNXst4zACoq5SXrgBEhhOpNimnNiVLEyVB2VwDb4GFLIg499MgdXM2KOHOMAKDkxt7FwRqLNMC1kDk2xnCxTMFeObgPZerKoy8WkmDs1EdDz5cGnlouU8r7p16vVbrvb93613Z5erBQGBZ5SOJjWn/zYaw8ePFhW5QvXrzy69+HgyYeeBSWzcNbKIuGz9kNhDuC5b7Zp6IvSFQWm3BkdsarKqkJgBOjb+uaNl5RWIWXm/MYPvOiH/a4PqL4UeJ2VBySFKrMPUdardjHLIok5931zeDz9xCduF66QnJ3F7XabOZMYAQghG+e8b5YHi2a/s1aNIwTarrfaIKrVeqWcVMYNw0CoxukCnHKI2TDnzFppZgFEZi4KN/jBOacIU+IQ8uHySoy95ND3w2KxTByF+JVXjrrtXiCfPjkx2hwfTjfrZj5fNE272WxdUWmjATIi7vZ7sqaoa2VM5ubk7HQxmzmrL87WjHD79s0QisVBsV610wUpI30fc6ZiVu2bjdMGgBAJAPRFl6DbDcNwtDieOJ5OKxasywoK4RwnxcxHP51cZZF+2GadgCCkffb9kDtV0pAvuv2+KktBYc6p5UJpS67PQ9eGnASBiuLqpJoLQsRYTaZWucPFzdLOy+KgqqYIVmGhbEGgnMGISlAJgzAQcpQgkRUji9SVLfXxleXyk598M8b4Ez/0+b/+C/96Smnofc6MgEqj1oqI/q2//q//2m/91t/6f/8XWpUxJwDy4rUmHNXNCkQyAhJi0+yePHkM4kFYC4oCBChdtbo4OztfM9jMnGIElpxy025+4zd/++77Dyezsm1i28W+3+ecQz8YbcojFfomRQZuP/9Dr2udhn5Yr7YJ7BB9Oa2axjd9j6Sd1b0nUpBC9MjG6LJ0uw2lGLq2r6oigc8pMYO2BJA1GcxeMvmYZ9NZ3/aCiQiHYbCFrSfFcjFvuxYQi7Jab9d1aXLKRLTdra/evH66Wt1eLLdn25ACZlhcmbT73g894mwymaXD+XZzPgxDUbn9uq1Kt2v6XW6Gzvve11Xx9OkTTSYMaX40A+Sr1w7K0i4Wi5T3bRuHLsfIbddxzkoBESIBIumf+cv/xm6/PTk7eXz/wYP1hdlcpBzrsjw6uqKICm1qO2GGnEKla07CklVF5CBTZsU+N0kFUirE4KOfHMyKqp4US8lqUi6tsUBYuIlSRmmLqAQMohLBy9kbwIkxSwqMwMAiGTjmAEpy8sF7QwSZta5SilpphYoFos9KmZu3X7r14m2lSMiMOkwkHMspVVl+8513QgwAlpmVgh/6/Gebpuv7fgh+GHzXtX3bjZrPmPz52fkH9x60QwBgrXRd6Q/ufqCVPT3bjhJ+QIgppaHdbxv0eP5k3/Z+v++899bRyy/eeOutVwGqR/c+cKbkYb9tttroYehDyCG2KUn0QRByyki6adrJtFKKtDaKwFqz3zdKqRyT96FelBfbXUykjQZhpXQX+hRZAqMmJAwhMucYvYgEH+azhUCuKgcAzb5NMXeQCZUhRYxN2+6bZrtpLzbbxXL24ku3SacnF12IYbtdx5KGYXDOEFEeQuZcuNKpJDEpgNmkSCmKiAiISOyHvjHBmA8+eFSWNFsWN2++8PrPvnDy9On779/TOhmtisIQgdZap5xdNbn50uzWi68g+91us9ts1hcX9cERskBIZVkiICIrIgEpq0qbIpEobbRxqDDkaIzTpAWJtEbUIIhAkZMgAAKyAAsSsQiPoFEyaCOcM0BIA6qMApzRMzVtq60hqzOnOMaWmNu4zgwoGlCEhRQRYkZWWhMSS8o5ZRZOQGhEpHBm3+wF4Pj4iAXarvkP/6P/ABgfP3rSdo33YYjpN3/7t997+539bhOGATierdasHLDUpblz5/5mvblx/UXwLAIpJUFBUt2uOTu7GHZ+1XSeGUC9/Mqtn/7vf+rg2D188HDz5JxAxWHIPklS3ssQBKkI/d5YmxNPqnLf9Dln0hCzl4FdYbTGvhu0KgEiEU0mk75rC1vExKgUYxZgAUxRJGPm3Lf91StH+/32jddf+9a33w0+2MKysDYoIolTzrGupyEwABmjd+um2w0PHjwwBRlrOPv37nw4PagQVWLVdU3XtZzzUV056zaxpYpQJCc+WC6364sUktaGgIjA+8hZmn5fFrbd99aWTx4/QVCT6fT4+Oji/DEAlqULPopkPYSklEIQUkrZ4ujq9WvXb1lSGUQAMLMwI6BCAJAEIoIgSiGi0kgEAk4YAMY+Gc4CkkY0gyIokHMGQAFBQQAkAQAxRgdgBmbmzNn7kHMOQ5CEXQzaGNKXQxAQEAESKUREoHEEUe/jfrdt+nbvB07se++DTzmnIXGiEANw+t533gVQIeaD5aLr2r/9t//OrJ4Nw6AUVmVdzuY/+pM//kM/8vm/94v/r9D2zHq375RtC6tA/Pnp6uDgWEQjAiFao4MAKT1dLG+98PK733676WO28sKr1//Mz7x1sXv07vsXKUClppr0xdnq4qJl4elycnCw2O8bayyTgEhOSZEi0lk6BFMY1/W7fkgxpZdef/X99z8UwKHzQwy2pJFjHwfixBRz4sOjo74fmqa9fnx8dPDCfD4FwLouBWUIwXfdYjY31mmjjbPDMKrnxHdBk1JKSOmU/Wa7UYpySNYYERbMqFgp2e32u03om3h8YDSpPob1esNZjHUiosdWS6U7P7Rdf+VouZwf79vd0Od3330fRF27dp2IYszaqOgTc9aFK8YsgzkjImeOWTJIJpGx45gUiCCOlgOktCJHI1HDLCzCKAjMTBAIRCudckYiTYo54/ghkOBjzpmEWDjnmEQAMYtkwQwwViEF0RWTccwaIKpncFshI4AC0EorUomTLcxUT6tJxQAo2vdD23ZN0+w2bYwcUlwcHn76U28Nw5BysFb92n/zT6IPAMwgAkCgtLXVZNJt9lrpT376Mzlwt9u2nIiydZWA6lqPxFqRAGQhgJRSP50c/tRP/8yT05Metq99+vrDR++vNnvEwiq37/puc05kJ4vy6pXbk+mknNUPHn54sVoxgbGmazwRdb0vKoMCfdMNfUycEfHevXsxRAQBwOvXr91//KFSJiWwhdFFseYWEWKMOWdrjQgtF0ff/Ma3l4v54fGiC7uyNNudDy4ZowCVANe1Ozq62u32XdcSYT8M164dTyfT87PzsrT7ri+KggS01iLiCjv0uWsDiDCz94EIAcBaCwBxXCvAm7euAMHm/ZYZkWS9WS0XS0A7+H69XnOGpmkm06qsjNorXVRWBABIRAAZgDMzABGPRLoQITAwCCBy5mbYEinOslwukQBJYg6k1AiRYubAAQFJhBEEQQgIFIJoLYCYmBGJjNPCiKQZGAQRgRlQs2hOUZiZnnWpIxFiVgYQENEoq5Wup+VVfY2zaMKYYtsPIYRxcIMI5pxTijmn/8H/8K/1w9APfuiHdt/2Xdv3XbNvmrbxg99ud4MP7b4lpT7xybeEBTlfv3aFFBTOHh0dg5AxxmhFipyzmhQohJ/6SQBJcXj/g6//f/6r/0yAnZsqY9t9P5kubt98dTo9tGZSu5kBo6wJnt9+9x2GnECLZAa2bpzTort+iMKcxRqdM7Ow0co6HaJ3zhFpIuCcQWkkYoDtbjfmHWenZ3VV5IRFrSfzkpvBGHP71q2nT0/7dlhMJiISE7/wwu0P3nufSHH0fohDP2ilEIlI+m7IGea6ZOEYWYCNUdqAUWa327rC5a5nTmSKEAIzJ0YRSDF/4lM/cPLk4uJ8rZUuC3dxsZlO59a4nLIAts3gnL569aqPoFmCCIqgMAAgqbHjklGh0poEAFApbYwZ+yqZeb1en65PLy4u5vMZgJAS55xSitAqZYlQBEYlJyIiKAFARGU0aS6IxlZmIPzI0B8WkZyFUBNUABhz4szCDAgAkBSPcxlEcvAx9sAERDRKRnPOwiAg42AQImWtEhEAqOsZaIWAePnkANE4ERJzijlnFg4hpsjAXGq97xofgrMmxZRSHoZm1LADSM48zqqMMYLI2cnm9rVPFIUjoxfL42GIVVGVdkZIAopECqfns3nbbnJO1lkEnVNGAgSARCD6+Hi23W2DT1ppY4wATKcTZRBAUHC/30xVrbUdy8n1fNZsGs4yTm0dfK+UquqiG/YsbI1hzqOn9z4oMsL4wd0P902jjc6dOOesdQDgnD09O1FaHRzOFBICIgKnnAFyYo1q6FPhzNixN95DIkQmY3SOfO/ufavNbtenJFU16br1brs7OlqCYFVVgCut3dOTk7aLOoSotSEygokIUFhyghEkA8QxQnka7+kopxSR27dvijCAQgIieTYHRglLZmZmBGRhZh4H5I3Lz8zBh8EP3vuQ4vju+Po4U4qzoBCRGgOEIICA1joBDzH2PgxtLwzACrRSWhtjEFEpBQIpJ86ZRcZ+5PFqEUGIkEhpwyIgggRqHIiGoI02WmulCXJd2asHh0+/8aRpu6Isch5HVYhSemxWTimN3xvrx4fLmz/74usphl23iwzAqLJobZTW5dQezKaz6Ww6mZ48fQCMIISEzJJzjgGIKGdYr7fG4dRVza4pSzOdL8MQQ4jGqpQzEgpkFIaUU0rj06iAALFt+s16d3S8cGXF0I8V25y9c7Zvhq4bRDyhvjg/FxFkQcSicH0/eC9Xjq+uN6tyOt1ud4Vxs/n0pds316v9rmkQ9XrV1XUxm9qUfd97o6wxOoQgkrTBpm2UpuADAnadny+mRlufAzM3TY84M9rkDF0XU2StlCYigZRSaJr90OwAoK4mZVkSESkaXdFoOiKXzglRRGRsfUQChJEVI1Co4HIQ8mid4xhMEWDOzIwzZM7MOaY0csgijAjMDCICkCOIUMzRx9gNIeXcD33ThK73PmQEIywgIElyTjEwgKACzpwSx5RYGAXgWVgEgEwE4zw4REIkhQDAOXNmAiSFRunCUFXg0/uP1ucXk/lMIQoBACKMYxYFEQXGYVqIiBZQI1GmwpTRRis8nUzndV3Xk7KqjBUQIFAp5i/84RdizEDJFbqoypQh+SCMDEKalKbghySpH7r5cjmpq6p0q/WFda7turHefHFxAQKZ0zjflwCzcAhJKRSIx1evEMl2vUlZIDMKpAQioCzVdbXf7Qc/GEN9PwDIbF7tds3B8mC13+bEEWLX9LOqPJjNT882fRsAQIRRZWt1jISQEQgFx0mFIaYQ4nQ6Y973TT+fTcY5IPtmn3NyrtBG+94rVAisU/aZSSltnSm5dErPplMRHt0gKA1IwjB6l3HBUkqjG0JEIjU6M85MGhExpTy+orVGpOceFRCV1mN7EBJorZAUogJgEX4+wTZnQiDPade0yiYkiikdHOecM6JGBBHJSbpuSDEzMwsnDmMt1seYcpbMAJJi4gwClASeGwSAkEJCZKRMCQlFMkAqi/roYHL66NFyuTi+enWxWGQUY+z4iyilCC8HBhEpQKAsCmm8BVlSzlkrNdKvAjnn0Qg4JX92cS4AMcVKTxWKUl5EtFIpxWpalIXebBpAnbP0Q2t03fusrO67gUbdURAUyJGLstQTvd+01mhm7oeh6waDcbVCbfDpw5O28UVpndPz2ST4XDinSOWUrLMxh8EnH5MgDj5ao7uut87WkwmwnD5ZHR8fxyFJzkTofdw3jTAzZwTUxk4Pln0/xJhiTH7YXL9+o+u6rvfAXJR2t2u0EBGlFK3RMUZjdPBBT+r55fJDrusaS2JmGH2+XI5fBLwca4aXsQCeBYXLMCfPlHgwtg48Q05j4Lh8H0BEiFBEISgeUyBmAExJEocxyCrSMaXA42w7zMxEpAmVugxwAGgtldVUnlkMi4xjwMenQTKLMOecMuTImUGYJeWUUsqZ+RKWsWSWnHNikePDWb9fXzk6/IE3P2XLwlgTOCLA6KeRiFgkM40ZIgJlVkAsrJVWSgvwZr0CERBQyogSGOeEhWG1WqXEcUjFJJICbZCIlYKcGUGGwU/qCggXy5lIRmIQUETGoLHYtr4sK8DgnC2Kom16RTSmbNYY770YfVAcPH16trpoZ3VVFroop30XfeisoRCwKIoheubsnEISrfT59txqXVVFWVUxxuTD1cPjF1988enJibP9xapRSiGSACyXR6uLC84CAn3XG+uGwStFm83Gey8ggx/sOIMdFCIO/VBPSwO2dNa3XocgCBkvx2ILQgYiACUAY4Sj7z/uz/6Fy+l5ADgMg3OWhRFpnDA7PuXjh5gzIbA8+wYAIhEQICVhzgmZY4btdpfHZQFEDMz8zIJHigMBBFEJj9AVhDMAA9DoCYFwVHteju3Vl3UFASWAhAgynhxEBDBrrZGUcAZhQphU1WxS33n7O4vpTBFoozIzXj5NggAil2QewdgcCsyQURAwASNzVbqz6BURoUEEpRRzEpayKhYHB49XJ9pqUGKMyh4AGYFNoafTKkZ/dGWZOQ9DbvcdpFiVE2116gIiWGs5MwIYQ0oDc1IKOSGA0kZV0wo1KFLri/Xt2zcX9fzRyYeH12b79jRzbtr2+KAIXib15GI9COf5fEqkUYEtrbYUfIgh1EW1WMyvHM9v3TietGG9fv/wcHHrhYPHD5/6ISoiWxrRgnaMKJdRqqqqwW+7fjicFsYoZiFSKUetad/1GlErpS/RUhaiESsDACilLsPX93HF9/3Ts5gIAKK0yjyinoyCzwPfJXYGgJHkJAIGYUYAzpI4taEfI1fInAUkjtB4pLAARXDcROLSJPBypS/R3DPvhUBKjRYpoxXKMzJWRpNDGo8FgoAgoBSSQqu10Y4IJ65YTGsfBqPRGsWcFVHykQhYWJ49QCyiSDELoCAQImYRAAjB19aFgIdHh/fv36vKmSADp5yTsBirX37lpa9886tXrx8bQzmGvutRgS2NKbTRZK1lTtZapWyz3RPpcar4KCQvCtv3AyIJ5BiHmGJKmUHqwn3s9ZdcpQKns/Ozmzeu1EVx/959QEVGxrI75BSi78NgXJEiI0FOuW8HyQkJfAgpRK3U4IfV6uIP/vAPAQHROWdi8MaI0nhx1hSFrmezbuiVtd2+FwZBzDkhojF6CAEwVxOz3XRKUJECYCIKPmmj9aW3R0RkHHluIIDLUU/PLWk0l5zzR18Zf8aQ9+wg+GziyrizCBGqkSnIzJlFYgwhd/0Q8sCIiQFG9fOzn/FEzAwgCvFytjEAPLumj35SEGBMTS+tCS8NAQThEsQDjskuj3yvIlJIGkkBWjKlK4D54vSpQiqrUsAJM2RWpFBABC7ZExx3ZBh/QUZCZM4IWusYkyQuazubTbab3XwxDX5AQGZ+/87dK1eOysqRAm0oJSmKYvBRiFPyAlokaeMQJcRGGzlYHlV1sW0bABUCz2Zmt9uRqLIsBDDnJma21szmZebQddnWRVGYaTkzWjunp/N5125EwBiq3dQ4M6y3vFkTkcBl3q20zjkJiFJKRGaz+b5pGBKnHNkw82q1P3niZtPZbhMBEZCC52bfaVAIkHK21pZlmZL0MTDzjRtXm909RCCF+10/mUz6xs/qWn8ELSl4ltDJ950XfNSwnkP4EUQBXJJSl3QDACDwWLgRzhk4c0wp5BQ59ymycIxRGEfbBUD1HKJdJl/jGPFnsVMIEHPOo+f5714PClya1+glR283PhxaXdINzz9MSEikgAAJwCg9mVTOkO/2u91mtpgLkjE6Zy6cFWFS+vkBRxbj8lQswMIxkybSeug7RkKSg4MDRAhhEJHMOef8z/75b/3xN//k5u0Faogp+eCV0QwZEJaHiyShLkofUkqd1mq+mJCCSV1tdhuO7JTb71pCIqWU0v3QlaUCwaJwV24cTZeTbuhSjCKy7xunXVkXpDjssxKjNLR9R1YhEQuLgHXFbFYPg59WVTWtRVO/awkpJK8UamU8ZxBWRAgqJipRXIGo1BA6P3itlWTJICLgo59Ma2ttWZdF6WIKytBiOW+atmm6ejLNkjMk/RyJP3NAIAIi+Xk4G41p/P9HwFNEBEQz3vfn7yqgMUmOKQZJMUkIHDnFnOkyqAGLwHgkAUC5ZKsABSBzvly5y8Mic35+Cn52dhwn1T9zYJepwzMnemlbOV/SVciISIaUUkg4qmWs0UVZoAbS8PTpo8wZCPf7ZrEsU0pCPBL9zz3288PS2AaX2WjtyiLlDEUxMggpydHR4cXFKoRASp2vzlPulcuFpSH4zELEpEApGrqBuUaVh8F33TCdOULVhX6zPfN9h4TTyeThg6ezxQQUp8AhRGuUV+QKQAq7bndg5jFCbL1CEMzd0AiGrh0MmaFrbFG00fOYmiJk4clkOptPs0RgCD5IhLbxh4eTmKMtahAJKSYfi9KFKN73+yZobRiEkEhhaVzT9Jf4gog0KAWTumybHWmlDbrCrNeRiIYhlGXJJPq5VY0RbZx4PtJLH72hHzEpuaQXQcZp8YQoIn4YkKjrOhHJmX0IiSCzxJxlxEf8bO2B4PJocvkHvm8xo0LjmRN9jrGevyujVT2nXp+Dv+ex+LlLy2MPDLBSl5wIMJAio3VVFVoTQHr44Mn9+/evXr9GhHU9QVTaiI8p56SUdtrIs7M8e+6+b9YpJdLKgBlrCyDoh5SiBB+Ksrg4P73/4MPNfqMcaq0AgSNzjkXhQDRJ7vpOU9G1vStwMitTotSnlFPpKkCpq7ptu+m8jMMQc1RKx8AhpMOjRQxxdbEqppWYqBFz8s2+qcpKE3k/jOhHa8WZASDmzCDr9dpWNFnWZ08vSlVWrux1rzVlUSH4qpgiDM5hzlFrAITO+xSldO7iYtv3w/VrV4RJEqYYr1271jbrEPq2Y12qlJOx1PXNSDMNw7A4PmYKGgDGPP8ZO3C5KM9CG6FcZlvPUE5WCkTG3q/IfMmUJpYw9CnnPngWQaWILzlTGX3ec/MAFLj0CCBwWccGAgQgRIAx7lwCmrEENJ4D4aOvP5v4+X3z+j5n9hwdIiAoBJJniYUmQmStSSQSAwDXVTWdTId+mB4cZpGUgjVOtH6GqIiZc845Z2stICIBwSWJpVBlzoIYUxz6/snTJ0dHR/cfPvzKV7985/7bp7vzalr52IHiMY4qQ4gszCLsTLHdtcZp61zvOyIFmJBwv29dWcScqqJCQFCqco6J0emqdNdv3W7brQhsTlcxhMLqqqYrVw8f3j8zaGLyXecz0sGiVqQ5wcV6NakrqyixV9pqq3ebFgWR8mq1rusqCzdNM+55FsNweLQkxe3QxeTH7VXKogSQorTCebsOm916s7lA0aVx1hqMYCa6qsqujcPgY4opx6ou9OWElo8AcICRqb6UhwsDiBBRTNF7P5pdjJlZfE6ucCFG7xPC2E0KmQUAOGVBeb7uH3E6z73ViLWREEVwHGQ9JmGj0XzUTY7XxMwj5PxojIbnicZHYvpHnRwijtTauH+dCDtbaK2NsSg8m05mb7wuMI7jZmaWzKQBkfiZCxw5UmOMtXZUsHHKiigLD8OwXm8ePX603qw22+1+t99uNwmGTb9/ePFAV3RZXWBAQFJj7SUUtgREawttAyIhmapQ63WTWGAY/JCHYei7lqOdmGlOEinNjxektU99Nr0tsW3ybtceHs1zHqx1i/lkt+najQcga03MApL2+3a78VevXmEOwslZTUSAUlcT72PfRUQqS9BaD0PUpJqmq6cupjYHcYUq6yrFvD4PnNPQ+xu3jgBssyMffGbgnKcLZ40zenH//gMi1JqEuSrrvuvLqdPwfbD83Od/n/YcfRYKjsW7YRhSTCJCpAExRY6xz5wBUZG6VPUTQR5dFD1bTngWRjMiAhJcJmwgzDCmd/j9oDdeAxHyKIX4ft6Kz53TR6uQz30tIj6PeqM1fDSFBBEkNNrUdU2kAGR9saIsQrI6v5hOpwIRYZxVzlob9cwFjhfA+XLfJUNIxqYYY4j7/X61WsWchhgSZzK6D/7tO99ThcuCiZMzBeecUmy7npR1hU29OGtE2A++KIr9vmvbnnSRUs5AHCKilpyODg6Mtc2+T0Maej+ksJhXN68dBR8Rs2R54YXr9aJutqvtdo2IZWV3Fw0ZVRTWIgnEFKNW5AyGyImRWXXtMJ1UeVC7XV+WBSB0XXt4eIigOAuAKIVtOxwcHJCBkAZmQIJCmxiTH0KMKaXMWXKCojCksiJtjCnLYrftRZgz+i4G4oPjAz3i9EvADDQW9ZAuhZo5xeCjcPYpC2AMEYiYNHMen0UQGBmBUWUzHukZ9URjpvYc/j93XyOPynyZwDOPip1LZynPesnHabFaqzHyjg5pTPs/GgfH43+0GPDcvBBRKf3c/Kw2s1llDJKCHHK3bwpnY0g5Z2MMC5Ma9zOksag1xl4ZC+okq+16d3/HKffdMPiwa/Zt2wlgM7Qxhsxx8HEyP/zEm59dbVdk5PHpdzMzMKTAfR+VlrKcVjX17VCUM9IYM/RdP59Pm31gUH3fT2wJGQ8PjlKC04tzH0KIQQQkUumsBWMKyyoL9GL8vkubzXpamn4Y2t1gjT08XJyuVgkgx1yUFgBOTi5eeunaowenkqVaqNm0DJyN0daRUtYPw263r6uqcMYovb1oq9mUrPS+zaz2u2CUVqRiTCkKoSZFSqMIlLUCUU+enmqtc4rWKWOK/XYYK8K7baNHk8gpjchGKcXCHPMIvKLPIbK2OiYJKQGwIpPGcvJoBTzOyx31c0Bj7RCRmRlQALTSMCpbRIgu934ZrQRAj85GP6PTRr+GiAA0Tr4H4JSjIjumaM+D9fPjPHdmozF9H109Q/QpB0VEmgypaV2VpQNkVPrkyVOjVFmWcbcft5dJKaccFWkNFHMccbpk2e62FxcX62bXdB0C+K5nIQQcQkgpJYbIHJOkxErbtt37kLuuJyYUFGZFyihjlBOWi7PtpJxWZa20jrlHtAfLeVVXp6erBMDM1phqVh9fOXr33Q8JgVR2ThlTuEIh5l23v3L7WhyGzCHmlDiSQjMtOaacsgBFn5wpQtemJCKSOR0eL4MPILKcLofQ7LdtWdZNG2PmnJvFfEZoYz+Iyc7aZheC57TbGQdl6UJZQMQYU04SfBqGoayccxYBq8qu102OmGIA4KKkzBlAGFhEdrudZpYQgtEaLqnk0HZtjIEInSsyQgII44woAUHglICeVQNhzPAEmfG/g52FBRG01ohojHnOhD1H3yIyApdnmsIx6Iw87TNpMioAYYljSRGeJWXyjN9/HqrkmWUTqWeqCso5AeSRZShKW1ZOa41a+q7nlG3phmHY73cHB4c5SQjMIuRU4kxKiQgh5ZQuzi8ePLwfQQC1MQa0HWXbqU+II7agEFiECGh8SJxzT89WXTMYjQQqRtZgqrrs+w5FMUuMcRxxaq0ehgFAlNJjhnxwMN3tV0pjQaVxQKg2605pcgX2PnbNru8774fjazeUVrKYdF3ru74oCltX23VLQpxgTO45iwg+fnhelg4UFFVZWGga7+qq3W3nc5eSd8YRYFk4zsNiWQ8cAY1CqZxuFW83rVJKkY4h5yxaE2dWCo1RFxd7TmPvNxmr9rsoQsKMiNY6nXLQRDHlxBEJREAZpW2ZGPqcWSCBgCggGgkuFoBnZsQiYw3pI2TEJaDOOQugUqrvk9b6X2Hn8RmvIeMgMuZnMU4uPQ5nGN3gpYsazSgjIKIek1aFCM+gOl7ytCjASo0kCCCw0iiojNaFdnVZWmeREAHa7XZWTxCAsy+KypgyM2tDnLMiYkICSiGsm+bB44f7Zi9a5zCmhsCcSZHSSimVM+ccAS/xWIzeOROSdkbNJtOuXQ7dLuc4grbtprt2dORDiBJziKhxMqmaHGLmwjok5eZacmp2W2YGyHU9TUnrgoqyRMVZoiIqrVnv/GI+f//td5ybVKWzioKPhbP7tgs53Ti6rva79X6XBQDCxdmmKOt66kytRMt+12y2jdKmnDgiNW7/eu3K8Wq/vrjYLJeLfTNwxsnEnZ7uJNnprMqJOQsiKm1zZqWRFBljEFROohV67/0Afe+1VoUrUsqHh4d68B5FyBAjjVsgX3oCUox6hNsiQJerOOKhy4r0aFyZs0J5rp955kUQcazOXQa+/xafKQIAo4J0jLmjUSqF9IxhTzmN/ue5H0QEYf5v5ZXPwNbo85QmAQ7ACKgvNYBagJ02k6Ioy0qIUNF+s5KYq8ksxtQPjTUWUSOJIlCYCYgYiHDf9Q8ePNi0eyFhEK2tSGRm76NzOuQ8ZspIqJ+V6jMnBdpovV2t+30/qxap88ba2uqLzUYpDQlRcL/d29JVtiAx3jfWFVoZ7/3Q96V1YUig4MbN4+22GcveHfu6cLPlApF3+91kOok+ck7trhs6P6lKJM2sh3aLLAn2RY3U5RwhZzFaVbULMTZNCypvt01mEUmumkSft6vN4bzad7rthpQzKSrLoukHYxEV+D5YY5Sitm3rugo+IUFV66YxfR9izIA6RK8UBs/WmbLCwhVhUA8fPiIRTor6IG2ffITEevybWaEoEHUZXugZCUDPSsFEBulSYPARNP08Ho0k7fOFHz3T+NQ/z+NGk3HOjXY2fmwc5AUAgJco6plbIrzkZp/hfLjcr0Zrba01WiNCiHH8sLXWGOMKV1ZlUZZ4aaZ8dnbmnB1P5L0vywIBiJQmA6JEkAHatn3w4MF2uwshcGY9QgUBUsoYPeaqxhiltIAkH6flpHDOuYK0nla1EjyYHfjOIyMxceCu72OMKafLvBtU1/rdtremsNbE1ANw1/Vt2202zdD77XatlBGRptkCR+Z0dPVK1/nNZp99sFpbZ0mRUnq365UiUoBKisrqQq02az9E76MwEZH3YblcimBZ1MoZMmoyn4mijIJGRZYMUpR1Wbu+66bTiXOqbb3RWheajFJKXbt2rSjK4FNO0jbBD2EymTjrxsCnlM0JqqpYHpqqpsF3KSXdB0ACYAIEAclZEDUgPdPrfb/4AgDMQHA54Q5AGACVMqN04ftq4GfEFQqCossywCiER2bWSo3NIQCYciJFOUYcI+yohLgUlALHcfNLJlLwLAQTXu63OyazgDL2hZFSzBkyGSJNSo37MSvllCqNI6vHDZG2F+uJq6aLQ0CK3eC6SpmSmYkUCo7q/wyCBucHU11S0/VZSCsbi0RaOeuCD977sYMlpTT4IYUEgNDkrpemaZJIiqlv28pUWISu2TU5DH0wCoIPfRy0Vn3jXWVSypJzjIMpnSa9XTdWW0mShtjFND+cIwWjqdl39aTc7rYiYgyk0M8Ojtu+3aRGaSBUrrAi0VV2Mp2DQu9TSixJaeKiKKpJIciTulJVoZptikkLYBYEKCtnratn02bbGW0AJHFQWpjh6PB4t+2H3nf9kJNYpw8OlykG30eldOh6BBIBRJVSRIKcgtIqBdnvWgDUMQoRM+exEgRAz1I2+Ah44hEgMeeRNQcaHcbYEDHWzp+pG74vpbokAeDSNpGZFREhxRDHVSdEYYYxvMlzduuZ58PLjcSelWmeESMj1QlAapThCDCMkmhjDI1tuzGOvFyMSQGCIqONcN5crK5dOSZtAKHrO61tZuQskIeUUtN0SiltDUuqJpOqrpfMjOb05CylNDpZ51zXdV3XjYbVd32IIaZorEUAyRmJPvnJT21WF7vd5uwCm/1WkSq1m01nGlVdVtvtFjKnBClFV9p9s68QJfsUYyLttMmZU+LpbGKTfXBv71yVmWPwKQcinM4OMiRFajItjbb1pOz7XiQfHC78ELshFa70fRczKwUMfUwCwVgw3W47q6cn2+HsyfbgsFIEk7IgpPV6TaCrqg7Jez/M51PrVAi+0GayrB+3ZyEEVOKHeOPGtZy609OtumytEmYuCgOYY8gx4H43jIutc07MOKZ4DJd8+/Oca1zPkYgHeIaU5bIkjDjy4Cw5K6IRM9GzzrHRwEY7Gzc+/VdIS3gm0bxMFS+/OG7wfonAPqKngO/nB/h91zgqsBAJUY1dFIg47noNADklTeNVISBt1xdOGzeZjLXLvu8tqbZtm32732+7rosxCojSKsbYdb0izSCMahgGH/oQY4rp6OAYEPq+H9srhmEYHXqKUWtd1XXOedj3VVX3fau1TsKaaFlPnHWSJAMrAbQqcgo+aqNTFK3svt3FmEJs5tNZYYoY/Pvv3z04WrBkjWrskooxlmU5xHjy4UVl9Xw+m89mu/2m79uDg4Nmt+/bfnGw9CFYWwbflKUNKVrmYfDd0BOC1qQQyZhJWcXgFUqKvm3CpJ6P6NYY40PohyisjmdXdvs2pZiTHB/f+OCD+x988OHR4VRESFGMUQS0UsEnQClKNXTJD5kIcpLv52ssLCxC/yobNDqKMZaNbmkUJAB8HwARIgNIToSXLDkpIqScIcaklCJCZlAKlUJ51if5/AjPLWa0NyQYZ7PRM/D+/GL4Uts5akoFQYABR/0NjoJqIiTrrNNm1HsWWpdlhVZlyWePn05scfrwUcppt948fPhUGENMIy3bdi2IhOjHySKd90pbpZRzRQyRGTILacPAl9JaIhgnaY67zzIrrZXWOWddlCj5mI4RwjD0TbMPXS8MMeWm3VljVFl0fd/GYbPducIZ0jnk2Wzu+3GHATCFcoUNsb9289Doogm7lHNRVMIy+IE0udoAphh9N7Rl5ULwQx/aJk7mmBJr0MKolEEGRbpwOPSDJGm6bjqbLBdzIthudwJsrSECyTn4RBpQVIxJJMeAD7aPERUpIIQU/Gw67dq2KCZA1ufnNoIpJaVBmIZeUuCjw+MXbt3Sz5dWEQnROFuBnwmznse1ERIRkYCMwW1cxecoW2S83c8ECJdSVmRmkfSMrJAQwvMmBXkmtsFn1PglQcXy/SN/hFu/dFEsCAiAIjlnEQal1JgWIpJWqAgVIAkgyuWIPYWAdP70ybvvvDMtKkDohmF9sTGuEiBhBsLCWGJgFoXKWpdSAkQGUQicM4AoY8wYssekQZEhIyLWWR/C91t4iFLOmTnF0O33bdNZMpUtIQoS9sMGALRSSCqGFIdYTStg6Zp2jPLWOoMqeV8f1F7y8cGk2fsH9x4cXKsKNwn9oI0BH46vHrfNXllpuQVEYdztdv0QDq9cKeq6nrb7i04kj2pmpTCGMK0nfT/0vtdGC4oPISU21ilNVV0pMClmpSjlFGNgzlpbXdphCMdXD1PsjcWm2U8m1eJgfnp+FlOuJ1PvN9ZaH7xzRlsEQFfosiZbov5o5i/MkEQARGHOeaz4fl8oMEIM5me6qGfOiQiAAUdWhLTWKaUxTDxjQy9d3UiX58zMaQyLo3k9r/mMxiGSRwnhCGKem5eIKEVwCedRafV8yAh9hOmALIw5J1GalHmWSaT8zte/tVlvvOmQgEWzqDQ2ehBooxOBBx5l7WPQGaGdALA8M2siYPbeaz1220lKiRC992NBamRrc87MIiDOFteu3jSkzk5P9qntfY9aa62bpqGUUkyFKWpbZ8lKK2tN1w4AeDyZB+Gh64pJ7Wy5SU1ZmWs3lilHZr44OxWixntS5W63Voq06BB8jNHVBk0eUiwqtzpZCbBzRjk9mdQAVd8OWuuD5VJZg1pvzs8Xi3nre51QizJOKWtA2BgVMsXIVW0A7Wq3L2K/mM1OnlwAQFnptt0xxxSA0B4cHOScRJjU/5+tP32y7EryAzFfznLvfUu8iMgdQAGo7mIX2WST05oZG5PZyGxkJpnNHyzpm0wz+sAZNtXdbHazweqqAlAAco3tLXc5i7vrw3kRBVJKg6VlJoDIF++de9z957+F0dy8nLa70K3zTx+/de0Da58fIrLDqgpgQKagBNSIWQANQHqiSZGINZSraaI8NbwN1YT5fCycC7Xmto78edWzx7h5/BnC+XiNKSKIVkKHP+MsP4pa1UyZyUzAkJAUm0M1IZJ3HLxjo4CMiI7BoREZIHz48OHb739i5gIMqqalMTHAESKGGNSMPBOzibJzxOTUqpnUaqimpm1LYiaqUOsyz7XdtWa5lKdng4gYqFo1A2JkCj52oe/7ZalahyGqyjjOgb2jQh2mWrWk0DstVWtFIA8w11JBVeo8LfMyb9bDaX/sN4N37rAfr68udRZwlJIxaLK0GiKYVpM5TZh1nhZAWG0GY4g+lFLZYS5JTeOqu3x+9eNPf1iWBIA+smpNUgDZgNlhreo48tARu5Kqiu6uL28/7edaX332vJTFez+Pc8uS3e12b9++d45rqVK12QKAS9XAPX7SZ6xImZAQHvFua6qYR4gc8dwU/+yuOuscft7vP9FlHrnO2LCrR9o4EAVEeMKr2il8vCDBGlPnsVaWUlrL/0TGQkQiJ1Lo3FWxqtW8SGWLMTpXQJnQMeUsZR5V7e/+7h8EwDtH7ICxLAswsGMjVFNEzMvStk+A6Lpg82gAxIyAjtkxzyVLraWUqRRCLKUYQAiBmL337QJr38tquy739zmXdDod7x+cRwM4nk6qkpbFzNabjSIDQb/q57lgNSqC1Zg8AUx54eAvtgN7rrW+fPn8tD+CuOW0MNKb1y+n0yT3Rx8CVstVcrLddt1fdncPt/OUuhg22zUJ7na7u8Pdx5ubzbBab7vg+OE4bnbru9vbNsOexsktfrMJhGCm85xj50IIASiVmlIts+ZZ00kP96cYw+Fwco4BsAsRHUsx56jv4+k0tWPAzoFZS2dxIYSnS0tN0Tkz47YWNGuuMkTnWe+pjcZHmsv5ZmK2KiJyBsrVmB07V3JVlaZDfnrff971/9fdFTxCE+e+7fzjqS6bKSGL1Ob20DALAHt4uN/vD2aw3W5XXVx30TnMmU3FRA+n0/v370MfiT0RCQD56Nkxs4po1XZqHzNzLNXiYmjCaTAM3ocQYBrT4UBEXdeVWhj9WbMKEGPMOf+xXnsfnX/78VPncFgNzlPswul4HMfj7eFezRiJvOv67uVnLz59uF2gduvBr4bjj58Y7TBP3jPUkMbp8tmKmQBkGqtzaAjE1HVdPlWt1QPPp3l7sVKpftP3w5Cz1lqB6OLZZpkO601cxrK/3e8fxhAQCe9v7jnwi1cvbj/cf3b1ep4nxwYKSAQAOeeh72vV/cPB+VBK9p5vPny0oopmZF999fWHt293l1f7w/7ubu9DMIBm7cGOiWxZFnMWYnGxi0QIoAgdEiFSzkVFBExMTeBJuoPYVKOtAlII8ZEaj4h2pncSNasdIi9SiYzINdmFGbS1z+OWEP7Lw/THY9RGO3gUMoQQnhQyAFBFABqpAY7jOE6TSJ2nWUSDc2aHWkItIZydIx1TfPv2ppTSxV6qSCkuBDVDAxBTs6ZXeIRIyEzBSFQIgRhj8CpVFGsVUqC2hjLgR/rYU/soIq2zzDkT0uXFpXcUO38aT7DUi+3mu++/NYDr58+K1KUU793xeFjSEvoIqnWpteRF4GJ3sSyjHcdSy3yw07EMQ79/OIrI+rJDcJ44g/gQtpt134d+E99/fP9wOpIqI+33pxh7KSXPC3n//PnlvR7GUwlhtch0PKT1RUjj0REcj/vLqwspdTyOu92aEERABQ/7Y83VOWa23dUgRWJ0fRc/+/yzmw8fcinEGPwQuqmWcjrM603XFv8AhkBS9HA/uhiZHiGGWqrIeZ5nIhUA1AZiNf8q5iarOcscGnaAiKoCrfVufM5HEj1RI3g1wILlUeBgpk+cevwZ4+Vncyj8vPFquEObMKRK4zWXUu7uHx72BxUgQu8oDn7dd3103qFD9p6JeJ7Szc2dc0FEPbECqKqIPkJr2vd9KaWdXTNjdo55qlVAWVVKDd63dXtr5QBgvVrN85wf/5d2252vPdW0LCH69fMrLWLVmOuY71T1+tlzUw3Oq8g8jsggNXtjMyVRSQWNAGGeFwQY+ujCahyP3SasLzaH42nVD1aVIo3HUzcM+0NO0/Hy2gHaeljPxzmVfHF9HZ9fILGUksYsCqGPoQ+nUwqhOx5OcQjd0JlBKYUQxbBobd6tlZGdN0UV6LroHVDwvuuWMWPgi+1Frcu7dzerVUDEV69e7Y8PRRKSXVyuDGqVusw6nsqGnffkclkcezMUKaVkM8/0RFkBcg10QDMwBTNzjg2qnjnxXqQAnh1FAZGZa60NbX0iAz6djydW1lNL187fE6wFcIa4fmbt8jPN4SMTq2ERN58+7fd7ACAyFfX9OjiOjgi05kLOm3HfDx8/fUxLckPfandKCQBD1yEagIpYSulpPm2FVUQR6XGLpaUUH/xTvWbiGOKyLD9fjzbyT/u1FhFmU80lpzmRWfDdahh+8YsvtpvNzceHw2EM/uI4PozjPVaJu86IilkXB9TqmIlwmo7P1s8Q1+Dkw83Nkkvf9dNxGWLgjr0juV9mmbp5G1DYOQwdiu4urkTcd99930VWlWdXz3/86W68O5Lhzc1tQXVOs/paMMRumeZpWYLXfvBELZZRmTrvOqMSIpaSi2RwkOdsBt/+/g9NaiEih+PBOSKWq+tV0SUMZqlOSVzPsffOFfdwfyCiJssxA4TCzpFjVSUmQjCAEJjZl1JLVhEFVAMCpFJK20xrlaZlL6UgoikYtDMEiGcgvvXvPy8fTxysRmZv/+rp5nj6w7Zjfpq52sDw6dPNw/2h3XBsgM5HH9fDIHUiQO9cCOHHtz89e/n6/aeProtEDomY9ObTT2+++GWMwUw758fT/vvv//PXv/pzdr5R+70PZtV5R8hmJiDIrUGXtEAppUABwlornp8QVcPtZrN/eLAGl3DNJdWc9g+3IcahHw57+e7b79cXF2i4WW+Zw5JKSQn7Ms6n6P2shVdDxJL2DzGs2PE8n8Zp2j17PtcRJhElYj9suujc6vL6dBiHrROR27vbLg1d73Opz948/3T/8OGHO8c0jVMfVx/e3tx/OKz79eVuNc4TAylICGF8WAQSEDI7lQVDn0uWaqCYLTfjE2YyxdPxROxi6HI5dV1z2XFLWroI6/VqyWMVHae89Ry7cHHJm603yKWqa48mYtv/mSEUqfyYQYsIiLQs4j065zOkJ6KeqjVGm6qaGCESUyOWMDkmQocAqPqYqPuzhr09+k9Emqfn/hHK+qPMq7Uv1mwbtBFH8f37Dz/88CMShxARAar64K8uNkMXRQRUuq67vb39ww8/fPvj2xg3IXTIbKhLmlOamT1icGwodTwdCW2InQBKPVPEnONSzsBY69ZVteRsj45fABqCz7k4ZjVItZRcAICJxnEkRs98vbv0RCnneRqTlF//63/19u37jx8+dHENCCnP24s+ZzTUUoqYxC6WMg1DJ2ZaCiClJB/ff1jyyKHzIcahWyYBc44juxx7JnPTOM9z2m4vskubzcWnTz/VWsBQi2ZLKubZ+cC+8y8vnn26v5kXHU8FAUuR9c4B5LQUq53HisiAaKLeh5vbY8zu+YutgeVUQ6D7+wep6AKGSP3QA8A0T1J1XKp31HEAUnRz0aQCtap7ugxaOZCmb3qkqTiHzMHMwEiqeeef+gnv6cmSz0wNqDGriAjwbFPWlqlnhLLWn09/T0fqCTh9Onb/fy42KKrgXVTVm5ubjx8+iCo7JyqmhmqD6xj0dDw8HD5thj7G+M033/zd3//Hz776k1989dK52LyHj8fjer0RKcwEhnVJV1dXn3/+0oduLtUYVAQRiJiYpJ5pZN77xjl8pMrwPI/r9coTS1UMDplUJee8zEvNhRldF7sQh+cvl2WZpmmzGd6+/cN4OsWmTxfZXe0A7NOnD877/eFw+fJFkoLIcQiGWnPx3r948fKHdz9Q8Ko2rNe5BpVq6scx1Wo55eCh6yK57rCfiN3h/jgfpxBYa3VEVpv1nYnlaiUdRwMtRbJMQ3Sx8zFaqVPf9athEzjcfXo4HI6r1ZqIrq4vljSK1BfPX9zc3C7LnHNtBXS16qa0jNOkVU/HzNF2zy+ARSoYGFBwxCqLe7ow2ufNaIjURHjN0aZxXcyUGZreu/GMn4AA1bPW3lTBkJnNkAhF9GwBpCqirfd/wrfa/QXQ0OxHcpXzYMrMTOCcJ0IENjMF7qLLud7d3d/f3yGR9z7X2nY7nfcINM/z0MfdbnN3e2eIz148/+Wvfr27fIHVcpm476Sku5v3X339ayAmUgfOiI778ccfP37+2a9cF8EqGGotymhqraw3jKrd4I/Qnc7juBwevvria3TEwaeq9WyLpEPf55QCcxdjrTXGGEK4u9fN6urrrxi1AFCtRQHGcX88PVxeXhTJBLCcxrJk5zvnfSW7fPZsfbHa5gsFvL87hWr7/XE1DMNqMy/HGNxyShy7GDEt5fb2vltFBA0MU7KuWx2PE0hGwBAoBj4eDkQmoAbad7Fbd+gUqAaGi4vtENaHm4OWGnxEIDDJee4Hz2A//vhjKdoPcXPhADAED2Y+OkrGPXcViwqgFFFQIaRlNqjKjpz3vpHvnPPNa4XYG4KZee9FVEScc48ywz/ObrXWlFKtlZ1jhCc0wcxElIhKKQ0Kyrkw81MXhef4bn08YQAgpVZA9CGQaRdD7z0AiFRCMMBcqmi9vbl7+/bDeclDrICIMPT9Z69eg2ldZtXUbLoOp8P/83/9f73+7KtrH5BwOs4BJKfTvEzBcRyGXOYiVREur5/7LhhASllNEImCTynN89Lu5vZSuxgJyaz1Bnh1eZWn4/F4f3m5g7kiuppLu4xFBInmafrNP/x9Nwyr3VarlVy6vu/77ni81YouhJLr5dX1xW779v3bvuvevnt/tds9f766n5dpzhebdZEiTochTtOiNRMMXRfWm1jqdDqdJEua8i8++/L9/H48HS+2l6fTIbsUmDYvn4kCMpUlq+rLFy+Pp5PVshm6LBlZtpu1ap1Sba53DvmzV29kkvEw7i63ORci8I4ur3chuDkt7KphFRBQnObUd/2qj7GLacnOkQrXItwwVsDDoaBqjODaqSJqfhjnxbPYmeXSKppzrmkG24/WULfC55hLqcgMpk/vbDtkj1iD/lyEo+dtMT414wBgcKZ9igiCgqlTc8wlZ7DivHeOT+PpdDwyOSNGUueDAADIat0ZVJW62Q7v337rg//tb3+barm4urx69oyjZw4rW+d0rDWt1xvTClq990nynJbh6vnW+TzPquBcQMQQYqmlPQPtqTuXbMIYIzOF4GtOKPlwuC91WQ2rfnWptS5zy7StYOYIw7ojxsP+jtBP0+K9Y+84eGSGqhF9LvPD/V3J1TGvh1VZUh85gC5Sa5q3u+tP796G6O9vblCx5tQFl9Ox5NymoukwPdyeUF3w3dCtTvsjGnQxTMtExH/yyy9//OkndjyVUdHQuSUlI+37OAzd8Xb/anN9s78JFx2D++G7724+3YUQnj27Op1OSORGOy2nSGG96di5rGV/GCVZcN1mvZnynHMupSDAMAxdtzodj8FT29n2A7Mz196+9sG3YwRQANExS62eCREZG7LFKo8YphmoMaDzzvN5I/t48JTItc9DRJ7cItsF0MzKG7voj7TjRxkPETG5p9WKDz5VnbXub+9uPt2KKBp6RkVqFbbveyYap2XVdZ54tVq9//D+mz/8br3efP7i822/6ciLWhfDh59uvv3hdy9evOlWGwCTIii6W226Pt7fTwWggrIhg5VS2J3n0DY9hBAQ2lbeex8QSQk364vr6ytEkJpLTVqqA/AAfYzDMLCHqZxQ9ebjp7ubT59/9gsknKYTEzcJjUqpKW/X227dffPNP/Z9P6dpP03dsHu52YFjIgTFZZlLqUwxpzSBrtDXnKZj7bs+DvHtux+J6OJydzwcTc05P06zOuLo7h4+nU6H7W4tYqf9NGwGUc1TfvbqGQrfvX/YDOvtapOn6eNySwyiYKY1LbUsRUo22T+M9a52itvtNqzCsOpHmdGRoj7cH2OMF6tNyYXZHfbHaZk9WQxxO4QwgNHkYoz2aIjdQMhHNnC7YrCh0vD/o2R3zOhcO4tPyPUj+/QMXznnRP64VWwoVNd1f2zzH7+gkZVSuzhEH5rdWqpZwYro8XR6++5jSsl5LyLeOR9CThkonE4TIjgXAAiBh2Hj3K2Y9cPm5cvP+zgEH8wQDIYYd5vtl59/KflsVJFT6ULXPADVTM0YEQm6viulPCmL2svz3HoGnecZEatmDqFfb2op85Kc8+sVl1IcMyKuVsNvfvvN3/z9v6+13j88fPXZ1103bLcXXd9F45wUYEpJc17G6XSocyWwnMm5fvNstb0cp7mm0kUfuwBMz19cMfmf/nC3WfW1VFPwzplaP/RSbZnnu7tbYrd7tp7zknNxTNcvXv/ww/sl16HI/pBOxxK6st36NNePH2/KVHwISx67VVySpiX7AHnWzXqbazmNU62Fg3fktWgVeP/uYdhEYozOl1o+fjqWbNHjPMqyJHYLeA4hMGhKhRjUFEFdO0lPQ76ZtaGQiFRaHotv/5aIpOrTmXjq33PO+ChQhvPijx+nAWy4vP2XZn/thJ3lVABmatayo8A5AkM1qSYpl3lZbm7ujNxq2zfDuForOz4cphiHv/7b/321Di9fvN4MqzfXz07j7V/9+79G4KvL54xd83ZnZCJ8dnldJadpnseRiLyPtYqs5HQ6pZxaAykizRKn1togup+/YO+9WT0/gUjZJFVRtW61QbMueiR2ju/vH4goxrDdbk305dWzq8sXXdft9w+I1vVOBd69+3G97j7dfEC0ftX/z/+X/+s3//mb29MDdXE8TDcfPtSiv/qzr0/HO+dxverv70YiHMdxWAUR8z5O07S/H/vYm1nKxQXBwNyBY0Bw7378sByW4DpVNNZ+7ZldzeA93R9GrHF92Q2bIJIb9UrN2PmU8sPxYIBEwQRQcBVWtVazVLNKFbdm56zWCuhykTyfnOdSBMyK6uV2UFmGFYMvVcA1ZPnprDAzKDIH51DwnHeDiMzYGvn20T42TAZAZueh74kCo9o4EdoWhfhozvZ0DTzxFIionSdAdo6Dj81BuVRl58p0+nR7c5qmrt+UWr1z7GKpNmfZXj3/5u9/L1n/H/+3//vh/tDFbr1eXV5tih4///qXF8OOAAkJzASkit48HPr+IsZOtBAyU3AR0OPh4aFF7LHjMzvrZ+hae0OIqKqkeSHnnHOlFCYHZkWEEK0IoOW6iEnwrFhubvab1cX/4V//t4R48+nDMAzTOP3i8zfTdLq9v7/5ePPuD9/FldcsInWeDv/ur5e3b99ePb/W6qZpMpCu8zE6N1FO5e1P9xcXa+dxd7VVMZFlnhMYO+fmJXvvwailGDnvLq8GSXZzsw/OO4rznGN0gghg0zyXXHcXq+Ugwzoq28N+IedAAAFrtRC9A1yt16XaeBoZXfC+GTznImoqZMfjYgY5ZbTGj3LO+cOYVuu1c9QNDV9gMHVP3JVH5EkaeFNFuSWNn4ugMlGx+nRRAUApAmcuXnOJAe9dCx155CdJO3lPx6jdju3LOueIuGFYTWbTHBad84hhHKf7u2k6ZTASqQ3BX+bl5uamCAQ/f/j0TnL+1Ve/3F/sx9O4Pxzmcvj86+vPX3/m0JWcvCdGEqlmstpuCD0RMvh2nhWt6cMAUKSZaaFnXJal1voE0bUhtOs6xwxIosrM3runJAgzw3bjMf/0/u04TSXpeuiiX326+TTOs2g10Q8f307jxD4+f/GK67Ifb2+Op2VZ9nl+d/Ph+sX17f39zc0xz8tnb54Llt/8/hv2brVebfqNSvXOD0OvgtM41ypMrKqA0PUeICx5QsTVdtut/MKnfutIw3Qsc55Xrl9t+i44hHjcj9uL7bv5drUd5nzYH9P1ti9Zu7jCoLUWIkzpKAarYXWYTkuaROrQDykfQoibzXoaS82qgsQe1BCYCWPw3pOIDP16SXMkg6oupUSPlgqN+fQ42Yn3yuwfxzdo8axPk127sVoQSBNsPMpK6Wk1a9ZyIXzDhNr6ufVe7bfMbFaZiR0REgCK1FpLzvnjx3f7h/sYO2InpqYqIqXUV69ej5P+1V/9Vd/Hb//w2z7Qs6vr59fPTPV2vnv56tkXb37hkGutuRYyqikveX44nq52L0E1Rt9cJMkEAGKMKZWG7DOzqJyBK0AzfWoSCJGZy8+QW1WptQK2THoDIGM0wvcfP+6Gq3meb999vLm5/fjx3etXz188f75erbfbDZBHc88j/ru/fltRFgfR9ZDS7797O54WzbBdD2Q0HmfXYalK4JcpPXtziZDmaXI8pFRj7No2s+u47yMAGFYFXU6TZJxOo2NUNLUkFbTAokfvhovNJi2p693nX7xYXaxOn04v3myckKltNhd5zoeHA6HLkmLfbTZrRTuO9zknqeYcX19fOkfeu1Jq7ChEU+xUJeXZiJzHZVmWOYdI63j14f7GtZHwaZ3SLi0zaxhBU3WKiHPc7EWbnQicfT7+aEbFzI1j3DSsP1sbt7GgtV/iPTU/kUeagxG5xghkx4BWFU7T+OHt+8Ph6L3zIahB8FHB9vcPnj1o/M/f/M3Q8Y/f/fbcKdYKjAXn9eC//vzr9eoiUACQLDMBFZPb/S1zIEeIJKAIZKqOkZ1Xm5uPHAKCaYuBQDxzs9oGKefSDYPvoqWi5/UAOe/OtA2BOSU1w+BWq90vv/5TVqilXD3f7i63l5ebzWa7Xg05LWKKWpZxuvvxJxUIIZbjpKrDsFr5evliN49l6CIobft11rLUUpJ0XUhTIbRpTqtuVYv1PQFA7HzXhZxTKguiz6V68vNxMVMlAs0hBqA6RJdzReHD8aBgyzyfxpHW/sOHh6urfjV4Qne/vwm8dj6epqOLsdZ6mg/DKrK/fPfunYi6wMRwPI4+UGec58pGrz97ddjfffy4cPRVa0rFu47Qn47JjN3Tnd8Wf09lrh2dJoY5P7igZtpwhMYzYfaIZ8efBrirytMXhEeqgqo6x6qNe9NgetYnPjygGaSUc85EdL/f//jT23laEJ1Vh86YCZFvP30aT6eXz968/en94eHeUc3zaT0MqiIsIqIol1eXb15/6TgEz2b4cH97HPcp5aurKx+G9aY3e7QvNKsiKS1mj0wyAFHbbDbr9fpwOD7tyBHxjMlJFT3PLiklRGHP636VS15yNgCtuUgFs+vrZ6Y6TvtXL968fP5aTWsV08NqFVSVcSnPXz5H88fDbrgqpjd3t3/2xVfTkvh5mKdklrth4JqnY33x+Ytpnt6/f++8e/7yWV5QRG5vby8vL2MXp2nyjrsuLrPUJJmrGjIFZCKvjByiXw9B1d/f7Z+/uma2kjMiPtzeB48MOC9L8Byig6qrdTeNmmopWnx0XNI4nhyHYRhyLfd3+4vdZpmXWhCM1+utWb682nrffbi50QxDv2LyPgKAEpJj5ta8Pw5o9tRbyDnll82a1EKYz49ya8VaWfh5q0s/M0l7ghLgvAdsulRtpmoi5+0kEdQqOSdEMIW7u/0yF2TfPlAAq1U+3Xz43e9//+rVq1LrP37zH55dXf6nv//bdd+paalVGcX0zctXrz5/492GyBsoAALax08fa10M6ueff92UQu1bIMRhGE6no2mrd9CskGOMT8Ng2xa07+Vp5rBHzy0iZGY1AyYOZ5FIlWoAzeS9FlvS4p03s1p1u7kOwQPaxYV9+HRz8eylkc85s3evXr5e5vnm5kYRAjkR/+nunevi5eX1PC/zPA2xv3y2BVeWVMys67plWbquAwA1c85JySiIwCo6T2m16cwJmoFB7PqUyldffw5kqv7206eh66eUh855pjRP3ndImsuyGvpYQ10Ukfo4ZDlO06TqzayU5dnLy6Ff3d7cT2Oz/5s/fvy03XQhxBfPdvvDURSnZckV1oOvtbr2QgFgnueU0tNReGykWpNhIoZAqvhUB733iNasXdpBbFugp/P0c0iC2ZmJGvjApZxF8c00RoTbuhoRx3Fc5tR1fR9dzuXD+0/vP90sKccYSy5a6Z/+6Zu7+48P95+QecxaZRar03RyjpSvXrz8LIZIzEr1NN5N07Hm5fbjh1/+4svNetNkuwCAaMxwbpKaL5w5JEZFx16KgLYoC2ujpYjUlJHQzn6+zdaGU87BhXU/OKRa67ws3A8iknJurpPu8UYHwJxT7MKSUsp59+x6CO5it3v3w0+H4957Dwbeh9VqA6DTeLq7pfn+2CFVhWka110PXPaH01IhxrDe9CLGzm3WF9M8OY8+tpaGBURVT8dp64OhMPkGOANaWjJYSWk5PCwxMKERYE4Ca0S0Yd27wGlfHjEjWcZK1BHy7c1Dv3bEcnPzSRVqUWQ0UN/5uFq9eLkbT4ePn3IRi7Fj9A/3Uy35XKqe8Hd4lDK31qo9siKS08JMqvK0gW5NrnMNCWu5F9Quoac60tq1thMkakb+4PjnB+4soFiv158+fbq9vf/DH3789rvvShpvbm6HfjPnErreO4eI79+/Ww9hPXh2LsaLLkQ1ub27Xac4rFa//ud/fnX9rO+iGaeU7u7fffub39Q5BUJUcUDyyMkh4r6P4zS1cKVWjr3zglBy8c63e+uJ29PA91xLs8l8urAJUVVzzrXWnPLPS39gv99/vLi4+CPszEhEOed5mru+V6mhW738/It4v2bGaZwohGG7+va3v2PGl1999v7HDyqlFA3euw7nvCBGxMKOUyrLXJZlWa9WV5eXSx4BjJjTUkTEs2su5j4QkZ1Ok6GepsPlbnV4eCCCYe0RyQcSo2mEq2uPYLWIdcbMqvbs+fO7+zupEpzPqcYuPnu+VrX9/sQUu95rsRD8r77+09M0/va7H0+niRw9u97WUk+H2Tuqhk5ExnEkohCC/Yx210reU4sdQjADojMb4o9BgWcintf/StMM4IMX4XZGzcw5L1LN2rTV4KGzCHFZlr/927/9q3/373/88T0QrFbDZ29evnn92ddf/2lV2B+PHz9+9N796p/9EsrycHtznMZhGC622zeffdH3K4/wu29/z8ETUCmLaZPVROedSvn8+tW666ILyah1Vw0N2V1cIEBaFkQ0RQRwzq1WqyaLsEcFR/sG26ahYENDnDaFHKKZHk/TsizMjExSiqo6wHlJ//RP//Tll1/Gruv7vnUYh/2h73skqmA5ZxXptxfo3Luf3opCBTuVaffyWqTeHu+vXr1wXG9O+5xyrngaF4f9NC4O6HScAUgEmulhLaCmKtUU0yJM0g0dGJgJM+ckoeerF9ua5u3FRuTQDXHOGoZQC/crP06jd+5qt2NyMYb2RG1Wq3meVGCpSU1jXN3eHUwRCGPnMHAI4Q/f/3R3d2uqXbdmX0uZVTDnstn2JTfxJFG7h9oir90xrag1cMvMnKenNxrBqamBxhhbSyZSiQkNay3MzQ9CS83OeTNt8YANPfLeq9b2N7bv4be//e1f/dVfffftD8fj6b/5b/6bv/iLf9ENnYrkXBDBwO12F199+YVIUUur/uLZ5qLrfbspDTB4b0SAtMxz70Lnu5uHh4fTQxFZrdYvnz37l7/+lz729WxWg1IKIhDizadPdmZwCBKIimodVqHj0PJqfz4si1qtioQm4IKXWlSkioxlulhvu647Ho+liuQsIgiYS6bg7o+HzzYX6NhMpQgRllJj33XM4zg26kQW7dYrMqgo2UbD/N333//u2x+//vrVeuOr5ApVSu243x8WVBcijzqRwbrvaq7QYUrJWpk3y6lER2rK5tM8mWh0G6saGD8d5hdXqxcvL2/v959u5i9/9blJZs/sQ9Vaa2GHBKI5HR8epnmJXZhOS1qyoj7cno77IzGmJYfYDUN/ODycTiOz77uh63halixgoLur4D2E6N2bN2/w8Upn5mVZRGS1Wj3uW6yVwkeisAGAWml9BjLVnInZDGsxJm6EaEADVCbfbNwAwHnuYjTTJntv14D3/ptvvvnw4cPr169V6IsvfnF1dRkiz9PUXpKIdB0OQ3Qc1DzzqmPWWr137WB9/9MfTuPSdT2Y7tYbJqq1Xqy7KbWvT11ccbwCcpITslMtpZRh6BuQ1tZKZopI1khhiIf9QfU8jpRS4GxDguwYidhxa95NhZkNTUT6vp/meZpGeUyLRcT/7r//75iJ2aNaXpI5A4B5mu6P+93l5TAMrTi8f//eef/61etn+cX7T9/94YfbzUX8b//7Xx+Od8dpPM7TNC/PLy9NIE/LajVoi0d0vjW1G9iIVkKqomkW0MYf8I6Dma/FPNXmPDgeEu62RQuB7XbdeDxYNs+EAp2PpnAaT0C4e7YTlW7TAfCHt3vnfC1LGtNmtd6fxpKVTDJmbqQ505Sy8wAGXdchifMKqmbg/vEf/7GU8ubNm4eH+5TS1dX1drtl5maG9oQ7IAIS2RkyAHaU88IETXkh1ayoaA0htqWvIiBAqUJETIyGUnMb7IkcO1bRt2/fnk6nZ8+eIeIXn3/tnU95OY1HkRJCCCF0XeeIPXsAdT4SgSMDdgjkvWeiV29e/W//7q8I+NXzl52PClZK7gKw1Q8f3qPVGPukZqXw2RMJ2keiqqvVysxOp1Pf92CU83nlUGr17ryYf2K3OsdVpOQCCMuymIiZitYuds45U4utCavSGnzv3GYbAaBkAQVHXFWYaLPdduuVC/4J1tntdiL1b/7u3222F/OyP01771GhkqO0VGDs+phzUgWHzaC8+hCCi0ue27cgVTgEMNMCnjjGLi0l5eI8mGm3c+xonpY8SxpLXLNzzteFIeQiDvnV85cfPn5IkHKqr9+8utitPnx87zzUYl3X55QDh5JqrYJIXQxkhEA5zdDSJkFyLkRUSvaBTQnBiMx9+eWXtVbnnPN4OBxyzvd3Dw0LuLu764fOOdzvD4gWonfOpZS6GLfb7fbiwqk5ZBVZdYM4AyhAQMzB9aUUAH8OhlRrkCMSOs/g6ebu9scf3t3e3q7X68YoX+Y0jqdpGWMIIYRWKz/77LMhxP39A6E26xjQ+rMNI3/8w7v7u9s/+eWv15tt54N3bhqn03SbU/rw7r138PUv/kWeMiKioxZQzkxXV5eH436eZ+99a5gIqbl2xxgvLi6WOT8Jis7rHYOSMilWUIPq2EtRqVBJuefWlq26XlQJm50OowAiOFRgxOBY2zQAzgVFXKYp57wsCyLN8/y3f/PXL1+//OzrFyLoXZzzoYBWMEWzXCvKervTI6FJqeKdY8+2GDHHvn9GL06nQ8td8X0Yx9ENHIMj4pxn58G7MC+lDy4OkchSSl2IMTj0PZNPdbl5uP/qizdE3fpq9enmZppLfShSrOtwnsv2ei1V+mEY03E65WHYlVpUjYBKraYiAQHxerud56XMCFh9wPNKBwAJabNZr1e7lErJlYi6riNyVZb1eoOItRQ1G3rLOS+zhKAypzQvtZSum5a03N/fMpOPAZSCD+z4cHgI0V9dXq/Xm+PxIKqXl5e3h/3vv//+8HASkd/+9rcXFxfX19ddXBFR3/UheGbquu7V61dXV7vD7T0zpOWkJkjgyXkXVPXDh5+++eY//2///n//F3/+F5frbXS+rQq6Lh5O6tiD8eXVNfs+OI9IoiJLFhUFFdXVavUEqZiBmtVavfeHwyGn8uR92WYXVUO0Yegk15pTI03QOYTWmojocceliOi9c67JtVVVCfk8YwI0v0l8HI8Qse87M/31r3+9Pxy//92PMUQwqkkQ8epiNy7LcdoHZkK3Xq8QbdrfpHmCri0qwDmHEPYHOJwSOSq5iGhADwDTND9/tttuLjbb9bv3n7qOhyF+/PjeO6+q0zj23YYdPDwc+u1GgWJ0S5ru707Hu3mZU9eF7cXmWceuoxD7Lq5OPx5CdAIVCaRqTmJKIYQudjG6Lm4Yu3fv7lZD8N67eZ6bQrxKBrC03CISoSslO+cbaAmkRM6H2PaAqxUSAYKtLtZ8uWUiVUtL/uKLz3MuPoRlnhzTNC1gkut0PN7nPH377e8vL683m9XQd7/6kz+9ubm/v78fVivHTlWXlNtCipmIsOt6qfU3//kfb95/LCl//923ZnJ5udtu1l99+SUi/q//6//y8eP7f/5nf/bFm89bd11Rs+T9w32p5f3HD10/fPnLf7a9fGYJiFkMTbKJpZqnadpsVk/zbwNDVEvXdblMuZzzKfDRiSlG7zxP08nEQnBmKKUCQgjBVJd5dt63du1JD62qpVTvz+rcJlF8nDTdMs3Haez6rg2hKS1/+Zd/KWIpzWLpt7/97e3th9XFuprWVD17K3U+TiR8vbu83T/0gTbr9XEemRwh3t7fl1IVyDOx49XQDxfdw+EekVbr1fu3+/1+DD29fH29pKmLkZ07TTMSO+cO+2MfhmdXV99/+y2THY+sJUqpplSKipXNZRCUrsfbm49ItrvelWzHh3FZisPQrbqLi36a0/394dnzF6fTFDveDBeOH9Wh5xbVGNGcIyRkh6VkPTt9aimj88453yIs1IiIZlE2AgUTVRUSRYJSpr6PZrDb+qvdRevyliV99vp1CBHBHafj/uGuFOm6YXf1TGs9Ho/kwjD0bVBoe4H9/mDVnu2e1VpfPH8BAEQMltum/H/6n/7Pt3c342nsY0AENQEBUzOzm/3tfjyEVW/A8zJLpYBojsC45NJ1q77rbu9uz92hCBG1jIxlWTbbVa1S8pnEQWffeUMAZkcAS62GYGjNo9XT2fmyuda2zj3XogCkELvOe1rmbI/x1c656TQ55u3uIufcRmNm8iHu9w99111evprH/PH9x2fPrtn5m9u/q7UuhxND8CEu3eKQjbHfhDGPH9/fWK3Hw2lYr0ERKsSuqzUB1FKqmb1//5GJUoWY3DBIqWm77mqtBubZEeqy5GWptbCK9RGCD8pO95BTEuOUmfLi+5iKhN4DUEpT8FFNnY9D9LWklBFAhj6wD7FbpVT2h2Mt4p4gKzADMARHyKVk58hA2vRH5IhYVUtOzjsABFOpAsyPCRXoolMzx+ecnLbTIaJSigg55wxsHMf9w2l/ejgtkosS0el0klpTSrJklVpj8J7Wm+7ycnNzeyuikZ13ntyZLhHcyjEZACJlcYfTd74bnPcACijMPsbokbWWOKyxoCX1zhOYaSW06Cn2wXkG++Ou6dHmhBBx/7BPKT1FA6sqM+VsatJ1sYxJVRVM7ewkgERGLbuh/gyeMDEFAwSSqqVIwzXa2QoxICCAohkxi9TVavjhp+/+/V/9u//xf/wfS85fvH7z+99evv3waXexCRwmWLrVjpXBaqmltaQIuN1uS7IQOucCiKHqercdNvHhoVQREQVDx2G1DsfjMTh32k/DEMdxmeeslcwJdSa1xq5nBu9dDLwZVvvDjIRGEIe4e3kNnOd0QoC+i1ophng6Tqt1l5NqXZjZueBIlmW5uflEQKeH0Xnnvf95SFNLwOJaRVWXJT+uI9gUmblqRghaGxalAFDymYtsCJnMAToCB8wdwTmwqSm8ENFElJCk1PE0GkdqVouqq2EY+uEpfmuz6V+8eL4sS8kJCIFaq84A5rxv8Yo5ZYF6c38XhzW5gC2mpRqh5VLzktM8rV99dnn5DJA8+yYQNVUCMymmwTnXbpEY47IsqggIw9DfP0ytEyICkTPk24zBSi5VxMyKlMf4IDFmGevFap0f16OICEwAgGreta3l/MhyRlElYkIEQz+spUopS4z88vnzGGJKybPPeX716urhp7t3794R4MtXr8ssmmqaj4hIjh35h4eHblitVl3O1ZRAwRMDA7JeP78ajwszl6wIVKSAIimFjq5268M01jynqdoQBQyQmOlhf8/O/+qf/Zkuy93d9/3gnF9fvrhatCzjXIvE4KfxsIqraZpT0ujx4X4PYtvt+rAfAyMzHY+n7WozdKuCmTo6dwZmpore+2XORP7sdW1SRQC9qmJ9dMMCLKXao8ld+9k7p6pqKgaKBhUZmzeCOuey5K7zBO7h4bA/HhEYCLzzpua7rlHtTEGkbtbrz1+/KSVPx7GPXQUjMeccEp0RNTMDYO8fHh5STuv1WgGmWhgRq2aZHqbjaZ6AAIlUtOs6Imr8gnYpr30YD0dRBUMVy7ggUs2lihwYt5uL0+mUUsm5tH2DiFTRgA4Qyjl+/Bwv1bxSTP+4mPLe11oll/bYjNPcxQCAMXZn4zADJMSnrV6tJEoM0bk3L1+i6s2nm2/+w3/6lD4cxwcg7NZxnuZhs+2v4+1HnU8jDjGuVg8fjvl4VDEWc+RLLYyotSyjTqd9yomJrRVZr9VzLbJed9M0mgl72l5ulmU57CfnGMyZpnmZf/jp4+eXVyH2PAAhM0Oq9e5m//LZtWpeRqnTFGMkh/M87i5WBvr61bP37z6VIkV01fUmgg5SziLmml95q1kpJyRskaSAbdv6x/gA731tSXiPmuaGUT0CXQgtsIvIwKqZRxaRWgsSTkWOh+OHm5tTTqgmqXh/jqVAxFoFDGMXNttVzWn/8KBSmfkxOpZaXGatFrwvtfzDf/xPxNzHLrIH0dgFEK1VEMp4vLn9+OHFs89evflKCXOtXQhqBo5LKTFEx27JBgAEqFLNBFC52VEoLPMMgM3hoz1vZjbPY4zeOee9l2Vpda0R19QsegdmjUfUDlaDdgGg74ZmBT1NEz4St4maJ8ajfSG1Xlavrq7A4Lg/sg/TabSmXFJYrbbbze72w4c8zTVlIAi7HRODArNHwM4hYHc6nSI6Jod4KqVWRQDarFfdgKf7T6pyPNqw8t26s5VzvF7mhYhWq1WtZZoWIvf2pw8713sXDTXNy7B2luomdnmaRQsp5QpMFp1HBmT37Pk2Rr7YDad9CoHRRGQBLI7QIbuGwTxZRYbQyhwREjtHjCLabNsRkJlElB6dIBFRQVGRmJqLVvvHBV9qJWyAqpWl7o+Hj59u81JqFgXbrNa51EYrbZ9E3w1XV5fr7Wo5jFqrcwxm54RMAjUFNAMax1NLqyslbdYbRsJm9+G4yGKQ0cp23X/95Z+sNjsmJ1WrVCDwXUBCQIhd9J27uX/QIiZnOTa3PN8+nubFe/8oS7MQAjOXklpJbHWzAQ1tF9QM7KTXzWYzz7OqNhCuMZG6Ljb9Uim1UR0RSVUqCBN579Fg3I8pz8S4Wq1vbm5eXr7E1/yPH/+WmRw5RHd7czefJjIgpM4HI3dzc+OYaxFitxq6+XSY5kXAxlPu12x0DnIDoHlJx4cyH4uZqhTvceP6TMs4jjFy1/uup+OhrFbDPBVG3h9OlfEwjkuaitRlnoP3iOhczPNckmzXsTXRpeZUpk+fRi2+5Bx8BDMVyGUBhT6EM0W4baDNzg4++JjIBEBMZ5xGREUrAJiptjg/cqbnZGgfnSMmA0MgJEeMBkg8TfNhf/h43I/j4p3v+qHxnFjt5yqrEP16s6oi8zI7z8xORUjBkTJUQBNUQvv2u9+9fP4mBG8QQtd55wAgOK8mWfLbd98v6TgMHSLWWlzkPri0LGZAwTMRiZVSDsej5Cq1mlrr0xHZEYTgOuuWlEyhXT+qWmslcsF3hAygSNxIMk+XUMPAhmFoDLY2GLY60GIZLy+vfvzxp2b6QGdjutAONCFuLy7fvTuUuXax//IXX236DdonRJWSf/r06dXLN5t1n+Y0jvPFZrcN/f54AKpzLUtK6+2KwOZx0Vp/8csvEuXDfAMO2ZFWBJTj4VjmSkBmHJwn8LXS8TCVXCVL3/fqTQUd4Xo1EPD+eIyrQUrdXOyQkIsG71NaLq8u56mY15Kz946JOeJq252OdTrl3WZAkIvdesllKcUsL+PoHqno5/jTp9GmtVPwM0V8WwK2XXVjvPxcHlhq9cTb1Tq0YBxiRpynecn5uKTTOEcf2wT6FEH9KN6Hvu9fvnzGjMfDaGaA1NyI6XGjQkRqVkr50z/9k/GYSpHtxa7v+zaiEomIIJaHw91+f3Ox3qW8uJwIsetXSLikVNPSxXh1ffn+3XtRYWaRes65tHNRanwBVZX6XxjjdF3XfOfUgImKFPzZD0JwzKWUUsrT5v6R1aTLsoTgXr58Vsq5Pj6Nh22CdORfvHhJRIBwOOwVJA6xH1bTae66TmuNfo2eXnzx4vRwBLPVegUpxVWYxyRz0o77vl+WNM3TmI4VDYyCg6wt7ohEABAZkdgZ8ng6iYgpLUuqeQq0XY5JEL3r0bR3xMyr1crHoKY8DHmaACDGIFK7blCV/X4ZT3mz6aDSPKZarYoEBwaiKrWmGINoPTs85bw8vVMNwj4TZpqBmjSdHT4x+OhRy/UkrGAiUVnScjgcGkghtS5pGZfxlGbiMz0m53w8HsdxbHZnRBRjvLq66odumk7zPCHhmQDN5IM3gFzyu3fv3v70EyLc3Nx+/4fvV6vNer3puiHELnRBtc7T4Z9+94/v3/+wzNOrl692uytEVJN5mdrrR0STKlJ88OwYUNuw+XiL1Bi74Lv9wwOone9Rwp9pdURESs5yBuv/6IPP3ukj5k6PdjRPjCMAFCk+cCml3X/tF2bW5oN+GLz3peQYw7ff/UZJ/uM3fz9P9me/+jer4XK/P6269deffdW77vnl9dD1UkSzbfrNZths+xU1+Qnq/f1ec0XhOruymKqVDNOooAgAhhb6rlutWjmuoiXXUmo6JauY5jqNSynifPDeOUe5ZABwSADofTiNJxHd74/OuRg6qbbM9ebDNB5zWvJhfxrHtOSl1BSjNxMDPcefxo6JXIuUE2nuyNzusCoFAHJJSPHJyuFs3PAouPDexxhFxQBbQFIpZT6cHg4Pt/d3qSg5L1VaFej7XlVbg9W+mki9ublNy+w8F4TIrvPewFJZyjyh1b//j//xp7c/ffn1VzcfH371p7/uV73voiKCFESVUj9+fD9OBzB9/eqzly8+71cXi1YwQGQwBcOHu/vri03w/vLi4jSN0zw5ZqIzN9oMY/QqSi0hCJG9c97ncmZUmgEgpJQQ3dMM2M7cUtKS09X2ohU4eBSSPLJVERGbGXpbmD7Nj0QoVWoRpuB8IcbTclICdZBzIoOc02p78ebVm+vtxbsff9peXMyncbPd/fbbH+Z9hgUqC5oxc66JFu1WUc2KgSn5ELJIWkpApIiI4qP7+OkjGMTQoSoIIIJYqWa1oHNGkVKpUfOSJ0O0amWZU8rDeiBCIgaotUrs3Re/eJFzvb/bI2IIhATsWNXYc888L6lKdSKiKs67xzv8zPVuXGF4dAJuB6i9m08PKz5yAM8BqgbEFGOspnf7h4e7/cP+wYe47jwgTtJMm7F9/VY12jkDQBUzIzBuaSmMaoBseH84/uGH3//u978BxH/7b//tn//zf73dbuKqcx0zigcQkRD52fXu7U/dGLovPv8q+OGprLMRR373/u00jm9ePE8pHQ9zlWraIjD+mPxbS92sNy+ePb87HVSMkMZp7GPXGnnvXQzhZMaEQCT1bNjc9kIA0HXdfJpSTvTovtx6hnYnOudXq3UD9xvgXkry3ivgsiQf2Km7u3+YUvnrv/3rJY1LWpj5888/P5xOzHQYT+RcF9cOg0tLYPfh5kZQvHM5FzBaUYBgPnhh5WqX6+vTvJjVfugtZeeaDspSSt6F2AfvAxMjIGoWEVXbbi9qTVVVJJpZLXVJSaR65wB0nMYQfIzDsOqW5bQaVl3fzeNCiKVW5/DisiuSfIiefc6FjJ3ZmbcuUl2jpEklcmbWPK4A0DH7lTczFSWiXHLX9c5xWwcxc+NyISIhprRUs3GZP+7vQbEuiUqtUlHMOee8x8eQwTa3xxjH05hS8tEbUKnasalWVQPF1TCkJR2PeyR3fX39/Plz55yPjshMixmB2of378bpruT0/NmLu7uDowMwUheGfgWI4/GgmrfrwbQeT0eR5snRAqnAzNr80ZZIaZnUU9veVxH1VquUWlUtpbk5vxMSPGZItWtbVZd5mZeZiOzxsDaK22q1SkuZanrx6lkrDs2gMBcxIO9917tSp9u7m7/5D3+zP9589eWvaq1/8ed/kUshpJLKP3zzj69fvHxx9RwQRW2eFgQsJVVc+s51XaxVow9VKqKqSKNLHB6Ozjkm4i6CSRW9u9sPQ/+rf/almHy4u//8s88fHk7z2xtTc97tLjfv352uLre11JJLLVKzEJNzWMqSSlZhAnhIOed092kBQzM1ZQBgx973auK9NzUk0ipORZ33ZsbUtKmKQCVVQzXj9saZNToMVau11rTkvu8b2aZ9JF3XnTtgM0Y6Hff39/fLMndhVXIFZ2oamIpUqGfj5Zxz13WNq6mqIQYRARNynpAZLNdFTfsh/vmf/8sQ3JKk64fnz553fc9gnojIqdFpGufp+A9//3dW7fmLN8+vP99uL4gxWzW0rBIiv379PDpfRO4f7oNbededYxGbYlYMFABgHMdciwgwoagi8DwnAGi5d4xIgDkv+dGRQB8jEYgou/9Cntm6KO+9994Rt7ay3euq6hyvVitEIKJ5mWL0b3/66esvv/xl9/VpXIbuYhyPS176OOw2IqLH6XR9eQ1sZjBPcwz+9es3h+k2RtfF9XhqLmWcy0Louo5zzp135EPXRTJJSwUlEIoueBfe/vBDEjngcTyNJWtg9sNQSwKDw+G0XvfBOSnGwb14fjnPhyKmswFoTjml6gNreUyNAAUDRJ+yqQEhTXkuqmkpLsSIoM0pX9VaMK+BqVhOqeuDqT29g0/t9jIvBmfloPd+HEfnXIxxnuZpnD/e3tzdPxiYigACGjgksbPfhguh67pmXtpGJ+ecjxwhkmkzVANA55yaidTT6fTq9WcxrD58ujHD4J3ntiJSgeo7YAfTdAhuePnis+fPXhsYoCGzIqmoWTmdHmZzqeRpnt+83jG5MakRMIKJISEjr9fr4+lUUE1BRVs8jHNuaYio8+v1MI4nKfLkKHauoS1cbl52FxfzsjTo+GkM8t6H3jPzOE/t+z3HczOZ2fF4/Lu/++t/+a/+vOu6EKMxXl/03/7uD76Pl7vrVy9el1LG8fSf/uEfv/nmP/+rf/EvL3e74zJRdHZ34+KVaCm5LPNcRYhIVFzn0eHV1Yv1ekkp930sZQErWhRNDnfj7775vl/3Yvnj9+/TUrySdz5N6QjFsTseZu/RRWeWLna7omIIItIP0bswHiQn8UQF1MCaZ8dqFYFNUL/46vO3P/3I7PrY1UWcSG0CeQAEA+8dIiJjs2Vv5sfwszwSVQ0hVsmtT+q67qzSEVEVIkpTLksd+uF4PIIDQpRa+74rqGigRdtg1bjFZxI9k4KQoUMA0yJJpCA0WYvM8+ycK3neXVwS89t37y62XT/0683aob7/8O6HP3y/LPPVq+dVa64LAofokalUIUBFvru76Xj15ovPRZWI0rxUUSRGgFJy9KHWOo6Tj2GcTmCGCMF7ZtcqJgCUkhGHUouItiRfFW1ZKa0HaGOUqGYpaMBISNiEG+ZciCGV3HVxnucmWKiSzMy70PdDyXm92aDBetiwY/9Lf5wX53z0flh1p+l0d3s/n+bv/vD9/+l/+MWrQH/z939zKKevXn+ey3I8Tgbu4eFhtRrY8Wk+9UPcXV503VpqnaYjsS+ZmGJVZWATBOWaRdWqmidwxFOaNMaSTQVKri9eX7W7++HmLnau1nJ1tRn6zf3tJyZiZCY0wGq16/nrP3mzuexPy0Ha2CDSx87tOndmu1OIkb33RG1ydt4TMy2LIGE7Me26QiQRnefUd506zTl77wipqiGRiOZSmV3NNYQIgCaV0WmFUpNzLsauC4H+aApCBooMZNDi34xIakYCBCCEcTwdj4evv/7Tb3//08V2g0iq2SSCQi2S0+nT+w8P9w+7i+vYufWq72LnXPDBp5KISUSS2f3dQx/Kmy8+IwJCXpZJAEPwSBhirKWYopmFLsJ4bLCtgdZamv9qrTX40JIXAIGQyRCJxBQQzjwiMVPNORVTBCgGpBTYE8CoCmZVxDkXY9D2n4oBQBe7z15/MU/T1e667/tlzib65ee/OI6nDx8/laW6NV9eXv6bv/jXNze3Wuw0jb/5/W/3h/1xOt0cbjXVkvN2M5j2RMTBb+IFejOyJc1pWUrJBgUR2TkSYUer9WaRuizVsb+86LsQp/tTDFxrLdlMcZ4KYWWOh4cRqpF33gEiTdNUcmYkA1KshOwQv/7lq9efrYvp7cPoiHYXm/mYcq45g2t4HZFndrVWkcLsVKvqH+NSn+72ZpSIZKt1UAHD6hx4TyoIgKfjeH//MJc0LnPKKQTPzLGP3nWlVHYtewlCjH2M9VFelkoayJMRoBCzGTggAFUzleq9/9Nf/er92/ury6uXr151PhArOWdgWfJpfyzL8vz5cyJbrzdDNwxdZ0ApJfbcdV1KS67061//q877Vl6ncfbeg5iZSa1oSMSiGdH2D4enPaBzXKtJ/aMGrtbaD0NJBTxXyQDAhGZaoBKAZ0ZEPStdgdr+CAEQgbCKroahPUtt88NMCOD7/uWL19NyJDLnnAqlOTUBu/dxnlPsgpKt+n5P/N27Hz5+/DTmfHN7jyQfb285y3ZYOZN1H9YXFwX5tMzkrWr1gfIC3vuu7w92lAoEEIIvRbphUNkj4na77Xwcbw+IiAQI5gAZ8PCQH+73gNAHdo7MuYf7se+D8xicryqbXX91PRwe9i7AcTmIWIweUHNJpVQiX0pyj6sGV/LZfaWU2kKeSsmPUgLHjKJaijF7AA0RiTglqZItyzLV/cPp5uY2V3E+xL7zTWyr6J0nVjZdd9vmNdp3nfe+TFPr9ZmJzKILBllqISRqKh+RZcneu/E0idqwXiN6jJ49WjXTst/fHI4PD/sHRNxdXj1/9mVcXUyllFzMlIVTSiICQMOw9awpSUkwTzWEjki1Cjv2fJaQq1WR6pilMYJKAWM4J27CkpaYyHmSp3AXBDQyNe8cE0fnikrXdYdpdMzOO1MDgyoSgu9j8EApJVVJKXddaFzT0+k0DCvHDlCZw2YzBJ+qGIEL3nnfqck4j9/84zfv3r4bxzROUxbdbDalLEWXzWr91Zdfrdbb03jKUjl2H397u1lFNMw5rzdrMyt1npfFu8GvBiWbp0WnWaogwOl4nGEixzUJAzkmdi54d387PepdPZ5djOtqGK6vLpwPS06u88qlaPnppw+Xtet7nsYcOpnGuWYlqADqmhUHMzzpnh+bHzbTUkpbxAKKc8TkmZkdVklWKiIGH47H0+mUb+/uU86lVmIXQmiuQNNpyiWvQu99JyIxRkRIaWkfuWNGNC21susYAFFFQJWYUWGel1pr5Hjz6bYftrGLPnQIYgrIqGI155TTXGZUexFe5JJhyoAE2MTKBlLVtEg1k+5irfM0nmY1Wq02OecK4oInMZG6u7piJhNRRee9gWkVACTHzVpYDLClLxGqttYTUM5JLw2hQdXNxZacV63OOVDTWqtqSZkxCpwp7977YVgh2LIswGygqlXNCMF5jF3XEo1UKxI6RwTqnYuxW+bSxe7ZdmtMp/Fwc/9hd3W1212llBARDKbD3iTXwmVKWhUDLvNM7DbrC1VggiXNx4c9iFJ0gFSmlGoNLiCjicbggBmAayrBd8zguG3xtYsO1DoXXYc+WDEx41Lcxa77xRevxmmP4OacU05SgAC6fnANhqm1gVjQ9oA55yb/MrOWYcTkiQkMVFVL8YHJNxxLRfDm7u7+cHCIrRj3YGqmpjVXYLY+ipmIzPMsol0XmuTGAFTZOR99UFVARWt8JQTgvhtOnz7+w9//w+XVyxg6YjIsoqLWgm40xm61Wh8PR0P4/scfiFYXF32IkZhKrgiNbK6N2L4sZclCgdnwdDoxMzDWWkvKqlpJN/1KVYqaIQCRI0JARGVPSAxEXddNU7FHWRgzEzp9jERoa65aS6lz86ZHAK3SHpWled6f1f2diMAfG38lcnmZCauoBh8el2zFBweiXdf95V/+5bLk//QP3wBQFUk5v5PyodQuxiUt+/2eEI+Hh9v9vk0GJU/7+6OW6n2QqoxElucxAWNwXq0EF4SgHCc0QwdMlCWLIVrbyYuZhq5bDXw8plcvnm8vh4eHh/2nw8p1QFmru7097C4u/+VffJnqOE/14/sxBnIQyBEYdF10ItquK1MIIdRHJ+qm1SSilFLzaGjbfmZ2nkyxiOS07Penu7vTw8NxSbkLgRmapkrUyNQNLjpfTR27wAEBkyUDQ7DoPRDXdkYdkzWooxnTKKHb74//y//y/95dXX/2+coHr2A5LyEymlbLjuh4eMh5AYBU05LnaTxdXREAtBqEgMJUpLJ3l7urTx8/igEykGHzx6pmiqaghrbk1PlgBo3jiszmGcC4cWhNCaHmsuqHlBKqCRizQ8DmEHZ2EdNqi6a0hNBpVs8OEKRWFVQiNVWz4EOMXlXAFAHUBICYHCAAiGNfaykli6jzDGDavqzB4XC4vrqqVff7fbca1l99fXv7YeiGi82u1prSktPSx16YP7x/vx7WQ+xvPn5EMD+Ei4sLQVvvtkbAXUgPJ0aEZloPAGpgGLuhi8PxMPYxKvLl1q+3gyN4eDgc90eRLFqBWAWDG4z0Yrv5V//mV8qn4/5k6u5u5+fPNt6HpSyO+Pb2xrVVaQhcC6a06CMW8LTPaeyDZvZ6Bh2MllmOp8Pt7cdpSnJWzAP70ILXDAjRYgxtaTOOR/auqvQczAcfAkCFaiTqihJTleqdNwGRakgpZUTuV/1/+z/8H8dxYR98F0LXuWbV3FyOpR72d3/39/9hSQs5vLy43G43SGBgLdw+5UU9CNhqMwiCKiKTtnhNUQCtqEqGgGrq2eecHTtEAkJF8I5FoBZVraoCqCb95mIV2eWclXBaFlNjRNWzBJwdI7pxPDHXGGNVMTDnXa218SlqLsf50A+dtrS64Bt9nxi9d4AKoADqPFcpZmYGIgXJVE1qdcTk6PJiRwTs8L/7y78sSb0L2+327q7E2JVpRoJNt3boxjyWvIjWft3vnl/PJamimY0P93WZt+stSC1EIAoKZrDq18uSVMAzZ5Vc8umkZSmqsN+PIkoE3gcpsJiWUrp+wOiWjLuXr8bpu82ldysWlQIChgJ29rh5EpifOTCltPjJdpjaSJhSCqGxxXWa5of7w+3tA5Hr4oo9dX3fBNOMzTjqTIcX0S52wQcTRQOoQh0aoLHqsgyhj8NKwMyMiW4/3CLTZnvhHeVa0XFcreOwXm+3nfcGIlVMZNwfp/nUFrx916+G9ZuXX15sL53jKppLUQNBUTFF2O/3fV/MrBVHUWMFQPPBo6Pj8UQEKlLVmBmBDEGhUTaoEYgea1MysyqiZlIlMLdYOjBg7x7V9/C0nFYxqdU1drBqUVGwYppzDsHPOTMTMYERonjv5nmpxRBxtVqLSDMaOROXCHa7nWRFpFqFmcf5tFqtj3VMy0JMjh2hA4VV7DfPNvOyiMiUTuRodbVTx8usWnQe5/v3D7vOq4qYkXeEWkUR+dOnOzNYD+uUUoFSa/nVmy+WMd3fTZ47UVOT6ElE0lJSyvOUf/P3v6FAX/zqqzGnuGLnsRQ1rH23sQoO0XzwtVQVa6DlGR93rjGu2gUWY2ynDQCWJd3f70uRGIYQgnOhilUV55yqBH8ORDWCXFJH0MXonCM2D9TFUEAVbFh1isieiQ3MpBZESKV+/Onjv/jzDTLN45Jr6bttN3Rn/pIaoj1aQI2Hw+HZ8ysDfvXss/VwzRSbiS6hGSgHNlWrdbvdxq4/3R+lqhGSglZkgmKCDhHMu3BxcTEdj4bmvBOV1uw9btzbQYFaylNOAiMZaHNGNTUQrLWq8bDqvQ/LsgBAyUVUHTsDA4MQgoCi0JKWLkZiFjVVISRmcuQZi4gCoVklBmbSc6CrERozgyN2ziAvSxGx7Xa7WW3++q/+PxeX234YLq+uLy8vb+7uxukYYzfNIzG9+uw1BP/h0+3dp1tCnE/Lq8tnq849HPfkXN/3mksZF5Fac/UxOudKXtg7BB2PU1qWGGItzZvOHl1Cz4nG092y5BLCp7QIEqMIiXllDy6PySFC8AGhkfH1yWo75zwMwxM3rR01MxORw+G4LEutyuyZnapq0VSTmnnvqlQRIULHngmJAQlrrWSKgAQYojckZwbRMwFYATWVogi762dtt61g85IdNY9uxwRViomK5pTmYehfvHg5zQ8P4yfTsLt4HvwKkRo9jxANqYK2oFckdM6F4FMpgNguIABTaftiyCmnOSmAgIIWZmZkEWmuOGfGnyE/+tEREajBmWFrAGLVDBFErOrFZvPx06d2tT/1EqLSdd1l3KkpiZkoOiQmUKuloDkABMXoPDCM09jWiPA4yBiWZkYyTePhsGeOxBhiX1Mmhrdvf/r1r//5ZrNx7Lbb7dv3727v7lKa+qHbrNf/9N23b2/23mHw9Px6dzWs371/b4QMkOaFEAyNkaL3gFRFstYVd9H3H9/elSLODWYZsXFiVVRDCKp1t7s8HHKpdtofUYGa4XWtm9UWibOIM6NpSohsCrWWZVnW63Xbwy/L0lAufUymMLOWkyZSmZ2ZlpKD7wDV+2BgtZQkEmP0wQMatVkSFEDBIISIiE0RDNaCn7FF6CIiMTOX7fYi+LAsaZqWGNfMnEtBUkLQampSaz2dRmZW0ePx+PrVV871SKjUWDCGbRQEbTuWWuXjx4+1lHYTg4Ijp6QIyITtOy2lhOCncSmlMLuu65udmve+lOocMVFzYzszYEWf2FcASMwGgGaSSmNZPfUSjekgVdKSzjO1aPDO9wHVnHqppdbaRIpVqorlck5WjzGIFDVtOpUQfKnLNB+HXkMcQgjH4/FP/uyflbNtJO4uLpjo7uH+YrsJ/hfm+PLqyv34QyTcXWyev3wWkD99/2OVguiRKKWpJXci4rBazSmZqSN2ztVSzLxUrXUxIzPoujiOp3biQ4g5J7W6WgXETKqRAyOt1sFBmE/VOXbTlE01xlDPZBJalhSC996Xp+Cklq5WiojcP+wPx6mW2kUOMRIhIpEam51b1JJrrc671qC0W6dWQzz7ARGYVXOR2+fyuJplNfPsiNlQHx7uvYur1aZbdV0XmRUBzFlVHsfTPC/7/cPvfvdPV9fXr199rgYm1bFvHYmJSJUiBcw8kSd3yqdhM6RU8lyGOIBihRy8L2e5EXvv1cQ5bvfEzzmi7bZjJrXmoANqZk10DSANeiBqDohaxXmPjznFDbprB7o1FWd2g1/1XahzrVLP3CSzru/UoFYVTWBWa2myDgBk9OgAgfp++Prrrx9dpVwIYb3ZmEgpZVmWeVl+80+/Gadpvd5cbDcYgwK8uLiCVLu+02WpzhlYYIdAF6uNI/7w4VMMARCWcWbHYMBMzOh4MM1SW7YeqMA0L4Cg1WquKeXqKiL1/SA29ZG11LkyAVxu+3mZEJwj5FRrzkeiEGPnPdZaUjrzDhrjsf1iWZab+4f9w1EE+i4gNQNkmpclpYxE7ROKoUmljR0H7xAQFNBIa0laiMnabtjO7UtzT2hNMhE5wmmZ5zkNw6rr+r4LzjuzQgDEUEVUpOu63/zmnZo67PqwbdR1AgRiMQXnmYDniojb7cV6GA6HPXl2ZisaOh/LIrWA974tiRFRRFKenIvt9OvPbMmZmdkBWClZTZk5wPllE1OIobVgiGBNiUpo+F9HpvtzSp40Ppaa1VIYnaAU1VoLokXiJmNpm6AYYoOsiQia7Tk2+pf3PrSzdXV1lXP+7qcfd7vLFnQ1rFb0CG5HdCktX758vetX+9NxmsaKidhdrNc1l5JSqYWZPBEQQFXnIjgWUYe0Wm2W+fZxlWfMLkaXliJFaoZSIM3VBS59XV90wePh4ahSkHzOMk+LKbnT6djQO+ZCxCJlWeaW7sxEaUmAUHIhpmVZ7m4eUm4Wy2W1HjxArrIsyzTNMXa7Tc/elZobMyR6JqaqFdQG4AKSpaKZYzf0vWq1x0CRM5cLjBiN6XDKMW6GoSdCtaqqACZmpdR5HD++/8kxXV/vqqQhbB1EQ49nYT8goDGRuRijiJSS52kWkZ9+fNv33Xa7BlTTSgZt5dCuE2ZqzLNaixmEcCZXtWNRRUxqOxftP2unpPnMOOfAAMzQqamlWkrJP0eYHx8efKLm5pRi7ImplJJrYefYsLlM1SqNd9qHHggaQ6Ke//KqWn3gJ+QMEUspt7e3tdYYu3c//qSqwzCs1+uG+4yjK6VWNTG8v3+oUr336/X67tPt/f09BGa0ztNmvfLBf7qfkioaQsHjcWztdVsQO0cAknKuYqaGrQctQj6uL69lyY6j1hJdN8+llMoY3JJKy61Ug3Q4IEHjSC45WaOVegcA82laltRqDaDlWjil5m4dY4yh884zO0ekiKYCiqpIiExEgCjmySkKKcauiyHmYnoOUNFapdZCzKnW+7vbUnCz3nkfua1qm+UNQpFqWh3TzacPSPjqxWfPrl4jMpIDMAAFMwQkRQRSJERzLvz29/80L/PDw0O/HlbrPyMiRFuthmKWcgKAq6ur2MUlTcToKTSasj56jWJLjgVwzE8HSx8NV1u3gEiEplJM1Tkm5pyzGeSUcAPM5ySsBveNp7FRUovknIuoEgG7oCJm2PLrmoCbmIi0ionWR4d9QiKtdZ7n4/GYUnr//v39w8Pt3X3XdWlZmOjFs+eXl5dEOM4zLEuZl67vP97vR6mby61TrQSnknOt61XnAS42q9fPdwB4d5wYyCocDyffd3Q2+gciXNI0uLjZrPf7sRYyM9/xZre6uOqc5/tPR0JXUmbUZVYwFBVXRRuZ3XsTEWIwcFpqrdUATDUA5Jz2hwMTOx+qsAKp1DbZl1K88+vVivAspYohGmizQSdHZoJiWaSRYvo+Dn2HAC1xuRVBVVmW1Fg0+/uHYbNDIueDdwFJEcxQRGVapjRPV5e74/42l7LebGM/mGHTOiiAVAHkGFrzlIk4hEAkzPL5Z8/jsHXON7q6POYGmFktpQ+eAaQUZEcEiNZypOAxVBEBci6NUfMkWG2SEBExE0Q1yKpKHNar9ek0qgAi5lTUUmOtNREKIMQYTak1SSllNJynGRHX67XgWcQLAN558AjWlkuNOejRrFEIt9vtNE0xRhML3vUx9l03jZOZHQ+H3eVlH7tw5dN689O794fpdPXmxfXrF8fbOxEdLjddH3LNu/7icreNQ1jG7ByDD2WqU1286tB1p2k0A9G67vq+70VlGHQ8VjECrF0XkXguuYoE5VqKG3pYMiEpoDscDq0kwc8Cea35EomC0bKUWnMt5qJDpBhYwVS56X0J6Sypc060MjvnfVOOtzZdtdRidcoEuN7EYRWJtBnKG8BTsmEjNx+PR3YuhhhjbE2MgZrZNM9I4Jw7LOnDh3eHwxEJu64zRAVArdpMjghNFRFVRFVj9MMQP3vzRZUCIERxHidRZSMT4bPmG0BlE328frY/TqWKGbBjB74V1oaLIlrfD+zw0ZoVnrp7VUWkKlJqIgCt6r0XqUzODKVCkdJaqyc2s6oO/er51dUwDIiQc27mtDmXEFzf9y0TuboawTvHzjWuANfalt3SRkIz2+12kf3peCQm5zyJjeNYSnHer1YrY2vbw816I07f/uEHUMnjLEuxWreXu4BcVKwPSWy4vBSj+9Odna0AWGpFIuciMU/TXHJFZOd4Os0Xu1UMDpXG/VFLKcWcc44DcXZMudrZ0U/BYFna5aHWdgtQa3UcAQGRYujOFo1EudYQgnPciEdglnKqtYTowjmlMkV2QICIogpojNZ1YRgioFUpzZ5PVUkJEB4FCHA6nVbDqt8MYYiIJjWTI0AL3hMxoWNHJWet9fmLl46DWet0IXgPDrM0NxJ8VNLiPM8iBBZKSd6bI0bAvOTYdQTgiIGVkbxz7KkWTaWkXNDYe2rMdyMEYCJcr4ZScquSes42O/9AbL89EzRyoxugqlAFAYNaBIHAUXvNqiWlchqX7Xa18oTHkznIubSrqUniGmDhuPVzpf3WjESSCqrA3d0dAMQQ1pfx2e4y1zIvS7Nj6rteRJa0AOI4LvOSQvTs3Xg4lSUFoGkpPvovvv4yT/Px7ua4pB/ub0/3GZROx6NHj4hgFQ2iC0OMnl0qWmubalmqeA5oZlXqaa5zVgNEVoBsVUzN4OxxKEXTvLTpzwfP3PBmRILgAz9aPDh2asbOOUYAYMdSxURLKTFGA1LAUmspJTIQoHNekcwheBv66By1EbMFa8FjFW9tSi7VkGLXsyMxdQBmouoAWoqaoYJWPR0PN7c3188/M/ViaqCd75idohgYEyFCrTWEcHGxu729qbWls6BU67t+XmZ2TIRo1oUgzIg45bRMpyKYizI7U9BapLGtq4pAF2POyXvfAaAjK+08YRseW0MWfCe1ekcx2BHG9m2JSHMDEVFmFDEmj55VtYgAs5Ta9ytCrKVY8z8AaBuONhnU5tqd8+OUo84FH+D169c55y5GpwAAy7Icx9E5h22hrzUtCzvnnU9p2d99evXm8z//Z78+7u8f7u5Hc1dvXgy77ZzmSjglubrYlf3d6TgxUAheqmSsV7ttP/Rd59aXm7cf3j/qItmxu799QNxyZ8uiREzsAXCZ07IUBDYTF0IUbS7oamrOucd9FzjviMx5ImR/NodwtQqTtcGngYRS6jAMfd8zc8k5AzCoc+iZEUGBahXfdb5Bt49KhFZ828FiJhCapsXQo2NQVVFwBCgigGCEJlWtSheHro/r3WpZ6sPDvYtRzfzWNx+mWgp6PBwO3vvnz58z47LMLe4VAERMlZCorRDaldy+i8N4Wk6TD6uiyJ6t1pRSi8VUReYz5t4UlArGxE+Zho390ZYNqggKxN4eI4YQqfGRHl+DPP2clpRTKiVh1RgdOzTTItZgsLOOAxxiw9JCa7yYz0mwbTgFRHE4nsaaS9dHtcrOLcsCizDifDztLi9fPb++vfsQEbDkoettXXHJDvBwe//dP/120w1OwDEyYghhvQ5apZYCgOtt9+LFZal5mkaptfV5gDAMwzSNx+PYgWP2fT/UYt6703GWWokREV0MLmUBg2rqiJjY8Dwht0KraqWmKtW7s7N+84jyzjmmdjd0sXMNoDdovAYfI4mAKag6xmHVOUa18xjVRvH2DiKiAeSyTOMUY2SK0fchdiYi1Ti0m9MTlqKJkfrY68X19uISCQCByTG7VHIFRXIAqICOaZ7mGJ2qqRbvXd91JUutBY0QgNqWCbmLXT/0RDbqidUAecmF0LR1Anj2zVbTWq22YgDnbIt22bd+6AlZEBF2LrCvRVpuWd/37STpY9xhQwpySdO8OIack3MtLgUAjQhrVVPLOauV4M/A1XiaYhecb4UVmZvYWEV1nEYAWK23SMaOV6tuve6XcQnO1ZrXq/5Pf/l1XnLLkXrx/AUpzWnqI/Uc59MspxRjDIh+tzHTNJeIzqyKFu4sT3Wa5pILO0fEKUsXYxd7563rwvMXVzktdzf79Xp1PB43225ZpKq6LgbRWnMVtRgYEFrSZrtXGvhbay01IZAqmWnrrJvbu6owe0/sWrg8EjMGhzVXRlApJS99PzgHIrXU0g5ie3/bMN+SksbTZKaOHZNjjs03yYylioJ6zyI1l2QIq9XGhb4fBiRvZj4E5x2YVhU0ACRDSTlrEebN5W53PB5Xw6oRFFTNuRgQFM7OetvNNoSQy+JDADAkhdaVUxNMoKkBWmvWG4BUamknwx4F9fAzXbiZMeKzy6vb/eF0GolQ9exh5JxTtZxzKcUHr4rLPA9DZ6alnCNkEcEHVtPaYotA5mVZr0Mp5ceffvj888+6bsXkALAKqJ7/r2EYQggh+hB8exXs+HQcu2FIJddpev3q9WG/H09jWz/62PvO3958Cs4T0spH5wOX0vIYV10/jVPN5fnLZ7WkeV5qKUPfFdFWZnKuzrv1JvYrP47Tsoye+enKEElm5pqjC4t1MeaUzCx20XmaxumsFjeQKs1CuJQcY3Nij6oVCZzrAQRUVNV7T61DqaVYroDTeCLUiwtnpqLypE2Axw1d+xkAxzF7H2KMMUYzrdXAABFK0Sp1nkc0m45jjBGZr7bbod9WAVH1MVaRpmmuKhW01iq1ukAtcu3q6kpVU0qiBoZt4PfBOefGcXx4eNjtdsuyqKqZVC2E5NAVEe9ccFSrAkKDoOFnqWYppSewlH6Wc4aIana928Vh9f7DezUh5CpKiP3QI1qtT7JVv1lvc55bE9IwTwN1j5bNwUXRknPKOQ9D/9VXX/T9ykx9CGBgUEMIrdC3XVkLKzXTc2l2nl1cD6vTPKvq0A8I6HyXc7268inP+/3DF28+64Zh3B9O40RVSGFZqg9US1GVh7u7eXKh8+yc865Oy8V2VfIhLQBUVheXq4v4/e9/v92svI/HcQQ4u5oDkDtO42M9slwLqIUQSn66rgSB7DHGkIhCCK3UUrPkNlUV79hEkRAI8phAMrRCG7iLPRKrapun/CNs3R5cZmSi43FUw67ru+gdUyPXgTVllWmVw3goZUa1LLOiEfkYB6cgdjYFVQQCJAATRbPg/ND142lMaeljMFBVQUMVEDEDk1pCDGCmIp4dxJAXX4p6IgTwzN71gOAYEQwZPTtqCArik1/D02H643L60Qlimmdmvr7cAYBUSTkzcfAewBjaIh4AwBECe+CK1MSJi2pNCEYMgmiEJIyWc9pdXsS4S0lKEW+GRNio03p+PkUk+MH5SAii6IC2F17EDPTZs+dpmT3zel3HafLe+13IJRtqzTl2cTwczCylBSASMgKIaJOqnvZ1peQCE3KIfrXrbx8OXReLnrqVZ8YQw3q7S9MUojOzZc5EjpBcqZUQc5GcMhMhYWMdhdjseMzsMf7KufMRPJcAQrJSspl6dsyume2nnGpZVptViy1h5xCg5JJyJiL3tMBRNVOioEgpi/MdO0byDYlGNAMwMAVbJKnVDx9/rHnabC6mMYNi9FtkX6SY6mkc7+7vnz1/wURm+pS2WFN2QGqASIBKBKbgmVo4OBg0qqtjjnFtCiXXXCsiBPe4SNaCgMHHwIwIxGyAKNjgmKc62Ai3rT62NwrMlnl6zD2WFmCcZkGA9mfBeVMdi/gQYteLVCJGwFpMVJNlNjI2/v929WdNsixHmiCmm5kvEZF5tnuxVGGqpyl8JkX4/38EH5pNcmZkpqZQAC7OlpkR4YuZLnxQjwSaKRDIEeAsEe62qH76LQIJ+kNEgAd4grSlHqzMfd/f3t6GYcgM2whAljqM296ImIh770Wm+lTBbLH729vb6XQiCiS4PF2+/u239ce69z6Mo7v3hr/79ff39e16f3P3vvd92wHj/OV523YNrYOUoQyncd33qL5rq0Pdtr3tmzuGUynVzEspoqpMlNN4gvgHAwlRhFU1raT+WWCYpEpmBsy5h0UEIBI6qxFFGWpi0wdbcN+TLP/PV4a7m4Vp3LddA89DrSNSDSJAhOLpg4ABsG728vL97e3lfn3561//Oo7noYx7W+owQ7i5v7293a+33//ye2K+3xZhwPTTZnQIAAQPAnFXiCAW4kPvT0T5Xdyj7btamBsCNI/8gubaevcg44YI0yyESGIFyb0m1OkPY8n3LZca8TyS4yG+ADtMuY9ViNFDu4YLPo0TNYiIWiftyISARgAjD4DuUcpQiMgc+EjKyKxkAoha6/l8/scg/xFT8O3bt3m6TNOZGXvXcEN3M7vf7/M8J3DQe4/wQPj8u19QAb98vr62YZjU96fTed/vampEquZmnz59/I+//PnvX7+ez+dt7fe39bf//DYOEhEeQcQ/f9yY6y+//PL1628RIb11qKLqAKCmGQpX61BKiQBVy9zK/MQ5pZeSofMASAiZxptrBSVw29cMFGEkCDAPjVQfcKr4c9yo3YqwA65rL2XIypOrEJGbtbaWMgMEh0Zbf758/evf/jKOxc2JwawBWalkO5jZ5Xz+lz/84eny9LYsRESU3nFo4cAZG5TG4Kju3TpLgh3oDkTgELfrbd3XnDQm158JAcIBM77akEotrbc6MLEj4DBUREybHX/YffEjB5SIVF1VCSE95RFB1cNcEdQtCAyAMNq6zuczgB/4OzIgcXiVwqUggkckMJL5wmnHAgGEJYgJHSbM1abdIo7e8/n5OQK37VaHguhta6d5ltL+7d/+LWeQwzB2sw+fPgPiME8/fvtqqsS2rq/MPM2T234UPMJhse97uKHH29tPdTqNZ9qlmUrFWsuyteWmUuPH9++m7qZi4bpt7liYyzQCAheexokIswF0923dTqdTbrUIl8IPq1aMHDMHIHg4BME0TSLCxKn1NFXtDQBIqts/LH7Shft638zifB7HcSqlkEiabDlsvan2/fb2/evXv/a2579yefrlfHo6nS7jMDCL2eYRUsre+7ef3/UBAjGzh2EEBrgpIALVgJZjb2teSpj5tq3jON6X5Xq7Rng4MFMEBEUgqTsAZniHB/TuLFhBII4aCx8uKYnCvCMOt9stZzgIBMkARWJm8+imTmDhYBjugKiqvbWplnVdCQXRA5wAhVlEgDDUetu6Ngj+h9sFUkSEQwSmXR4AEkmmISPix48fW+ut7Ug8AVQpADBN8zyf8qBFpq56Pp2J6O169XAIOJ2ml5eXdd331ty8SCkEPaLdVwb45ddP0zS9fP9PkfHX3335+vMrMhQo67ruu2aUhLl6OCMIMFlX0xhOY77yoQ7HAhIpRdreI3ZEHIYhjSbDw8DyXgPEgYTBgTxCu8c4jg+7RHQ309a2bRzGvEzffU2ZUTvvu6Y+Nim476kW42nG1cmg7cvb20tb1rmMpcjT+el8efrw4fM8P93vbd92DyehZp1ZWARV3Y2YTqfTel9cFcIDUBGSgchcInxdV8Q4nadaBlV1MyJKX8wEAQMhmMLScerILnTnXrz1nlyD3jV/f3pxP3BlaK15xIfnjwuzRVrcMgAHsoYiUMate0SoAoC5iYzDMCBwFvbmRHy0exHuTgBOBP+cghuHX1J0DYgopTCjh7/zfvMgcHdw50xfQzxWPCIXIeaI2LfdWissa1u72rKs+94jYBiHy9Pldr+3fQ0IIDxfxtt1qQNb6y/Xl3Gu43l4e30tVcxsmqZxkgB1d2GUMA+P9P9VPWqs3jsQ1sIYJCzZ9ZgZArIwBIWjRyABEgZQuJv1cIsASU90Ijc3MzevKUl9GOamlzBxuV+X1ns9TWku70agPRNNkiyvBMxU69C0n+Z5rMN5vpzmcynjsrb7tnaIZjrX2VJjkynzQFXqPM2Xp6fX65tweqAt6aFj7rWWSeow1Pk0E/H17QYASARuve9EwswUQIT6SAU7UNLA8HggogmTBkCOJjGPjQhnEm0KDqd52noLC1U1UBTspqFHeZc1hAeEAQEJs1lgLhc1DVDoLJLjgoDMEIFSKjj40X6GMFIlMxOpgN16tD1n4RqAzLzc7gBQHiPwd72MLcs0jGamrZ/m01CHl5e315fXT5++IMLLy0u4csH21rv5+enyyx9/7XHX3moVo9j3+3k6C1Nr7XI+v/24qQXzxYwI2d0kdSZEGSRe87BFxEAwcwICQGZOgCBBrMT1PRzUC7ADhmqAYXj2/Ai5mVLUgbVWYoYIB0zrH3fv6tf7DYmEDrOo8CM/kwAeHWG4+zTNETiOp1+//FKn52EaI2hddw+XWniskT60QBjpUYPTOCUIOY6j6Y4kSAGQTjVATKfLbGrLstahMhMcRmJZrKgqAwDYP8rhx2yY3JOI4AAYcdiTZnpK/jeROHqidh+enzxi35v27hAGMQirm4UzcSkFASxgrANA5CcXKUkLOICMB/ELgUQYkQCQicPsIHQADFL2bXd3pFiW+75uX3/7Gh5cy6fPn75/+8bMnz9//mcsNx7UWSZ6fno6zXPvTWQ4zZdwu99fRei333778f07MV4up6ePz8i03TYmRjQWnGQotSzL3d01YlcP8G3bnp6eiGjbNvn8+XNifUQsUuBhheUQ1vRdmpJfT/joq1mQyDGiRjg4gIcdpviFJMzVUxrlxIzM9tDG5Enee399u6rbPI6VGAiRCJEhKI3XSZsjSpFpmn78+HE+XYZhnk4fp9Mni1ANQhaBTW0YJtcgZopAwhzKicjLy8uyrsQUlhmBYKZpe3nM6VrLD4NE5oYOEcBECSllu/deReXlUgrvrZmaW3L3Mdw87B/rIB8XRBC2vqqWMNS+b20PiFKHUaozdlNETFMMBxc/1nRAMFOOZe1hg/uO7+dM2jPPp7ddtZYSEXvfWuvIpLbe73eEECm1jBq6bdvtdk/mzzzP755kOf/IzwyHQzhcLjQO0/1+XVdOtPZyvtShUiFn/v76om19sOB5mudah3VfpnmK5mQodSCitAOOCMmv9yjM4VE0KLgDHYyzTFsYx1EqRqgHojFXKhWrQQQbxd4dmYSZEZIhmI+GmC1FuJkCEREB3XXZFylDNmERjzDKbupcpdyvqwibWa1jgH/59GWo5+n0zDK4useODMMwLq9vfW8YyTDuAOBqZSiqutzXQABIIDHF7FEKE3E6quW7HIahSvHW3u7X1vXpfPnw4cO67tu2jcMQ5hnIMU51moYIWvfNzBAlvebe66pjQAvgERoBCGoW4G+3Rc0tHCIAtAFEBwTQcA9MQR3W0kKDQtJ+5JHQmX9nXpqYFzkgEmuER4DZ6oYAoa5hAoKI8zAWoqnMIlNIWPi//dd6e7sWkXGaWu9jKTlhJGYLt97dvbCkc1OoDoXHaSh3+dc//YsU+u3r3zzM3JfbWyr5ahlJ+PR0atoocBjG2GAGYR4VbL3eCDmC3l2K+DG/M/eHR3KAuRURrhURmJEII4AQmaUAMgAXIhC1MGGRwpwCs8OHMxlcqd+NcAQgZg+7L7sFDiJBGBmG5a4aZurUtfVt3QDivtzmWeowneeTdnLDAGUSKcO2b+BRSUwN3A1h2zc3d4hxmJe+N9VSS77093yzIyw9T9P3XwNIHeh+B7Vt226327a145A2DwASVuu1FKnyUFggQPgh1YH/v6lOQICHgjuhQSQerynpAYiMbX+QBHM+3boz4lSHjGfHfxJiiAghutm+7UpdagkAFmm9772VRwI8AEgRMElP+tZu9TSNp2l4Ol3OZ+sahKKFAN2MEInTHNSzDMih+rav5iYiX7582fd9a8vl+fJ6fb3e3qZh6G4iiNyePp2WbbWGQ50A4r4tjEjdTbuFtt55GOT9DI9/GLYaIqnqvu0iMo4jIgYYoL9/1VqraPfNYko1vZVyZDmHx/sxngdhOqW/Pym3vu8dZXAkZuoEEtHaHg4IZGSGnZksbNm3pTUusxmYQWtaB3Fw72aGe++pxepNHaKDEdM4jB+fntdt624cDAb8CEo9aseIXOIPkNZer9fbbVUzKqLaX1/f0or8EWoMqMREP+Ht/HTCw5r4qP/yqqJ3Kk4eLQFquu77sq27qXoApT8zHhBBOAFmkkVAtNbc7Hw6GZBaT5uMf1ysD6fWbdsAovTiCJBBaBHp0kuHCi+Fn/v9fm9qn4bfIcx51RhpDyMia52Zgdm1mykgMhMC9q0zlTIMuh4JXOM4Avral9fbzSM+fHje2m5qVIkm+vnXt/2lT/M0neYIIGYzB0Y0ZKGIOHQB+fL3fdeu5prTPUAQ4YCotdQ6IsLDcZ8IMDLjyzAwCJBKQeIACHwULmrJ7zTziNwZaKbX+13NncUcwB3UIcBCIZAAnAMZ8g6dpunf/+P/+Pzxj3//fq1l2rqWdTGL1tUh3KNOIzHubQdEFi6lfPz48WmaRin7su9tp0KH3ub4iujhkZmfHsQEEdvemrp6SBUIgG5uyqVEgNRix0gQtm0DChEOB4s+DKMUcg8ISZ50ZoY5RF8XCprGOgzT7banhAoCCPEoBxAiANUiEAVZxABaV2Y21VLK7uph7GRhPTzMCjEya+/R1cLVTIZSZSSi1FwmXkMsZSjF6ufLE5fJmxmFFHEC0Ijwve95vt7um1skHKmmTd1skcLUizlkAlwgvd3vGm2YxzIwyvTz9cpArz+ubfN1VcB+OuPEw07NR5igLItHoCY1OR7xOK213JGlIhENwzDNcypPxnFMpZyasRBSYg2ZwANMLIwB/5hpuEfQQaXPF5ND09b15+utGyM5eejeQRCAIPTI9waCCLNsefzt7ds4Vhmn8+WslnQuklqAsIVLESKKCbTruzLCzd7e3izRqXcNVjxsGLKRAwDE8AiAfd88QEoR4aY9CZuFcBxGQkKm9LQFxNb6p0/P//rHP3778RMyaYEAIlpv2RCJyM/X1xQ/Mk9DnURufe8c5ITvh0p4IFPFlGPoqUxUyiEBYmHhrqGqgWHm3XWoNSyadnNLhxbtnSpfPnzorfnax2HMVhxtJADmcjrNvUMAmhoiqFlre6Iq9/udWSKwqwkhIEQgcTHXzLbZ930cKzOvtix9HeowU3392zculdx2M7Xt+WmE3XtvYNC3bmbT07heb0Da99COsixL4uB5ACZMgKpDnVNtx8xJwBImgfDCwRTqJMCIEbbv/XwaH85WnnEEOStEovdCBBEBcbltvWMIJrMAHS0UkcJ7Vy3DNEqN8NYbcby8fH97e/3y5Q/n5yeUIoyllnAKC2QaEOWhqdppz6qu9Y5Ey7Ko6jCOZoYE/9yyvVdFqTp8fn5GCBZMxFK7mqqCcxwkvmDMDtA9aq2au9u9qwKAMLt56z3B1VLKfbmnXGzf+uvLm5piAAZkMk8Cnplml1hULTWOhwOqWoj3vQVFTqYYALo2U/QwcEMggsJCTNo13NZ1LUFdNZsgZgoZIrB3BSjMbNYDspECgHh5eVH182kIdCdwBgwQEXJs7fby8rate3qh9d45ZC6zAnvXUaZf/+X3395e/rf//T/2bf3d7z6J1N72vvS2N6riCPdl0z0AKMIPy6v3kJxsesNdHj+1DhDi6q4KZIjW923ftkBABqKoAoRxPCuIcEjeFTLhI1srj7G97bf7KlTDArp7U9cG1s7n8cPzh/k0d92X233f+315/fbzt799/Zu6tT1u121ZDZC5jFJrMDHzQIWRCTn9TxApHGodqcr5aUYmZDHASMjtaE1cH5SDNI4uLGE216Km3RQiujtRoSIK2sHMj0zDbGhb23++vuy9ublp3/et9Zbs6aXvt21Vt9Z3MwWE2/0mgWl35NYjjBkpjWRNm7XmHQEIqUqZ62iq7jtYJw8pwkxqtq7bfVu7aqin7KWHUy0esS4bIhqEQxBiqbUOZyJGpPtyT8UKEGdRMc/j169//+23v5VSiAoBYQAQIZMcc+Eg4i9ffvnl85e273//7bdTnf/46Q8TnWo9f/rXP3WM221FQw75/tv15eWGgdu+NejDUzE1UwiHZHPIMAyPEvtIXy4hafhuZgRYRABCtYNjkdmsh6qQwMN+bxxqrs5kBaopALyHZcIjIgARl/vi3QAoZYAZZzPUMk9T3oL7tq/3Bbzuvb3dvv/tx59LZSInIimFWRCJmNgdgALQ3CFs2w/b/ggbxkpMl6fz3ryZ1aGEmnukNSM8UK4IP58/ffz4cd8Xj/BDhhpBZG5DqbVWM410t8Wjk8pbdNdOLIhHC+2A/2jMAJCIiISpq4rwaZ771rZ9BzWuIKUgGqEjHDMW3xsDiUiGDJo2d0DitMFBgHmaNJw9kDmYclA+DXPvHSKezxe3DSFNotC6urmaIhEXMYhaKwsA4LLc/vM///zrr78vtR7HLTEShUVaP5zmy9PTZRqm7b6s221d158/f67rum97CL/e7uv69v3bDwhgLvtmfcenS+lh9TScP55/+/bNPYgRezDxQYBMD+o8utLEZ99bxoETAJJjoBTBBIgDxmkkBrJwsHhQNXJWY25EREgHQzxBSMRt296utx0DAiCggzHieRhb6z9//jyMuJCIaFlWNf3rX/7z9v3lX//132qZkTDvjxSrmBkyOoah+0PAeaAA6N+/f7teX/fdMp6VDLUrvktPEfd9F5FpkjrAsqiZtTAMZEBFzC5YVSPc1IMO0GgaxvP5vLVFIQph+oI4oQcKMYa/f9lhHDHAPczMIx7Z7IXwiJCphcxUxBGxAhUWCmvbbm1nZhLWAET0iJxbjETeUit/OF5kibIvyxowTyUCWm+BSIc+sQG6Y6zbSuHjVJn558+f7p6RWM2VgYgoANxtWxsAn04XqWFNIyIdh15fX9dte319XdtePpzNelIMRagUAbBhqq9vt4+/fCij9B6mAQQK0FwPD6d4CAEeRhTsbiKVGBGcAompDoW0EQSXygEMjOiIHu6B6RCJHi6Z54GJeOr7Wdiabz0QyYEcNCJqHfat3dd7qULBRDgMVaju23a9v337+vXl5fW//ts4ljmwuPdtCyQUKgHYVCHBagBkIkRTO08Tqf/2208AB4TIHsLT2wpzcERpSOFurr3dx1qHKvf7lUKEi7uBhwzSW9feRQoz1aG48TAPtRbVQoFJJvY4+j2LAxWzNDbI3ArtHrGuq0R0DREONXfTACY213GskZcRIoAhAnAQo5SB1bqZeQiz0/EtwQMwhMWbLve1lhrqwQGGCLjvi5rVUi1czUk4DAiQkAH5tt6Y5b/+1/9rqSWAkCEz9NKbgAVrGbqqWby+/mzLTYh++fxl2VYiWu53INi29Xq7ny4n6xrQ3XyaaT6PgTFOw3mcCPz0dKoj3W9tufXjxErZ4DvuICLZ4nk4AUZEKYzg7kaQ8/cOEEhBSAH/qGDer4MspbNezlHj39/ebupx1L725ePl+en87//r/369v5n7UMeh1tYaEhHS9e1tvS3zOI/DAADTMJZ5VvM8DrMirLXubTlABI8AGIcpzAmhDmMSyAk5JPwRVlBKWddVijDLcluF4HJ++tOf/uXbzx+v13XbO0V4V0OsUuZhPJ1O4zDVOhKHe8+rDwMzjSLxdlVFliRdxcMt1o5ZqWnv4zhu++puIiJDFc5UOuj9kHO1iFoZIpiLO1r0nHAhIDMDRdtaWgxiQKi7HgTUUiT/YE5gk6MsjONpRmaHkCIRYR5t9/PpudZha7sHwN7UGz6k+xmeqKoIDoitt2Xbmejjx48fPnxwdwv79vKjfiinp8v379/31t0xHPJaEy7TdDqdplJHhV5q7f1Vcp5jZhmjPU1TKYUQPSAj6eEgaJuagioVAQQCB+8OSITo+OjiIzyEhTBbdHvHSN/e3v77f/9//ny7W+/MfJ6fP0z/ZWH6+v23t5ef7iZ1fH7+cL+tSCo8rrfXeZg+f/58OV+KFO+63ZcyTcScJui5jjEkPNwNAdIcwJWIgQXTNI+IMGDZezB5SirMxnEUEdO+be35OQYsHy7PArWPdr/fK0vXXlIzvW7edcVrHaon9yCt/OKwYcnF9X6m4JFvZY89hvu+F0J3TwjQTAFEykGcIqJmHR1JRu1BKKpWBiQStZZ+XchYTrKtG3tkKJObH+I8AA9jrrq3PBS2beOCLALhaV0RAGYuPDEXIhkqq2nheodr7613TUvsvTVCYuaPHz+ex3J7ffvx48ePlxcROZ/PAL7u231ZXn78aK0h0L7v1q1OpqZ/+c+/PV1O58sl0MwwzOuJhR+ZlAk0D7USEhOKVOLDYqUAuSJAEMBxyyez0QOBCDmnvHGUT5DKO3zQwLdt+//8b//r/+v//d8Boog8n89PX36ZZ2GxX3/5cBkZAX6+vdUScS7aVQjK01zrL58+fpYyBlZ36G1z4VIqEROBme37nnWNuyMEAdZate1ERAhFyAwLi7VOyRdnyJ0DR/CEny+Xfd9//ny937fWFJH3fSViiONpMLNqB4jedgQgKchs7kySczAz83AicvPDi8LMwnOsx8zadngg9JuqMBQW06TjQWBkEMZ928BNICC8yMRVHMPs0Pww81CrsxQR7Qc0X0px17EOQCRDqRjLumz7JlBLIAs5QFclOvxwM95hGkeMGIaRObZ96T1yYNr25uFMzESLmxKUcfil/tJ7H8fxfr+VUorUfW/RnUXWrQsLRLjh9WX97etPnCM8BEuMyOOWs+d456SbWRkKRcjhbY9uAG6hwMw5Wk4nmXePMiQEOtbQu/VFbuXU7/4f//7v/+2//bdpPhPA73/36/npcn5++vL5yzAOv3z6vN3e9n273lZ1H6dJtb293F5/fCU8TU/PUmcg9jjMqKZp2tveTUWYAZEZCdWMAb9cnoX5r68vRNRAAdAde3R7mES+e+25u2of6mAeLz9+3O6rHZF6XUQSp80c1Mf9HvEg+4twqdK1ezdouazB0fZtT7zGIXJyn5X7kP2DKQqbdhIECTM3MyQUoDxpVBXCWYQIt72PIiLFLONPHR8WgUyER5vCIiUc3RzIs3eZpql1Vcguws20yOjuXTsHYQ5LQtV2MUaEeZp85KQ51Frv97v2TiS3+1JKff5Qlvu91rpt2+vbyziNZqFdfVeSwki1spmKVCI283MZW2sOVof6/PwkydeGxyg6aywWAYB9byeZz/McrQkhInnarB9OwvkLdHcITPUI/BPHJtdWa+1/+f/+LwD4f/+//T/W5f4//elff/n02a0NwzQNI9Q+1wmBdl1b292tdX17e73rDiQwjIYyTOO5lm5KXEphM5iFWKS7CQJBFMobSOMISOKElTOMBMKTUoaIUkrb9+Sn927329a7e6A6MBGoEjPAQW6Og0xHAAdUEe61lstl/v7zh/aW0famgAAe7moBQcxVSm8NIGopH87n0zi83L66EyFRPJCJlKRZCEuifRAYxB7welukju/gSByKphCRIrKtay41dzPTQGbCZMJk44XEph2dKaAcdxwGBBLWWpHs9fWHnXUax0AIyDUdLDIMgyKZ2fPTp1L5/vpiqmqGiKf55BARWEqRWkz1w+XMA1MJ4enGW28dbAxzwCDkeZ4l74VhGNIaOc2gDCJMI6D1jUhLBnwwYEa1Mh3qrKSDEkUctdQ/iq3Hlb8sCxX+L//z/+VPf/rTy48fH87P53kSPlEIeLAIEro7OpVS3X3d2o8f3673qwb/4V+IiXrbQp0QUey2vW7bDoRSrLthN0IETtI9PF+eE9Ee6xDQmsVUB8FIw6sgbNrzDCgydG3bukXyyTyckCTBOYxQeAi1RdgCLBwBE9/4/PEJMDQh+oB973HITOKgHpkOw2jutQ5SawjXUsODRboBdi3HpAsESBB7DoYB+9ZFpJstbS94tLGJAUHEWCoANFWHQEhLINKm4gFAqeYLM2E2c5JaSgVkAEw7+cQmAQzCwZQgtCsJ5HAkBW0pUjerXbfvP34Q4ul0aq2dT2eLQBKf/HK5fP327WxahlLmas0xtC/r3/99MbAy8zRO2/q4Cunxk97AzFxYjChNCQkwgITlve/75593bP2ff7JM3rbtt99+O5/n3//xj8z84cOHcRhKKaWwN1iXZZorEXn4MAxt35N+Pgzj59OHoHquJwnWZjts4zj21pZ1zaMwPLBwEAFSAEQ4EZdaHuqG3QNqqYiorh7BUmodm/a8qe/LFRAHEXNnLgQHL9E8aqn+MJXIU1eYtWs+KFXb3/Z9VwR0gwhAYHN1C2LOzGxzcNeIlEqYzDMTNe3euwcurV3OJ0QMjyJcSnVz7VpLVQtHD4+v375epnkch/w6+767WWVJszgpknzoWqs7997M18R0aq0BNI0yTIMBLMuaTR8HMHJawz4/f5zqyMJJlSMER0AkZtiWNbt4DzczqTUJw+v9XkuVWvd9771DABOjBjsO83iZRwk0DzRXbW2B++tN8NAqaTwE4/+YrDFHoLt6mBs9nnXKbEyIzf/B3M2L7120mRDGjx8/tPenpy/j8DTUYbxcnk8nYQQI4KMZzvIOIJZ1/cuf//PLr7/84Q9/6B8tZIRSNCgIcuumnUQ6+yJTnefe2r7vjAyIuSXmeV6XLa+kcRz63nbtxGyt7b0DHcxCEZzm81TGH9+/Y2FwMzdEVPVaDnzkfd9k1EuOsQPi5eVqcdilAACRgD5EGMC1jqqWaYy9m7tOpYzj0FoXFvOABz21iCRgcT6fl+U+DKPHZmYsvC/7XIZ93xOtLaVEHnIQzIwBByKa8z+IXPdpMGnee9daym7aXZMyWokZKQBMAYBVY93u0zTgoaz0cH+3di6lMNE0jUXKMAy9NSLStlvE2/W6rauZEdPe2zw8jwNfzlPfDQF0M47opKZ4GK+t65rdQS6LiFBTDiQkpIKBzDOhOVoWCvGgTFoEvw/tH8PmfMHbtv788RNleL6ckeU0z+fTqSIChJn3HFdSxoocbMn5fB6G4Xx6fvEtSHbrHFJEAGPrjSHbeuCcQdnhKSKVkUmEi0AV3CCIUKQMguRoXCsXcgSCYagRcLmcRHicpvvrEkDeVQoSICKNQyEkDX2fWLtHmBOzaVcILgIRiEd3aWbLsiBmVkF2GDSO47qulNY9PVztdDq9vr5FaBGOQHDDCHdrezddpIzCDG6FyVXBYuBKD4/FfKQOoG4RkO8eANLEJsvBBPbGgRFQDWAaDQVMS00hZxBD2+9ddVna68vP8ExmPA/TKMwJ7wrx+XxW1WT8jsO0rxtYjHVYSmkvL9ft/vcf3yOQ0KEAU86q3SO4MmjOa1m9M4Vkmvz7HZcXYkS4W2EhQpIABSIKsICIQLWDo/Ku1sp2Eh72wO6+rut//udfArAOM9ZCRbJB94fBATEnWzm7S0Q8nU7TNKv2g3WT1gUQw1DGUt5eX9wPxCyh133bFA6yKwrXWpNnJcJSigf2val1JDA3AAY/CA6q/Xpd1Kw3BQRGCY93D7D35oMexsnukb4NFJYp0aqaHU/v3f8hED9+mHmaJndnITB282EYLpfzvu/MlPYqIqxq9/t9HBlAauWAIAZiLIVLeRrHweOwRs6PpGbJ+YzDU+SIXS5FAKC1pr2IIAaw0N72bBOIMPuz1veXl9d17aUIAiFiNxUzJuJCe0/mKokUhnANj3i7XQFxmkdVW7d1b+s4VY/QvXNQ7/tyfdPu17dNiqTVRK1ifScCSan1+5GTGq8sY5CiDvJQKHhEEBJhWtDkJeiBx2vO2iUfxPV6/ctf/vLy8iJ1LOMkpZKwu+/7xh7xWH9ShNJkLScvcaAY+YK3vXEpgwzYTcZxHMa+78dnO/oqAIBxHNve8sD7kUPT3fbeAVkItbcYSzrZWm/uxszrtr2+vpTr9TScHycTPFQ3Bx001837j6kxAXTvraUbuz3Q/FzZ7x3x+0MYhpEITsPovRPRp8+f7vf7uqyqKlJykggAzJKgORKYtgj0CCYiQtNY1zVvwwO76QoPj7Fsw+/3ex62EdFaL2UsVfbWIslIjyJYVVVtHMdpupgphDXtBmHuhCRMA/Lr2w3TjZMIiJ6fn5Fo27etNSD88OEDLvH1z/8OGNN4uX+/mepUyr712y3zpHoFkAEJSZglS/Ws0WqtgiSIDsCAAEHoHEgFIXZ3IKYIIJbEKMM9Fc/v5X/Wan//29/+8h//IUMlLlxIKMbCiGBmRcp78wiAjmCe0QHyOPz4ft/absIZkoChvt5uwkJl7G4p3oMgBiBGJJZi58u5a3t5vSPw6g0cpqn0bq1rIXYMLKQeL9ebSFHXFiFASHjwSAEIET2QAFJgBQIRlGGWEFLYLIRoLPVOKz7YXblD8tzKtrr1Rpx0HjQzBkBhQnp5++lu+75v256etog41CmCtft9ecvgzlJqa31b2zQNl6dL3rb0UKgyS9e7qrKwgzGksCryJe7dqjkj7L0REyN1Bc3+nREQRYpQbQHq4GDdFDps+/48DTlVcGtmvciAEeM4ariFA8A4TeM4/vnvf133LkTzyEMZOoBqFCnjIADS1Mxdu0oRApBpGIZxlFLyPJ/GQQDVjRCkAEBgIlWHVDB71/wQlk0ypcOnWf4Nb29vP3/8vN/uF6njMImUeZJ5wMKUDIWEiN4PA0SMwPeaZtu2+23zCMnAF0AgjAhCJBHYHQEVHw4cAaGGiNM43t7ubiAFk++Urv/pGscZDOEuCajuaubEPIzDtmyl1mQAERJgEBG4pbA23CHgPJ+kcNd+HkeRgtc3gCil7vsG/8SmL6WoaVfliPfVFuFZDLW299bzfzTzWkvGUamqeyAKgLFQ77rv+7ZtZjpO43tiT86jwiPjBc6nuQ5iGswUcMhQ8/XAO00ePe8iEena9m1FQKzkcZgJu2FI9K5f11XVai0stNyXLjaNBfCANvOV9dbGcbqcL4RYa60fyrYualZK/fTlc1v6vuMgpG1j5giXeRj9iOSLYailoCBhIEMwA8IxYn6ItxAoCcqKABlJ+Wiewt33beu9I+EwjKf5cjpfyjSOdRQqDESEEBAPXB4R8p/e952JkRARWzOzGIahlpp7EZEA7QBjEXJmxywAEGoRETVa69fbMk3jOE4dHuwaxMPpgHJvQD7lrItLLefzWVC23h3jsLbBICIGNjUi8ggEmOe59T3nClKklLK2tq2Luxuiqbo7C7/b/MkjDTlRUO3dPeZ5/rH+MDN8+M4lqSf1S0yFOAeIVkqBCYmptTZNExExEyLc70stw9En1oJkgCGCSLXWmjufOQCi1qG1BgT24AEgQKkDBuS4moiYRQLd3SP+8tfffn7/9i9//MMvv34qtfRm66pEWIrUWrftoMn/8suv93ZHAELpvQ3jIO5MEljE90IwiNxc3dzMZZwG99AIMC/IVcgNCFgAyALJAJCCEzNEEHQMNCLkR7+dsou0ObDWaymn02ld23x+piIU4OlCIYxgmBPGQ/wEEWyq673VMg9Ddfdl2YBlnucIV+2AhgRhvq3LvueYBY8Xppq+yuM0rOvq7iwCCFykIEBAMxVAh2NKzUJNO3MRqcw8zSMXDgDTrmAJIRoFBZla0igYiRD3tr3c3vbe3PXTx49jLW3l5NlN47R2Q6Ts1+DgpjlGzMPo4W3VvbVl3yBCVYVEISycgnq3x+AnkB2BW+8eQSxcAADMA5HnqRJ6LeBRh3J6NIbh0d2QkWodiCBCScIjjixcLEZwBJyn0bGcwsO9xa65togge0AeaD6Nb9cXj/7Ll1/Ol/N6e73dbmomdRinizCY9c7wX/i/vr69eHflnrK63vtYqKGsC4LHeTxdb29dXUrS+HtLUnRvABBHyO3BIMAMCXK31E5GBDERoj+Ik+Hh7uuymFmplUudz0+n04lF6lAJmVAI0gAtfehcTR8APU3zKdmnrbXXl1fAhJHiHz3aw0lRVYdhIJJIOluEmX3Es6mr6rZte9t37aaZQGdFJN6prnF8zsyIO51O27ou93s3dXALAwiNYGGPsK6AwCKFZd3WiECA+22tMpxOp/ttaa2nxkSkbG3ftq1FhwACDBJEFCbDIKIguu7ruVQ3LywIpqqMlJOlxx47kDCR8u4vkhUIMUH4MFRz3LdOREjQe3NoHJLO4gAOcHjvmln6X2zblqRtd4e07w9E8Ef5cVxUiPTrr3+Aj1+W2w3JSq3C7GZu9vb6en768Hx+hlAAnudTHYY6jC/fvltXfFwIDFSYnp/Ofd9uP3xrBccqAMCEQShc3F1tryIMTMhwGJ3gI1AtiCA1qwAHkRwfhEbtPYH7btYt6jgnoURYSqnMBQOIc/QWcZhPhrsL8zgN+75f77fr9e379+9Up2HoiPGwVAxXMzUpNdfWPJ8DYFnXoZY61PE057t3d4S07AoAKFXAj3XshwaGj74dQnvv6960hzvioSISyDzUrOWhOhKCgjFzAJATAIa7mU7TeLlcAPB+u0dETzA+oLKEmYe/3O+RAx6zcZqG05mZ03Qpx0rvfSWnYd/jDoVH5/vwSauEka64y7rN8wwYiJ7mu7n+WA6LDTr+QiGSte/lQcHo2g+UBxzioIWn8iXXLqOUD3UcEZHDY3g6yWmYLxezWO53pjBTdY0AAhqGIdwRUE3neRakLImk0G7bCb1OsyAEIBEXRER0FiqECFAY3MIspbLORMzlHbBBxIfhyYEj762VInWedNkBixQCAiIqLMJi6iwdgpgkSTfEmbMLZk1VX9YbAf34+fOvv32dpqfTZaaHDrOUkm6k7o5MiFiHsmqTOtSBfvn1Mw2y3fpQBxmH1nZALLX2vQWAhiMyHGoRFkIMZYxAbstm1jtpBHBAIUHC9MQKiiBPJW4wtTDvIEERDh7h9uH5Mo1zni7bUDQZHxbTPH78+GzqP378aK2l+QwVLAXRo5ay9mBkqeRq2ZQ4hDCBuXY9YFbzY8ofcbvdz+epFG7Lvm8ZH6kiwIwAxQw0AMyQKYCSJQYHlgaVCiBzkYhAYI+uphTODgAWcUyrjl6eGQiZed+Xt7frdDkDM5QK4ejbnqSawmrm2qc6fnz+GBEvLy9ENNba1rWrsvCv0+/H+fbyej1mOESc4+Q8pogPQBwe+Wnvg5oEeY9bDA46R3pszNOEhLd1CYChVq6FijwgU8t96GkX8jBW3LZt2zYzu96vEHhd70A4jdPlfC712Nm1FuKUHrAwq2pru2NM8xR9Hcdx731dlst4VtXWehlqQmtSRLeGREDEZiLl4/OzoP98u96XhojJLE0p7ZG9goAIxKQKQeAI4aammWRmbm+36++mT+fzRIhJxzif524egO4xjFVEmGKaptSvzvN8vsxmmsolMzMMYQyzo49L/48EXR7muRHHYYY5dY3aWocA976ubZ5OjtERfNdC0Jtu20ZMB0lVuDcTkXGaVS3yroEwjwjq3TypHAcif5A4AIGIHQiJf/vtt18I5/Op9RYdUrm2r1vhYzDTte/7/unTp6xP5nEUIgB4fX0d66RzfP/5ktRkJOJ0FiiZ1Z2svbwKiRDRzJkPeP0AppGyukrwZhzHYRiWrf14fS211GHAImbaextLpfQZYnA3A2+9J4/2fr/nX8gkry+vXfWPf/zjWM4sKCLpJ2juhg7CAGTuvXdnDiYuBCFMFN0hoLfWIfyYJscxVSziEBAxDAMAbnub5nm+fHi7rwcJGRAgHKG7MbFTasQgEILQEVIXmVYchHBfF7Wnve0evtzXPAgjWN3doF/bsgAA5jTX3Od5HqQEc0cFhIAQc7BQt3ecAgGRjzRvePitHQ51RPf7UgNVVRAjcmJI4QHuGJQcwnXdiHld18v5PM2jal7WM2DvbgAAgQiUqVtISCwUDqp4UHzJTIlJA+o4/8sf/2Xpe0DUWtXcIoapOCXPLET4dV3WHz9++eVL2qcXIibKme+ybExymmbxw7XRmbyIUARghHuK7B5V1D8whQQ24nHkuFnrzSCmWjzgx+tta3qZBiI+TafKVEvlwgChoaBBiBjYt/22roBgB7kSLuNzqxoKhYdwcu0NQsYhJa+5vgNsbVtABGWQ4RGpFbuWND9Kw6Jm4R6M6SIBBHjwNfi+rOu2D0OdTwOBNlOUimAY+Uke8fWHxJSIOeGy/JgIDgS3fdvud1Wz1lR7BAEyCRWpqhbdEKDtewIc19dXDBfhWsvlMrbuphoY7zNZyKhZwpQXJGdBiFOFQMj3+96RsnxKb4i9dRHBAAMDwFKElHvvKMRFINAttGutyuyE3PdwdUJi8sDj8ilSdzePqFIgHCAQQ6QUkT/8+sdv1x/MUqRuuC97V99FxqHSy+uPdb3f72+32/12v2WQu7sv+04RHz9+fH19u92WKmPOYby1VkUGKUlTAAR3S8yTHj5d74vpWGQQx3HVmrBIKWtv375/JyIWYaaBy3maa61IAegPqzpblmXdNjOrtabG+nw+Pz09SalBkvJLJ7GA1pqZ5jGZKFfCSEkG167JWELEmsYyEdkAt20DNd337X631r112/t2X/Zlffv58uPr14Ip5Lf3zZM9iB9ZvQyA8rCkJzo8iYn56ek53Ndl680IR6YJQCLoAQ9RbrYcz+UmbK1///7y+vrGImqWvSk9Wqp4cEPywQ51yD+VTz4hqNabP8J5ckyZde3h6fMwPHqfdeZPFi2AhmBDxXmQeSgAqtH3aO69MI7DwCJSqFRiAUZHsN7X5/MZ3SOilkophvOodRqGadu2aZqQ8OXlxczcY1mW6/X68vLinrw0f3o6SZZ7TMRI4BktH5aFeRojE6mqu6X20OwIuXyfi0FAqYJMb29vFjHVmrdnB+/hAklKyyQtba3t205MOZcGgFrL6XTuLdZ1JSnvca+Q+u/8JHBQLovU9NeINKMFAICnpydm+fbt27bvOaUnovM8b9tuXSsLM0sp27oyAtc6jsPz+cm9x+HiAO/nR57/pmqP4XqGMRHRy/11vpw+fnjatkVVCQvWQAdCQWZifNikRTz4F+M4ns/naZzDXzMqStt+Pp/vy93CKg7ZHufqgchhVfSuKVWl99N6s+l0SXglHpvH3M169ulZkAGiqSFHWoLte5M6IMRpHgCKWXTFoDEAPJyAp1qljABhhgEE4La3bVnBfRAe67A3DceAtCGK+301i2EcPzx/2Pe91gqBb2+vqvr09GS935f7OExPTxcAkFoHcBdAcjDTqGmP6aqGkOnIh0I6fQrh4VDoHr33vfdhGodal317fbuKlEfmHqK7mzfXLFvSuvOApxEMY+37KHWaB0T6+fOnqUspHQwRAT17CSIAIHcPT9QD3YMZAwCRXE3D5mGsWoahWhgiFq7MlLrKeR6PiLYijFPSD0V4GmprSJjlM7inLVEQIwOaB0KmDFDhMg61dSei83waCml3YnDzpuYeUiRl0+9qKgCY5tndA4BLMXAqBKDzMH3+eNmaLcvqodYbomDA5gsLYmCzMAyWgqm2IAqIbdtqoUHker2nh0ciCGvfA6AgihEhOTo6uJmCI2KAt66yycDEIg4GaAAoUPK2cbOuzbqlRisJUgdwaOrmhThKLFsDQkI2N/PuHuP8oRaapJRSWBgeeoLz+WRqBFirXK9XyU1/TE7A3MIeP0z0TgB/P4ffD1tTW5ZlWZbPv3whLm/ffyz3hYfZkUsZxnEgxHVb3RXA4p89yhCBmUkKy1QHJlrXtixLGm5zdg6MbqGqwzC908XgYWOZE5sHD8yv1+v17eoEdRgizbPAqfL8dL7f7gkb9jDQA1N1s9RqJex5fCpACI+Hu7CI+IEJE+T4vJTWW2ul1uHLly/Xt21/sCrM/GF6ckSwZipHcmjz0bu2fvaPnz//9W+/pe4UAMw6RCCAGyICCxICklGJ3A+35c4lprkiOVKYeUZ0ezreIhBz652PSxMPHPhxv7fWgJCMgN4zWry1A5hVs+jda0XEsCCicBOReBQ8VARbm6eilW7XFSBqGYY6bMu9t75e38rnz+mj3lsrpYzD6GqZRyHuzu/tCVEas3s4iwhTer4SgT/Ioll2RETXvm17qXWoQ+/6dl2IJAIjMMJ7713VzUvliA4QGZtGxKUUGSoQMnF4aPf7fTsU2ECBHICEGEcQF6RQ5HguubYAABECylCv16t3barN/ZDaeGAAGz/NH7a2r9tu4IiM2XAzZyg5IREfxBJ8/AcC3IyQMrQNIqybMQaEuW3bFjEx0dPTU2+RAcSPEgcAKInwOVrO9fru3ta7vd3uHz9/+PLr59NlzsEUPGiS7oDofBhiQECIFO163mdAGKQagIcyZYATUgakJL1G8uqDQ+NKnDshXQUMEAN772lNkh/2nR8bAPYw6HYzJCqFsJSIAEQWKkPtqgWllOLRtGf5wa52++03Nb18+DJPkwgvy/J0eUJKM1eQx0jyeFsUQugBKeoij4Ry3o+bxKK8taZq43iaT1NAvN2u6iA8BlMlZERVM1VmSf9RIjRDAKh1GIexSHG3sFAzs1iXXYSZBQJBuOsDJYfY9j3raEQMd3cLiFKLmzmiSPnx+lOYpBQ3TZ9FYmRmNXt9fV3WVdEBQYiQQagawmJ9af1cxqkMt33DwEJyuH+YR1OihyyWkAgrshKyyDRNRAyQQnjJABwAp8x+RIjw9+rzPbPpKICIWm9uOg4lHzYEkjMxpUhOted4Jm/Vpt6dREYiACQRnOfRGzIXEUp3/zpP2bObaqgxi7sxMGLO3SPCM3nZHFsupoc07X2UhIiPfJ6a0je3ZqqEGOoE5IbmzoV8dzMFpHCTHn27/twX5eHp8nFd9/vtOk0zAHTT27IcfKx/XjR+JPRBBFgY0+Gw+N4kuvu2bYh4mp+KyL6vr6+v7i6MpdZ5ypkopA8ioiMWJgTEUkqp5QDl1DzAwzNAAR5FdFiAehFGJEQJhMQUUn2f/hyIqGrTOKpq7w15SiZPbnd8BHQtyxIPF8yISMI7Yxr/ODMN42ABrpaOc/AYIdF7NAviMAzjOKLFMIxi7SBBAkJErTVbjfc39G4MBg+a6zuwzCyIEGDmx3slZDUNDXcnxG3dwSG/IyEu27a25m5t35Do6ePT50+fl2vrqqUID0QiPFQWiuiqYIrDMEcAuEF4gGhv4URACEhEGVaQN9C7a2Ze8cfzyefvBgCZszdOU5btANFaJyIpBQDbuqGH9ViXu27b9e2mCtM8ZaWUz0SYgHIiiRAQqh2PJjeLvCNJ4j3jJGssMzuOZcJ1XZd1pTIN41CngZjcIgm47l0EIUqtIwum9x8i9N6btkQrrtcc6EopwiTLfYUIQUIgZmrWU70TESJFTY9oQtVai5q6RyB1TeF10JEF4rmkzudzWtTlcjtaBwCRwqXM8yxctGsrpZYCAKWWjLNT06Q3lSokchoRCaBVQqdjhOBmVutAxO8E4mTCZHGdz4of0VTCRxYWBJkFgnfX9d5YiPZtGIYe/rYs4RgWgOBmphZgbuGq67I+f7hcLqfbfWEmQqxFmmsoFcEiwnxYkjtk1eIiDId1Plasa2vhjggiRCzWDRHTrOr9Q6r21na3nnVYa30Yp8v5tGzrOFQvsO27aYBQDHJ97U31P//PP//tL3/78PH5j3/4Qx7VX79+FSlCpAQcIAAaoIEmRBEEDghAJIk6vAstD74KwDRNUoqqvr7eHHiQgkVMAwAEUJCOrMNwwqi1lAIOgMBZn6nq7XpT1W1TVat1qHVEoFLLkREDqL0jIph7VwRS7QEeQupOTKXy7WUFoGkcI+J+195tmkqotrZD4YE5hStZ0b8DPABRSlnXpS/ra0Ik43iap58/f5bCAXBf7/lNh2HYm73er+NYf/n4ESuEAzo6GMmhGQGg+/2WNyAzJ/sjHnb272eDh1u31togZ1UjdETAWqlwyWFHik67YwAx5QkRAVyEIoZxIiQsUCprN2QCdF0XBJ4uT/lvZRAsGBBiDjUjgoAASEiEuIUDugiKDIvvhITkqpaZZPmZS6lLV3MspUSQdluWpY5jnQsz3+/31vogJ/y3/6lHxOsbljKMU2/t3//j//jXf/3Tl0+fP3786EYC/8MPpsO8mWZRleMqeIfeAVT1fr8PwzDNE0S8XW9v9w2LIIIAMTMwMwRClCIRBOjDUMtDfxRB/TCj6IlwmmuKb9zV3Yehupu2w20r4Z1Sipn3pkyAjqaNCFVtXdeuh61FwoPpIeyhhJhNWWttWdb0ryvC5JGhatefP/3h/dBau16vy7LclnuWIJlaneBQa+1+v17GcZ5mDwAPIDjNJ3BKtCvdNM2MmXpvuXzb3vLg8Yf8ASmIqNQi3cwUIGrljAfHADWfzqd12f24PhIrFxFurZl5220cy+V8uV5vre1SUIjX+3YDqkPNTuIgj4AjGlBkIYcOYUqITFyEk4ciVQCJe1q/Ut5iCVX6w0gMEfd9Z+YiTEhDHdDDat9X1svzxy+/fPzl91TrMI6vb99++9vfvn//fp7Pl8tTOKdOGCLSISj9cyBvVjqsm46OKR6MWyKapgkR1239/uM7MBcpRGklwo6I4EUYgMJzQUsaye5bi0jsuJlpHSsTf/v+7eDDdFPbk/eRQIt5i1QbubfW3XxXrePg0UhEu7bW1b21JqW8uwpWkSJiEK212/W2txbuJAxIEUCAjOTuO/huDRECoGlnosvT07qtiSynnqL3TsypDrjf73kFn8c5IkTk6flJ1bTrPE8PHpWrQqkFGdWNmbvbYfsGkUmcaeqSzY26ArogDaVqb+4+lMJI275zrShSEEvOTJYl3L98/sSM375/v96uz8+XcZ6+/vxRXl/P5zMRtr3fl6VW4XIIIpC4ipcizMiFwcB6W5dlMC11RkwUNrJ7HcfRzN7e3vLozWYkd2wRgYAIKyJts/W2m8N8fkKWrSuJDPNcSkXA1lqRGoGC6pinNUBOexE5m533mUPe3qloS5Am1/X1+na9vY1PH4pIHQZkCAhhqkSFJQtl5rQntt763na3I03ZvDNXB1i3zZdlqO00PyEBEZRS7/0eETnkX65LHjyllHkexhE/nT+PdXq7LZvuiLRs6ziN7wcDDSMiWN/DoXcjZGAWltSuRfhUx0BqZhGAwplRu/YmtRDR6XSa5/l2uyW4XEoRZiiFuWzbYgQznRCgP9CgOjAgpyoAEJCQKoOG75EyGRIMj2ZaUSDYc16uzdTS9BYMg8B3RfMEwIhoWRfrnaXsezNzDGh7a627t21vBrjsTYaRmFVtb20eh9aaqW6hglMAABiibryVItM0nYYR3H/eNndYehuMz/OZqHp088OYJAt5ABARYUEEN3c1EOEqZtu6b8va1KOWWj4Oe1fFjaWM4/zhwwdEvC2LWkzjJPDAhBDB1NDhnc4Rj3Cid7DhOSPdjAAAFjtJREFUXTCds7DvL2/dY0QkZhEhYhYexnFkZnTEHAG1bbtbuHbtXSHeeThETAi0ruvf/va3jx8/+ad4fv4wz/NR7QqlaREAtH1nIiL6w+9//fLlUxlmQlzb9vHTBQDWRa0rsxgYALgdFB0WFj5yaZg5lWrZ227bvq3bPE+Jhfbew10jAuByBJYeo7fEh4mo7RpgdR4fVQMApMcVT9PQmrc9aq3MhEWAGoyTJZoCyMJj4fM8D+PoEWauqto1T4K9tWTkJd9PVauUhqxu6bzFzFIYAoi49yYslSAi7usKTIhoAOogw/DxdFr3vbm6dTz0nm4a26Zw9mkYWBiVEXnfG+Nax5FlsH1/X1jjOOb828PBjvGRup3Pp9bajx/fMUpmH0/DiNx3c2YmHn794+8zq+N6vW7LnnwsBwA3zzTtpMzmIA8Rc9qc1pduFpE2srGs27I1LjXFhoiIBExUWJjI9RCAL+vNQRNTNXcmPs1zOqKZeu8uzLXI58+fLpcLi7TeAkBqQQDmIiLz+bzuu5ghQBnP8/mjWUOAj8/Pzx8u277/8LdwN/KApIhBtrC11Cyn8nxFJmbmKMkzJ8TIqQtLrYP2rq6ZkZR47DAMaVXQez+dL7fl6mFjxHmcJJt4JDxGdcEUw1ABYZpGjSDic50goLW9qwZAHYd5moZCbkGEvXdhOVwSwtve9tZSa3Wa50GK1trdcmbipombRkStoqbqxgT35c7MVUoA7GoezoTnp+dlW7dl4cMwAXPRvF3vrj4OIxJ1dy+0t6YBT5eT2wG8Lfe7+z/4m9p1Gkc3X+9LKbJt63/8x7//4fd/YhkB2dxLrTMAhFt43xsSeECZBkAQx0AzJAr3d1Jv7tGs2cMtYZsw94cWPgK+f3u1iDqMh3AHD42077pD076Fs7uatSD0tLgNYKLyuLfv98VUPzw/DXV4fvqIUowxdUAozEC1DoGo1qGU7EC/vb6cni7elnkaP54/bL3ttw7uyEfuFxLmzMbMqfA7/GZmYUrMqFYvfF97SkYfXVtCX4bM27ImlzIHRwexEUDBmrZYsbWdBzHTiOxy3FXDnaR4wHJf3IFZgtlUQwORihTq4GxQUBhqlbEO7i4idRwcQu+bmUEeUAF735HBw8ADLBDA1dW07fs0VxQkkwjFAPBInI+ZlnW31T6UYR6nnLFEHOOBpN4jsZTStW+32/l82gHCrK1bPKoIU8N8+0Lqni+9MrtIeKj2Zbm/vPz8/Ls/IJeuht6B+v1+//nzx/3+ZuGbNgZyN3nvfeBhVZBqstzlEEFEpgdH+/1yvF2X69u9TCWrEEJyMyL0sL2tYbtbhxAPE6GAYOEiBQAybKyUAoFm0buO8xNwb+FkWpiHcSgi27Jv65r/XI6NAXDX/na9//k//joK1N8XGmK/b69vbwBIQKaW7VTy4h95ZkcLwszLuhLbgARHJmonzgFRxEFIwghXVRJOkXFSWE/znFwaXVRITG0Df3lZtrUlUJwxliQpYWjp+09E2rtlbTsOujcp/Jk+zMNQSp3nQyF4muZ934O5iDQ3/ieOLhN3U1UdOH2XYdv2cS51FNs09BBjAsAwVneNcLNYluUdlzqA3wezvvfeKMZx7KqFBQk1w0rdH3cOhvu2bdNpHsfRWCGgllKnsWtPbPbl9XuZRovYtv37z6+32499661psEHmugARkyC+k/cPrJke2tHEUR7sGN/3vZtO04yIP1/eiHmeT3UaaxkwPB5Mra6dIpLtCQAshcKzb45H/mIEanczWDcnHmQQ8/1IzgXsXf14zdF625Y1OV5DuHZbllVOo1Bp+/r177+1tskwwCEuDUQy10Sq3B3+yUvHwkzt6fJ0Op1e3+7h8MhUDlXNtZuHsT1CplLCpG4vry/qNtbhPM+Xy/nl50vb7TI/9d2b61hKAO6tiUhGAz8Gm7hu2+VyQQBz112vb1e6AFEZx4GZVHXb1n3fe2ssMoIkQdkhIoCJ1Q9G7HHqhBHRh6en1l6MQ4Ddbdu382UmolqqggFEV825JwIQ8eEYENC0I9g0jR8/fNjXVZuGmYar9lKFCfft8DjOzU+IkM5nlDA6nM/nr1+/Xm9vLKXpfjqdni5n1RYIwMDEQy09tXaI2dj/w5QbjjH4g4AGqZsyta7amU/rui3rerqcBilICGQACA57t0EozbQCABmQKIARoUiBdytAgDDsTe/bZgSBIYyAnFK31rqZpTyhlNKb59UMEYMURm7rfrr8Ustwe/txvb0ZRCjtvffW8g5y83R7DAgEOKiCCNY6ApaPhZnXdU0vAwhyTRRADpfaMCJ8z3smJkOIMAAsKOdhYqQ8yj1wOp8YGmicxul+99Y6ERMdhpTI6AippUEmN+g9aSNCzNtue9vV0t85JDGzMIOggMKsXTlAkCw6kiAxUGzbOg0nopt6MCVT2a7X16FUoWIQjyQNSJD5CO0lyoKyh7emtYrUuveOAJ6dLOE4FuYiRZBpqBXhQZdKhhKAWZzPl7///esg8vzxIxCyMDMHxt42QGEoQrRu+7atcvR6cMyP4KHoeswoAgBaa6nKFeOI+PH9NeMkIwIhum5hCEGBgaWCH3UmESVPsgy1FOn9f+Cpvb3eWu/Ah2FpKWMO1vKfLhklysRFpmm6Xq8AMI5jbqbz6dTVfl7vy9qQSNtaigyFl/va2i5S93Xt644YgPDh+YNMk6meymDmnz59AgBVU9N128wOUpCqTtMUdgwVmCWloQZhWetEREBT7UFSRoDtqss4jbybYmveSimpXM1ZeF4A0/nUw8AR5dB4jeMIgeu+3243eFeqlRIRaoaZq4aYl+/e9oGH3neR4oQM0HYbxgPcZ2ZG9ODeVOh47P4QmqcZ0PV6TW+OnKVqxPV+Pfs0jOPlcnGzpe+9sxRiRq7Yel/u99R3pIozzypmmsbJrX/6+EstFVRJuPJoqZnAUmXoPVozDKoySLKj1I4Z5IMmakcTAtb2/Xa7D8MgpZQ63q7rtmmp1cGICiCBRQSwAHN192SiBIS512EYxpEEmzYGDMhAFN/XbV03GljdHsTgg4H5zrUFxG4aEe9Rtr13D2AmqQJMp/PT734Xyfeotczj8PL2uq4rMgV2PJgnhoTM5I7BpK7btl3OcynSXjbyCIU6FKk1a3zmGqrDMEzTnBf3sm8EgIyhNtZ6uVwA43Q6X99uXffw4u4OsWyLhIzDqGpAoOoIMExj9Ka9d1MDKFWIcV1WIt72tu+7lBIAItK0ExIRmVsKpHp0yS7WIhyICZmjW1j01qdh0N6ZKaVcwpKxLu8rFR9F88+fP3vvf/rTn0Rk33eK8FJKrdu2qXZmWtd12Xe3hkTh1LXvbbvf5MPTB2K8b/fMF2FmB5jn8x//KKo+DiMh9O7qgYxMxbrvy87E4Y6RCk08gPUsgyLCTNvWRSig7VsbhmGcJmZW9de3eyA5IhCWwu5UaORRkDyCrSkABCE41mEYp5GYzNx6FCHV5hqK9rrc0o8lc7yQ2DQZmPFwGQEAcPesoGutqepxAGHxCGA6XS5Sa3isy7Kt27q2tiuxbGbNsQiP5/P9fr9u99hupjYMg6n9+7//+3/5L3+ap/HLx+dffvnl7XW57ysSEvG2bV8+f9R1y8P4fes/X57b3hS7lDJOU0A3xzQGanuDB0FNzbta4hrxyGFA7Uhk7h7Owkh4XzaRUoejZRuGQVXBQcPe2e7ZmiGAac8qHgIKkR3scfpwPi+3u5lnsR8Q3hvCA9AmSm5FrfXz58/3+11EAqBbJ3M3O82ao5/X2x1JCNkBEaSrCQsOxQ2aKSMEprWuI2EQFyzzjACMSK7R+46qEQGMrSlAsEOPsPAjCJOY3oHQVD0AxW9//j9J6Pz8zENFQlV9fbne7zfimjk1SJQziuN48xCWykwIJDRPM1EyQww9zLR3c0dF6OpTqcd1EaC9PzYZ4sPEm5lzgJXdU56jLPJ0uYT79x8/7vel98ZEtvd9393dus3zjGBDre5+u92y+i5SaCAz83BXb739/g+/yL/8vhTZ259fblojmKn3frveQlWq/Pj5Y9/2rLF0360bPHSIAOjurfdUO2a337uGYXZh6JHi0SSfYBKAgMlAI0BwXe7PZb48nXr3UgoElFJcPduX3FdMVJhJjh4IEIXFKSK8imPhDx8/vl5vCYQCgHtmR/4P2Vh58+aI2iGI2AN797fb8ulynmd5Xe9t3UqpiYoDBCILD836tu11qESCYAHojskcQQApBYDWtiICCztHmrsGHkNGpuMIhdQrPj5QMFPf9W9//vOvf/xDKZWqMIlpvF3vvdtcGQtKqQiEBAYeqszkEEWklhpmtRTE6H1Pkfm6rIBepCBytD6gqJvtDojEGX2eFln4z62DiOQc6b2xQIDL09P1ev358gIIppZ2xUGo5kDY3YhZBKZpen19tUc6RsKeQx1koHEYxlqY2TyJX4crSx0qIqzryozWbVs3KYWMWlOuJfPlXl5fLpcJAcKdODkGVkTAHZHCAyld2sgskEKSXwWIAQRoHsu2QVitcrlcAHjbGgAwshVL+4mwY7yWnhjEzESAGOYRmhOmCD+fTm/XW1fNeyZ1LQhHHqCHpWzN3QNi29Yy1GGoBtC1b70ZHEWFag9PWx14ADQyjuxuyfp31wAEB2Dy0IDQ3hGJiTuombm5MDsAciGPCA8AcYskQMLBfMeIuN1vP398JeGnj891GpAFA5etXW8rUWURKRk87gjoGH6YY4VaV8BaBCG29f7y83UcTyJi4Uycgptl2VvrDczMpmm0Y5ae8b6HLWB+mN77cQYc7igkzNNp/vljBQAETJXsuq6ZSxYQgSDCFHQ6nbIsy9r8YLAwFuRxHDEwg+zPp8s0LUC0bhsRDYU+fHgWEeECgcuySC3PHz6u+/py/TkO9eu3r6X+Qi6tbQNN6ZhQpcx1uN9X4EAMdwgEogwnhGQ4YLBhREDbmpSsZeN2vf34+VZKOc1zaw0QMyLP3WutQdD2ltYPTKS9d23jNA7DOcwxXLXxQ+Cans+IFBGlSKlja23btgj3ULUeLbMwILR3j/u2Up0IUJLPapmN5wBYSkngN8EmAIjM73MgAnfn0H1tp9Pl+fn55eUFDNDRwt287S2vF3of6eChrcFjuDYOf/yf/02GIU//7vbt5/euHQCIUJAEkAVLYQGCACmCYISO5HVgpCNcs7Xj0bh7mve/Lbet749zCNKsl1kymiaHZe+FQk6sE+uLiMvlQsmjeKy25HX84Q9/mOc5SRZE9OHDh/ezKiHc4x4MB8S8XCicwZiIRbT319fXt7e3+/1uqjnSSRf4/DBVZBqG/DrX2/Ugdh0EphLm4HEItjwyNsejEUde7vmvq2puHu2+ruv9vuxtT1WFu6spM2e6exGRWqNyHcdxHLX3tu95IW7ruq7NNQQOXY2IpA14Tmyzi88HmL8QlnfLLmtduwLA/X7fth0R123PKzvXgJnln3of7ORjTL+u3lUdLQiId22AeDlfEHHbDiplXqmEyeM7dEuPmid8HMe9bzwMa2vBgiPfl+3Hy4uQAAFLGnvAKFLL4KoTlmEaAGpKXQNctbtZLUUVTBUiWm+l1tuyrtuGjHOZh2HovSf2k1dwBDJLUjhKKXmX4YNEKyK1lLcfP67Xt8TWU72ZdIAc6r1727UDruT34UxW2bftpvYZh5KaBTNF95R6mWnT/u31p6lJKWvfEBGFzWxbtlomIPty+jwMpI9JaG5FNRPmL1++3O73ZbnniD23ewYZj8MgMlzvN2IBIne/3bdpFAg8Pz8RAnhQ5xwDA8BO4BimNrAgQt83JsJIWRztW4siTPL0dP77t29DGYQZw7ngNE15t+77nqknOYEQEcxaLYKJ0gJjW/dhqGavuXWT7tda8yME8rgZa60p3RNOwS0AAkoxiLfl+un5wxNexnHo7n3vIQUIAOPgvD8a/ngM13gapoiQMhYSVfv27bt2G+fTOxeMCL07kE9DlUpEqJ4mbLhv27qsGOEWEBwOrWsABMJ92wIx3fty9lKKMMu2tYgoZRgGyoWS/29+JCIiJCYqxLeXHzmofgAE7O5//etf/REHlFTE9/33AOQOq63T86WbuikTR8A8TU+n6WW5ffz43PY2ThMc1n4wjDXP0XngYThBgAw4TUNA/Pz+I1Gj44IuVRNiRkQidzD1OmRuLTDTvu/DMHc31Z2FCbl7/HK+tOYdEJHcjUjMNPe3QlQmDETCQKzz5KquaXPqRMelf7mMyzatm9ZStGkRaX0Ps2Gaah0NNoBLa5oPKiLShnSeJzNblrU3fXq6ZKvUWmPmtAtMFoKqESVfg9NdHIkSfS3JGQlb99t9vV/mkwgvy1qnMQK2tgSGvEeVvB99rfUIKDISkQVU5pfb9eePH89Pn4Y6vbvThntQ1KGWIuZtWdZ924ahZv5l762KiIgZAQR5EEHvHQGen54eZjtBRBkjkDxaMzXDUmqeRvl7AHJa4+dxHofhZ9cIYDnG5LkEe+8Jl7wvoMvlks/rfUKVv+Hjhw/MdL/v8Bi3P13OzRsSz/UkUohIMO+UUDUPDVBAY+FSxggjklrGaZ7rMB4Hqkfbd3+MpABxnme17f1Uq3WIcBbuqlykiJzPMzMHx742ICHMZPFImKOUkoUvEWlP5XBV6CzMXAGUiAkJIX73u1++fnu73W7hhoit7QVJEODIGPfr9ZbKdUFytXEeB6lBvsem6w4AtdZ1Xd9P/aOoOt4FiciyLLmBt4eUjZggkAmY+Ha7PZ3OtRYAJyQInJ3XdZH3rj7vQXr38iIppaI7BC3LRszjOBauImJqyGBu5LLvyV/f1u3e94YIHoHIdRgpUxsydRfMWt9Ux3EippxjvJ83iFBrCYd1291tHCszLeuqbnn0RlioPT9dAL31DsKUbqIPiOR9upc/2Si95xHTI+lzWZbr9e1yOv/49tNV6zhIYUKhQDczV7BDM8Ms27abmZoChTACIPEyDHQ6TXWo4zhKqcuy9N6ZKMNUszQpUp6enn78bOu6lFIAQ2oFiHmYWtF93dyU6eIOSWzvphwH7woAze3EJQjdwsC6al6RKLxs+yAVEfbWCU2hny/DHz5/ehV2U2KS8gm6EmEZoDl5yIenGQHXbR/Hwd1P0zSOIxEXRsCowlVEVc/nS2t7PKaEj8X9D6dxUxORzKMiACJsjyp52/dpHKd56HvbljtRkDbJ4TY/nIz9Ib8MSEM9X5d2v29Ih917TgaSauwW+9aEybynvUeqZYQJMSzcXSFY3bdt7V2X3i7zkEOrvHN77/nUiNiREgVlxmRFNlUzpyAPwIhSJMDNgRDT0zeLevgnrVUurHeu4jvk23s/YM+I17e3bd8LEURsvbdtzbTSUqXW0lpzt77b29vtsP+RlCtjW1ai077TPEla/MBj2hwIpgergojWbc9ZgnsAWiBaqHbdtq1rZ46+tQV8XzYZRwenw58oEEm4AJg6bOuOlJJM2/e9lNJaIwdi3raNmcd5sG5CdD6NmCrfCENCBEIrDDiUp3l0j94MhDS8orDQ3towliLY3S/n09vttO+7u71X6/hPBM/jKiMHC4tADwADijw1m+u27/M0IYJ5N92Dwvfl/we7BXyn6lybRwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.Image.Image image mode=RGB size=200x200 at 0x7FBA87B7D690>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "example = ds[\"train\"][10]\n",
+    "example[\"pixel_values\"].resize((200, 200))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 217
+    },
+    "id": "-p7R9KP0yUOa",
+    "outputId": "c0487523-1ffe-4cb6-bfe7-dec0033a5d67"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAAAAACIM/FCAAALGklEQVR4nN2d25ajOg6Gf9mEpKqnuvfMrHn/B9zd1V2nhAC25oJDgNgcjJyQrYtaKULAH5JsWT5A/0Ejak8AYAuD5fKk/d+xBav6s2UoCrj+pKjLR2urI/sk4Dp2/OsoZe9JVWhSRKQaqJQHOtHalhPXMTsADOJBkQksUcxpSQCtFfVvn2a9u6cJse08cqXZyWUB8PDh2/jKAAAkSNKrg7TPOv/pBIwkA9UWkqQAFdeXYgCMgUrYjjiPpCS0cxxVaV5/slYlBDBygEA7qqxRe0DuJx7HTrguacEoc5VoIgaDixRKAVDqyrsbjqGXuM8SF18NlZQMAJYBewZBVSWwZVKV0w8yPMzjZFKi2F0AqkybAYDoUr0arr4YFu7y//B6DHsLo1PwNH8dkK6wcT9f5TjGzJ7HFEESX1OmqKqFhjLa7FP1h5kAOucEIAWm/EZEEp9tky7hAqmPuEp2NCBFQKphSbEBQ2sCbgTiEwVghmWwYQAoDoeiaUZP+mD5SVkgSQcKj2dpfpCkGLtrotgwM8NUjTxnh6J97uaU4pwy9HVbG00SXzxHSZm7NLKr3VpBA2xRtzdky+JyJctkz6Abcjhrm/qLJ+d3puyQk27bEz51qwEDMHY3CrMA1A/WJQT3N/bj1HFdKlsfyLvaswB2Id2BYFFPOyL3k/NZxtdb3v6Az+5zbGGSHTCrupCRqhPiRPHVmWQ+myieitxzkjGuYDSiNH5ARA7NkLNfRPZcn8n+bqtHzdGkb8f9m1PCibKZAQ++odGaGQCgnjv/MHR0ExtzSNoDhL1la0pbdi2tiWjJ+MrHvQuTgvdMIZmqWRikCQCX59xctznG50jWXK6sQCC6MwhQxxXJzhTHcr7l27bkmkLyS0tlfl3P6pCWWWkI87I7LchtauAljRZTmtosM1AHNRn+mVwTqnrvKkMUQ5a1vgx6PmQfRXl6SonGykSn08sOYKayoFvEKl4Q62kimJ7Tj5M5a5XsNPnzdhavCgol2Oj/eSM6OfGCePq0BGD3fIK1yACovSEy7LhOacCg1DLwlHAvwRdFEn9Osz1Ozb8WyG1RoIkUiRUYMKauowdCddf3uH8y/aMR3D857jwsdcks2QJcwp7BpuqyEynUtZKBYTDATZqoL1WDbrMnx4WFJfmld/tkf3EIRlVh0tnCGpgcTaKXQFR1xBjMXNE3FlMqjTrR2wny695K0SSAiaPFYAnZLIPWB53SGUCZA2QtcIkpiAhNQMktwVAYXMdglDZl1XVerDA7BkBNsB2jYUkAAqzJoQZ5AiIQNXbOsD6CWhgwxAyAz6rqyZDi+pJ52s3Sx/GR5tq9AYGagABmCzvnxkY36WIwV6NGuv3dm/2m6vswc1bsnsVRqFfFEwiq1oHfiqYloZJBCZVtmJL+OwVbzs2ZreHv/xIHqUes6udfDSKuT3WWAKDpchXKPw4mN2yrhzU1/hUgiWr9AGDLLBfj9ZyOTkd9uVGEPFFSp0rmusJ80YMRUmpHdqFigICZpRkAgPQwPc72kiCQr7aSfPqcIFHXQ9ZRh3xixaWkHc4Wc8QnFsjQQyqpSZIId40EQg7LAprg5DmCiUUCcSsEYAuAdhFMLBKIRyERMxFxQLS/xBYcw0XigJDPsgDA6O8x7hkFRGEEhA9R8vQxQEiP9p3yKG4Sy1z9WVIqoiRUIoDQiKsDgPUNDq2SSG3s2EPnbOTLVXeVFdIYTy9QFiM7Lw+iMBUdmuwhQhSFyXzP8RFCFE2YmjxLeSmvEnkQTE4CBp+k7yoPooFpEJzkbUsYpKqypopJ5VnctoRBZqZ2+Sh7W8QBmQ5B6CzelMiCVEPyczLF4k2JKAjNc3UggruLglQXmwNCeSGsEnmQeUG6lY4cJUHqqbHzTj4J90okQaprzQOhUrhXIgii69GVeWdLhymCIPNdHQDoJDvaIwdSe8jsatXKhilyIMsUAummRAxEtRM9Zopwr0QMpF5vsuApW9HIUQqkVsiixiGTbEqkQOox1SVFk21KhEAWewgg3JQIgdQKWdbLoJNg5CgD0ihkYYVqPUsEgoogcpUADwEAyakcIiDNtLXFLVwp1yaKgDTTQJYWi4L2AHCLBEiwQmA9yzNDCiFwjWYJ0/L2jeUmkAiANAoJmaBxFGvcBUAahQRwUCkWOK4HaT0k5OHKNe7rQVYoBEAmVQGvBmmnPgeVSC5wXA3SrroMe7RitrUW5KKQQBs5C9Vba0FahQSWR8y2VoJcFgeEPlipUfeVICs9BHKj7utA1isEELKtlSDtpxXNgYxtrQK5rBBYMRFWaBhuFchlhdia9lnGttaAdBb4rWoMRHKnq0DaT6s46HxnECXi6hCaibYGpP0UFMFfRKRNDAchKYWAjgKj7uEgnc1G1to4v55WkwSDdFeZrQ5g7Z/VOgkG6ShkfSBO5vfafknoitPuHnwy+cLnv1b9PFQj3d/JdLu/Xldt6Riqkc66NSuU9+TdX/sVIVsYiO64iFgmmunlJXg9XKBpdX4ml1AnvP8KTgaHgXT3E5Bco0PZz9BwJQyk+yvRWT5U/PwKIwnyEdXZqsK90ewaef6uA5QcpJHuVmjyi0G+foWMkYaA9HZMkZ+KTPnfAaFXEEjnc4zleMSvb4v36gjwka6HiLWGA+HDj4WrLgNAessIBcdle8Lq5WXRpZebFsW2rOou/PZ70arx5RrpKcRE3BKI0x8LYq/FIP09tB1bY8vJothrMUhPIfKtYV94/yOdSbIUpK+QmJYFAGD98m2eUpaC9Fc+x6qzOsJPP5I5d1kI0ldIbMuqbqL/O8e8Fla//dNjGxYAgMz7HI1sHwSUHWeYzTKQ/gZtt+EA6H3GRI9lIP2zb7WVL8zbdA94EUh/x8OVqesFQqefkzpZBNLfW/pmCgGo+HtqScASkMEWlDcEAZmpPPcSkMFm3zezLAAg+zpedy0AGSjkphwA8Pt9jGQByD0VAgB4/zPy5XyQYTBzSxepS/D56dfJfJC7KwSgD/940GwQGpx5DxDYD68dzAYZKOT2hgUAdPYmVOeCDBVyu3fW9Ivx7stCzgUZnncXywJgfTH9TBAaWtZ9FALQydMuzgTZikIAend3SwNB7qUQAObNqZJ5IMMdr+9mWfB2GGeBDD3kzu+ne3MlzueBDA/cz0UAwLw7Ds4CuVLIfTVCX45e1hyQqz3978sBp3HNAbl6e9J9LQug4uNKJTNArhVyd43Q8cq4ZoBsTiEA7NvwYU6DxHmf70qhfNjHmgEyPHC7fNaI0MdgrsckyDB+30CdBeC6jzUJcv3Cty0oBKBT37imQBwK2YZGQJ+9NOoUyPX3G+EAzJ/ufxMgV+HiViwLAJ27YfAEiEMhm9EI8NYxrgmQa4VsiAPm8/J5HMTxjsrNWBYA+roY12KQLWkE/Nk+11GQjSsEoLzN0I+COL7cFgjoqxn/GQNxhItbqrMAAPxeP9oxkK17CABQ8VqVaQTEFb9vDgSUVfMfR+aiON4ccJPJJ0uF0++HsTeWKceL+SJNxVwpTN9etB/E9SqH6POzAoWTFy8Iud6AEHXm3zrxOrvrDdob1QcAP8h1hwqPCeJSyOZaw654NeI4tmUOH4jzxZkPCOL0kE27iAfEeXTTClkCsslWvRVnkV0vyX1IjTyeh7jL7M6/b1shThBXY/iIIG6FxHyXoYQ4QB5SIQ4QT2C/cV93gLjf2L51jmsQj0K2blnXIB4PeTiNuMPF7SvkCsStkMcD8Sjk8UB8HI8G4hgyBPAAle8QxNeD/6eAPABHv+juDtUjuHofxFdlPQTI/wHFcdIicwcncQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.Image.Image image mode=L size=200x200 at 0x7FB95352B7D0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "example[\"label\"].resize((200, 200))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vp-fIQzvyTHL"
+   },
+   "source": [
+    "Each of the pixels above can be associated to a particular category. Let's load all the categories that are associated with the dataset. Let's also create an `id2label` dictionary to decode them back to strings and see what they are. The inverse `label2id` will be useful too, when we load the model later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 49,
+     "referenced_widgets": [
+      "c71c1a959c43465e9fa63a94e72e0681",
+      "22d86a1d282448a190ff5f81d5086f16",
+      "108d9a14e9bd46088a1b3526e9607c48",
+      "f53b548093704a4483f8825f2c7eb3a6",
+      "2be22416cdaf4ab1a48145dcdbafd57f",
+      "31288c6294644f4c890374a08c7ec1ec",
+      "abd78c14e61843ef89699b2ad68d970c",
+      "3dbd784ed0724b7b8f3bf3b5d3d87919",
+      "3f71c41ea8524623b129bfafddf293db",
+      "90d261d919a54a91bacba98abaf6b35c",
+      "d82c57f3e3484f149b5a8d63c97ac582"
+     ]
+    },
+    "id": "Op_AGsW0y5C3",
+    "outputId": "59041978-a8fa-4aad-ef94-80013c58c288"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c71c1a959c43465e9fa63a94e72e0681",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading:   0%|          | 0.00/852 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from huggingface_hub import hf_hub_download\n",
+    "import json\n",
+    "\n",
+    "filename = \"id2label.json\"\n",
+    "id2label = json.load(\n",
+    "    open(hf_hub_download(hf_dataset_identifier, filename, repo_type=\"dataset\"), \"r\")\n",
+    ")\n",
+    "id2label = {int(k): v for k, v in id2label.items()}\n",
+    "label2id = {v: k for k, v in id2label.items()}\n",
+    "\n",
+    "num_labels = len(id2label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "2Rg_WraEzMb7",
+    "outputId": "9cf28a2d-b433-4df4-c961-c987ba242ef6"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(35,\n",
+       " ['unlabeled',\n",
+       "  'flat-road',\n",
+       "  'flat-sidewalk',\n",
+       "  'flat-crosswalk',\n",
+       "  'flat-cyclinglane',\n",
+       "  'flat-parkingdriveway',\n",
+       "  'flat-railtrack',\n",
+       "  'flat-curb',\n",
+       "  'human-person',\n",
+       "  'human-rider',\n",
+       "  'vehicle-car',\n",
+       "  'vehicle-truck',\n",
+       "  'vehicle-bus',\n",
+       "  'vehicle-tramtrain',\n",
+       "  'vehicle-motorcycle',\n",
+       "  'vehicle-bicycle',\n",
+       "  'vehicle-caravan',\n",
+       "  'vehicle-cartrailer',\n",
+       "  'construction-building',\n",
+       "  'construction-door',\n",
+       "  'construction-wall',\n",
+       "  'construction-fenceguardrail',\n",
+       "  'construction-bridge',\n",
+       "  'construction-tunnel',\n",
+       "  'construction-stairs',\n",
+       "  'object-pole',\n",
+       "  'object-trafficsign',\n",
+       "  'object-trafficlight',\n",
+       "  'nature-vegetation',\n",
+       "  'nature-terrain',\n",
+       "  'sky',\n",
+       "  'void-ground',\n",
+       "  'void-dynamic',\n",
+       "  'void-static',\n",
+       "  'void-unclear'])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "num_labels, list(label2id.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FmMUQVLXLj_I"
+   },
+   "source": [
+    "**Note**: This dataset specificaly sets the 0th index as being `unlabeled`. We want to take this information into consideration while computing the loss. Specifically, we'll want to mask the pixels where the network predicted `unlabeled` and avoid computing the loss for it since it doesn't contribute to to training that much."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7iCzXnImeWle"
+   },
+   "source": [
+    "Let's shuffle the dataset and split the dataset in a train and test set. We'll explicitly define a random seed to use when calling `ds.shuffle()` to ensure our results are the same each time we run this cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MC4OBSUret9N"
+   },
+   "outputs": [],
+   "source": [
+    "ds = ds.shuffle(seed=1)\n",
+    "ds = ds[\"train\"].train_test_split(test_size=0.2)\n",
+    "train_ds = ds[\"train\"]\n",
+    "test_ds = ds[\"test\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4zxoikSOjs0K"
+   },
+   "source": [
+    "### Preprocessing the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WTupOU88p1lK"
+   },
+   "source": [
+    "Before we can feed these images to our model, we need to preprocess them. \n",
+    "\n",
+    "Preprocessing images typically comes down to (1) resizing them to a particular size (2) normalizing the color channels (R,G,B) using a mean and standard deviation. These are referred to as **image transformations**.\n",
+    "\n",
+    "To make sure we (1) resize to the appropriate size (2) use the appropriate image mean and standard deviation for the model architecture we are going to use, we instantiate what is called a feature extractor with the `AutoFeatureExtractor.from_pretrained` method.\n",
+    "\n",
+    "This feature extractor is a minimal preprocessor that can be used to prepare images for model training and inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PJJQ4s9S0Iag"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoFeatureExtractor\n",
+    "\n",
+    "feature_extractor = AutoFeatureExtractor.from_pretrained(model_checkpoint)\n",
+    "feature_extractor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "F7kWNDgSzzBo"
+   },
+   "outputs": [],
+   "source": [
+    "from torchvision.transforms import ColorJitter\n",
+    "from transformers import SegformerFeatureExtractor\n",
+    "\n",
+    "feature_extractor = SegformerFeatureExtractor()\n",
+    "jitter = ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.1) \n",
+    "\n",
+    "def train_transforms(example_batch):\n",
+    "    images = [jitter(x) for x in example_batch['pixel_values']]\n",
+    "    labels = [x for x in example_batch['label']]\n",
+    "    inputs = feature_extractor(images, labels)\n",
+    "    return inputs\n",
+    "\n",
+    "\n",
+    "def val_transforms(example_batch):\n",
+    "    images = [x for x in example_batch['pixel_values']]\n",
+    "    labels = [x for x in example_batch['label']]\n",
+    "    inputs = feature_extractor(images, labels)\n",
+    "    return inputs\n",
+    "\n",
+    "\n",
+    "# Set transforms\n",
+    "train_ds.set_transform(train_transforms)\n",
+    "test_ds.set_transform(val_transforms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also defined some data augmentations to make our model more resilient to different lighting conditions. We used the [`ColorJitter`](https://pytorch.org/vision/main/generated/torchvision.transforms.ColorJitter.html) function from `torchvision` to randomly change the brightness, contrast, saturation, and hue of the images in the batch. \n",
+    "\n",
+    "Also, notice the differences in between transformations applied to the train and test splits. We're only applying jittering to the training split and not to the test split. Data augmentation is usually a training-only step and isn't applied during evaluation. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HOXmyPQ76Qv9"
+   },
+   "source": [
+    "### Training the model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0a-2YT7O6ayC"
+   },
+   "source": [
+    "Now that our data is ready, we can download the pretrained model and fine-tune it. We will use the `SegformerForSemanticSegmentation` class. Calling the `from_pretrained` method on it will download and cache the weights for us. As the label ids and the number of labels are dataset dependent, we pass `label2id`, and `id2label` alongside the `model_checkpoint` here. This will make sure a custom segmentation head is created (with a custom number of output neurons)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qMdkERPg3ab3"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import SegformerForSemanticSegmentation\n",
+    "\n",
+    "\n",
+    "model = SegformerForSemanticSegmentation.from_pretrained(\n",
+    "    model_checkpoint,\n",
+    "    num_labels=num_labels,\n",
+    "    id2label=id2label,\n",
+    "    label2id=label2id,\n",
+    "    ignore_mismatched_sizes=True,  # Will ensure the segmentation specific components are reinitialized.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "L5umptad3k3g"
+   },
+   "source": [
+    "The warning is telling us we are throwing away some weights (the weights and bias of the `decode_head` layer) and randomly initializing some other (the weights and bias of a new `decode_head` layer). This is expected in this case, because we are adding a new head for which we don't have pretrained weights, so the library warns us we should fine-tune this model before using it for inference, which is exactly what we are going to do.\n",
+    "\n",
+    "To fine-tune the model, we'll use Hugging Face's [Trainer API](https://huggingface.co/docs/transformers/main_classes/trainer). To use the `Trainer`, we'll need to define the training configuration and any evaluation metrics we might want to use.\n",
+    "\n",
+    "First, we'll set up the [`TrainingArguments`](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments). This defines all training hyperparameters, such as learning rate and the number of epochs, frequency to save the model and so on. We also specify to push the model to the hub after training (`push_to_hub=True`) and specify a model name (`hub_model_id`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6K0B3oqs3PR-"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import TrainingArguments\n",
+    "\n",
+    "epochs = 50\n",
+    "lr = 0.00006\n",
+    "batch_size = 2\n",
+    "\n",
+    "hub_model_id = \"segformer-b0-finetuned-segments-sidewalk-2\"\n",
+    "\n",
+    "training_args = TrainingArguments(\n",
+    "    \"segformer-b0-finetuned-segments-sidewalk-outputs\",\n",
+    "    learning_rate=lr,\n",
+    "    num_train_epochs=epochs,\n",
+    "    per_device_train_batch_size=batch_size,\n",
+    "    per_device_eval_batch_size=batch_size,\n",
+    "    save_total_limit=3,\n",
+    "    evaluation_strategy=\"steps\",\n",
+    "    save_strategy=\"steps\",\n",
+    "    save_steps=20,\n",
+    "    eval_steps=20,\n",
+    "    logging_steps=1,\n",
+    "    eval_accumulation_steps=5,\n",
+    "    load_best_model_at_end=True,\n",
+    "    push_to_hub=True,\n",
+    "    hub_model_id=hub_model_id,\n",
+    "    hub_strategy=\"end\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "T3gr2e6ggAn0"
+   },
+   "source": [
+    "Next, we'll define a function that computes the evaluation metric we want to work with. Because we're doing semantic segmentation, we'll use the [mean Intersection over Union (mIoU)](https://huggingface.co/spaces/evaluate-metric/mean_iou), which is directly accessible in the [`evaluate` library](https://huggingface.co/docs/evaluate/index). IoU represents the overlap of segmentation masks. Mean IoU is the average of the IoU of all semantic classes. Take a look at [this blogpost](https://www.jeremyjordan.me/evaluating-image-segmentation-models/) for an overview of evaluation metrics for image segmentation.\n",
+    "\n",
+    "Because our model outputs logits with dimensions height/4 and width/4, we have to upscale them before we can compute the mIoU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eZeP3LdtgBj-"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "import evaluate\n",
+    "\n",
+    "metric = evaluate.load(\"mean_iou\")\n",
+    "\n",
+    "def compute_metrics(eval_pred):\n",
+    "  with torch.no_grad():\n",
+    "    logits, labels = eval_pred\n",
+    "    logits_tensor = torch.from_numpy(logits)\n",
+    "    # scale the logits to the size of the label\n",
+    "    logits_tensor = nn.functional.interpolate(\n",
+    "        logits_tensor,\n",
+    "        size=labels.shape[-2:],\n",
+    "        mode=\"bilinear\",\n",
+    "        align_corners=False,\n",
+    "    ).argmax(dim=1)\n",
+    "\n",
+    "    pred_labels = logits_tensor.detach().cpu().numpy()\n",
+    "    # currently using _compute instead of compute\n",
+    "    # see this issue for more info: https://github.com/huggingface/evaluate/pull/328#issuecomment-1286866576\n",
+    "    metrics = metric._compute(\n",
+    "            predictions=pred_labels,\n",
+    "            references=labels,\n",
+    "            num_labels=len(id2label),\n",
+    "            ignore_index=0,\n",
+    "            reduce_labels=feature_extractor.reduce_labels,\n",
+    "        )\n",
+    "    \n",
+    "    # add per category metrics as individual key-value pairs\n",
+    "    per_category_accuracy = metrics.pop(\"per_category_accuracy\").tolist()\n",
+    "    per_category_iou = metrics.pop(\"per_category_iou\").tolist()\n",
+    "\n",
+    "    metrics.update({f\"accuracy_{id2label[i]}\": v for i, v in enumerate(per_category_accuracy)})\n",
+    "    metrics.update({f\"iou_{id2label[i]}\": v for i, v in enumerate(per_category_iou)})\n",
+    "    \n",
+    "    return metrics\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aki6vBMbgHJ8"
+   },
+   "source": [
+    "Finally, we can instantiate a `Trainer` object.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DPvhqbUVgIhl"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import Trainer\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=training_args,\n",
+    "    tokenizer=feature_extractor,\n",
+    "    train_dataset=train_ds,\n",
+    "    eval_dataset=test_ds,\n",
+    "    compute_metrics=compute_metrics,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "y7ebFys1gO25"
+   },
+   "source": [
+    "Notice that we're passing `feature_extractor` to the `Trainer`. This will ensure the feature extractor is also uploaded to the Hub along with the model checkpoints.\n",
+    "\n",
+    "Now that our trainer is set up, training is as simple as calling the train function. We don't need to worry about managing our GPU(s), the trainer will take care of that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MVTWgGeQgRpB"
+   },
+   "outputs": [],
+   "source": [
+    "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "I96TvX-KgT56"
+   },
+   "source": [
+    "When we're done with training, we can push our fine-tuned model to the Hub.\n",
+    "\n",
+    "This will also automatically create a model card with our results. We'll supply some extra information in kwargs to make the model card more complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "m8YuKExogV4P"
+   },
+   "outputs": [],
+   "source": [
+    "kwargs = {\n",
+    "    \"tags\": [\"vision\", \"image-segmentation\"],\n",
+    "    \"finetuned_from\": pretrained_model_name,\n",
+    "    \"dataset\": hf_dataset_identifier,\n",
+    "}\n",
+    "\n",
+    "trainer.push_to_hub(**kwargs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dFzJ8Xb5g1Vi"
+   },
+   "source": [
+    "## Inference\n",
+    "\n",
+    "Now comes the exciting part -- using our fine-tuned model! In this section, we'll show how you can load your model from the hub and use it for inference. \n",
+    "\n",
+    "However, you can also try out your model directly on the Hugging Face Hub, thanks to the cool widgets powered by the [hosted inference API](https://api-inference.huggingface.co/docs/python/html/index.html). If you pushed your model to the Hub in the previous step, you should see an inference widget on your model page. You can add default examples to the widget by defining example image URLs in your model card. See [this model card](https://huggingface.co/segments-tobias/segformer-b0-finetuned-segments-sidewalk/blob/main/README.md) as an example.\n",
+    "\n",
+    "<figure class=\"image table text-center m-0 w-full\">\n",
+    "    <video \n",
+    "        alt=\"The interactive widget of the model\"\n",
+    "        style=\"max-width: 70%; margin: auto;\"\n",
+    "        autoplay loop autobuffer muted playsinline\n",
+    "    >\n",
+    "      <source src=\"assets/56_fine_tune_segformer/widget.mp4\" poster=\"assets/56_fine_tune_segformer/widget-poster.png\" type=\"video/mp4\">\n",
+    "  </video>\n",
+    "</figure>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QXY3erc6g8LP"
+   },
+   "source": [
+    "### Use the model from the Hub\n",
+    "\n",
+    "We'll first load the model from the Hub using `SegformerForSemanticSegmentation.from_pretrained()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gfbdz9Hpg9mI"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import SegformerFeatureExtractor, SegformerForSemanticSegmentation\n",
+    "\n",
+    "feature_extractor = SegformerFeatureExtractor.from_pretrained(model_checkpoint)\n",
+    "hf_username = \"segments-tobias\"\n",
+    "model = SegformerForSemanticSegmentation.from_pretrained(f\"{hf_username}/{hub_model_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SQJkEqGxQwz6"
+   },
+   "source": [
+    "Next, we'll load an image from our test dataset and its associated ground truth segmentation label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "R57X_iNkqv6H"
+   },
+   "outputs": [],
+   "source": [
+    "image = test_ds[0]['pixel_values']\n",
+    "gt_seg = test_ds[0]['label']\n",
+    "image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7m7IfMv6R3_5"
+   },
+   "source": [
+    "To segment this test image, we first need to prepare the image using the feature extractor. Then we'll forward it through the model.\n",
+    "\n",
+    "We also need to remember to upscale the output logits to the original image size. In order to get the actual category predictions, we just have to apply an `argmax` on the logits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8nNSSqEUBS2v"
+   },
+   "outputs": [],
+   "source": [
+    "from torch import nn\n",
+    "\n",
+    "inputs = feature_extractor(images=image, return_tensors=\"pt\")\n",
+    "outputs = model(**inputs)\n",
+    "logits = outputs.logits  # shape (batch_size, num_labels, height/4, width/4)\n",
+    "\n",
+    "# First, rescale logits to original image size\n",
+    "upsampled_logits = nn.functional.interpolate(\n",
+    "    logits,\n",
+    "    size=image.size[::-1], # (height, width)\n",
+    "    mode='bilinear',\n",
+    "    align_corners=False\n",
+    ")\n",
+    "\n",
+    "# Second, apply argmax on the class dimension\n",
+    "pred_seg = upsampled_logits.argmax(dim=1)[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oyHddde_SOgv"
+   },
+   "source": [
+    "Now it's time to display the result. The next cell defines the colors for each category, so that they match the \"category coloring\" on Segments.ai."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "Ky_8gHCRCJHj"
+   },
+   "outputs": [],
+   "source": [
+    "#@title `def sidewalk_palette()`\n",
+    "\n",
+    "def sidewalk_palette():\n",
+    "    \"\"\"Sidewalk palette that maps each class to RGB values.\"\"\"\n",
+    "    return [\n",
+    "        [0, 0, 0],\n",
+    "        [216, 82, 24],\n",
+    "        [255, 255, 0],\n",
+    "        [125, 46, 141],\n",
+    "        [118, 171, 47],\n",
+    "        [161, 19, 46],\n",
+    "        [255, 0, 0],\n",
+    "        [0, 128, 128],\n",
+    "        [190, 190, 0],\n",
+    "        [0, 255, 0],\n",
+    "        [0, 0, 255],\n",
+    "        [170, 0, 255],\n",
+    "        [84, 84, 0],\n",
+    "        [84, 170, 0],\n",
+    "        [84, 255, 0],\n",
+    "        [170, 84, 0],\n",
+    "        [170, 170, 0],\n",
+    "        [170, 255, 0],\n",
+    "        [255, 84, 0],\n",
+    "        [255, 170, 0],\n",
+    "        [255, 255, 0],\n",
+    "        [33, 138, 200],\n",
+    "        [0, 170, 127],\n",
+    "        [0, 255, 127],\n",
+    "        [84, 0, 127],\n",
+    "        [84, 84, 127],\n",
+    "        [84, 170, 127],\n",
+    "        [84, 255, 127],\n",
+    "        [170, 0, 127],\n",
+    "        [170, 84, 127],\n",
+    "        [170, 170, 127],\n",
+    "        [170, 255, 127],\n",
+    "        [255, 0, 127],\n",
+    "        [255, 84, 127],\n",
+    "        [255, 170, 127],\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "f4BzL0ISSePY"
+   },
+   "source": [
+    "The next function overlays the output segmentation map on the original image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "G3HqZXyQB7gJ"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "def get_seg_overlay(image, seg):\n",
+    "  color_seg = np.zeros((seg.shape[0], seg.shape[1], 3), dtype=np.uint8) # height, width, 3\n",
+    "  palette = np.array(sidewalk_palette())\n",
+    "  for label, color in enumerate(palette):\n",
+    "      color_seg[seg == label, :] = color\n",
+    "\n",
+    "  # Show image + mask\n",
+    "  img = np.array(image) * 0.5 + color_seg * 0.5\n",
+    "  img = img.astype(np.uint8)\n",
+    "\n",
+    "  return img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-yEXFytLSkht"
+   },
+   "source": [
+    "We'll display the result next to the ground-truth mask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vnSn2A2U0RMw"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "pred_img = get_seg_overlay(image, pred_seg)\n",
+    "gt_img = get_seg_overlay(image, np.array(gt_seg))\n",
+    "\n",
+    "f, axs = plt.subplots(1, 2)\n",
+    "f.set_figheight(30)\n",
+    "f.set_figwidth(50)\n",
+    "\n",
+    "axs[0].set_title(\"Prediction\", {'fontsize': 40})\n",
+    "axs[0].imshow(pred_img)\n",
+    "axs[1].set_title(\"Ground truth\", {'fontsize': 40})\n",
+    "axs[1].imshow(gt_img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "r3Chx4bXaCYa"
+   },
+   "source": [
+    "What do you think? Would you send our pizza delivery robot on the road with this segmentation information?\n",
+    "\n",
+    "The result might not be perfect yet, but we can always expand our dataset to make the model more robust. We can now also go train a larger SegFormer model, and see how it stacks up. Here's a call for actions:\n",
+    "\n",
+    "* Train the model for longer. \n",
+    "* Try out the different segmentation-specific training augmentations from libraries like [`albumentations`](https://albumentations.ai/docs/getting_started/mask_augmentation/). \n",
+    "* Try out a larger variant of the SegFormer model family or try an entirely new model family like MobileViT. "
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "machine_shape": "hm",
+   "provenance": []
+  },
+  "gpuClass": "premium",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/semantic_segmentation.ipynb
+++ b/examples/semantic_segmentation.ipynb
@@ -1,0 +1,1253 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU",
+    "gpuClass": "premium"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CL089-JvFAXe"
+      },
+      "source": [
+        "# Fine-tuning for Semantic Segmentation with 🤗 Transformers\n",
+        "\n",
+        "This tutorial shows how to fine-tune a SegFormer model in PyTorch for the task of semantic segmentation. You can find an accompanying blog post [here](https://huggingface.co/blog/fine-tune-segformer). \n",
+        "\n",
+        "This notebook shows how to fine-tune a pretrained vision model for Semantic Segmentation on a custom dataset. The idea is to add a randomly initialized segmentation head on top of a pre-trained encoder, and fine-tune the model altogether on a labeled dataset."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2UEtIWt0sGkR"
+      },
+      "source": [
+        "## Model\n",
+        "\n",
+        "This notebook is built for the [SegFormer model](https://huggingface.co/docs/transformers/model_doc/segformer#transformers.SegformerForSemanticSegmentation) and is supposed to run on any semantic segmentation dataset. You can adapt this notebook to other supported semantic segmentation models such as [MobileViT](https://huggingface.co/docs/transformers/model_doc/mobilevit)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "j9Fe4GuFtRMs"
+      },
+      "source": [
+        "## Data augmentation\n",
+        "\n",
+        "This notebook leverages `torchvision`'s [`transforms` module](https://pytorch.org/vision/stable/transforms.html) for applying data augmentation. Using other augmentation libraries like `albumentations` is also [supported](https://github.com/huggingface/notebooks/blob/main/examples/image_classification_albumentations.ipynb).\n",
+        "\n",
+        "---\n",
+        "\n",
+        "Depending on the model and the GPU you are using, you might need to adjust the batch size to avoid out-of-memory errors. Set those two parameters, then the rest of the notebook should run smoothly.\n",
+        "\n",
+        "In this notebook, we'll fine-tune from the https://huggingface.co/nvidia/mit-b0 checkpoint, but note that there are others [available on the hub](https://huggingface.co/models?pipeline_tag=image-segmentation)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6EGlFGE8uyBS"
+      },
+      "outputs": [],
+      "source": [
+        "model_checkpoint = \"nvidia/mit-b0\"  # pre-trained model from which to fine-tune\n",
+        "batch_size = 4  # batch size for training and evaluation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d32sBZeq_HQ2"
+      },
+      "source": [
+        "Before we start, let's install the `datasets`, `transformers`, and `evaluate` libraries. We also install Git-LFS to upload the model checkpoints to Hub.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vAvgC48er3Ih"
+      },
+      "outputs": [],
+      "source": [
+        "!pip -q install datasets transformers evaluate\n",
+        "\n",
+        "!git lfs install\n",
+        "!git config --global credential.helper store"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qSq03UMRvjRS"
+      },
+      "source": [
+        "If you're opening this notebook locally, make sure your environment has an install from the last version of those libraries.\n",
+        "\n",
+        "You can share the resulting model with the community. By pushing the model to the Hub, others can discover your model and build on top of it. You also get an automatically generated model card that documents how the model works and a widget that will allow anyone to try out the model directly in the browser. To enable this, you'll need to login to your account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PlSGaFpFuQSW"
+      },
+      "outputs": [],
+      "source": [
+        "from huggingface_hub import notebook_login\n",
+        "\n",
+        "notebook_login()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XalxdrirGkLl"
+      },
+      "source": [
+        "## Fine-tuning a model on a semantic segmentation task\n",
+        "\n",
+        "In this notebook, we will see how to fine-tune one of the [🤗 Transformers](https://github.com/huggingface/transformers) vision models on a Semantic Segmentation dataset.\n",
+        "\n",
+        "Given an image, the goal is to associate each and every pixel to a particular category (such as table). The screenshot below is taken from a [SegFormer fine-tuned on ADE20k](https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512) - try out the inference widget!\n",
+        "\n",
+        "<img src=\"https://i.ibb.co/8B8xy1R/image.png\" alt=\"drawing\" width=\"600\"/>\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mcE455KaG687"
+      },
+      "source": [
+        "### Loading the dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RD_G2KJgG_bU"
+      },
+      "source": [
+        "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download our custom dataset into a [`DatasetDict`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasetdict)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 281,
+          "referenced_widgets": [
+            "6de4fc2807bc4bb0825befbbaca366c9",
+            "77c817c830314013805fbd0d203ea8b8",
+            "f1f9875ed07b480591c975222fc95950",
+            "3a36ff18a13e46768228e7128e02002b",
+            "c7d020044efb4725a24a0a84ae7409fa",
+            "ad66d4abe2e2450cb7c8a573dc50d9ff",
+            "3e3d572c197e464da6a3ce0cfc4cc89e",
+            "59c9c5f2ef6d4625a97a4bc9bdc331b2",
+            "9725bcfbf9d54824974e8e69c64ca6fd",
+            "83896f5e610144adb992c63e9cbd56ff",
+            "ef4a5405c1d34d5badf0a813a8ea1fa5",
+            "289120fb74224df4a9d2aa2821432ba5",
+            "f7e2d0f3ee6e4231b22616fbf933bf02",
+            "78a551a0db66493f876fbe18030c3174",
+            "f3174b816bec4c918cd3ab4b10ec0efe",
+            "4fa96e02fc4b44cb9996bbef089fd74c",
+            "0031937aefa0465683e219549c935dd7",
+            "d1b7953db7a6462f831fb075199542ef",
+            "1c4348e789704fe2b25cb8698e88ca8e",
+            "bff07d8078824308b8aabf71faf16e88",
+            "12a94046754c49868ad14d688c48d88f",
+            "5ad48a5ce1dc426faa6e790064418c9b",
+            "3de3cc234bda43c1ad0b354dbc474ef6",
+            "d9f56ee4b21f4e0e8693232cbb490cdd",
+            "05621203ac434c5f93d355bb6ce6db3d",
+            "d134802237f84c73a2717eed6cc1ecb4",
+            "afce9206edbb444a944c291d5282c217",
+            "a60fbc5906394df9858d898670a7f819",
+            "1ee064e37e61448cb9a34fa7e66a3e34",
+            "01ecfb419b3f460b8377c79793740982",
+            "43f8dc298b7941bf8ca651015dec533c",
+            "32988ad67af149489bfd676c0942dbe4",
+            "a687b33460fa461eafec017738c863de",
+            "c5030cc8ebff4e628da62e8835965f33",
+            "33ad7766b2c146afb54a3470f352b8ee",
+            "915fad5434a545b086baf639459d4558",
+            "79894b070903437584f7aca3052e50de",
+            "ad87c3f60ac7492ab8aaa471630c41c7",
+            "e74bfbec17f94789bfb8e367983aa193",
+            "dccebc6c988d49c887484b78f4ee95e9",
+            "d04bc0eadaf242b6a81a9ade962c4de2",
+            "4ab875034a084c338994bc7909053241",
+            "3e2ff151429e49f5aaffd0a940d36805",
+            "0459a4d9fcbd4478a52481ac016ddd78",
+            "23735d2bbcf24587859d5d36bf901fd0",
+            "ca4341aa40384d228a99074543527b31",
+            "974c53ab4fb94ee3a86f650bba9562c1",
+            "3d40886e38454a618a8a9a756f5c458d",
+            "8db4e36ccc6a4d4492b78a50c7ec2409",
+            "ab102484e15d44a4b1182029637dfc30",
+            "389469716c4e42c884ca47c6659d5612",
+            "4d6b9ad04eab4a70bf1df3f43a7f5f94",
+            "b969b475e1b149dda5b119e37d7761c7",
+            "c298ba164a35417b9b1fff7a97bd7f7f",
+            "c8cd775a94a944d9a0e0ebeb2c3645f8",
+            "2cbb298d54ac4771be87a85cbcb5dff4",
+            "1a5bc3a601a949b5ab59b4a4b776f2f0",
+            "8c9c506bf6dd47fd882e8d70581e54c2",
+            "8652d0f8599843e98edfe6c21de5be9c",
+            "3b280d74e111402d94a18f61fe8c4478",
+            "998feff5e78b491dacc43d045c73cb8c",
+            "9747349d77e14ab3a47fd4c479970a0a",
+            "47cf642995f44f04a56be02be4ab0a87",
+            "dadc0338ea954e478246a588b2aa1dc7",
+            "219ab526698c43f895ca102befa0135c",
+            "ff2adb06e63e47798f7130e9630c1255",
+            "f596082d8bda42458543179605fb2dc2",
+            "af8c7c09c55341a6a14b4799ae2dff44",
+            "396a68b4f1b947b9876a9587b6958fce",
+            "a3a68016faa148158bd9f4d805863295",
+            "3bea3ea92ee8481fb036fa4e07c08009",
+            "0d05591c5dd74c26b9399ece8cea12b0",
+            "ea01151241174b9da977485761a27463",
+            "b2985292e9d24f8ab6c6523056d8371a",
+            "4af03fff36ed4c569c86908f228f7954",
+            "ae1bd290c1474450a169593db137974f",
+            "097c5b79a85642efa389e68aa5df428c"
+          ]
+        },
+        "id": "U10po8Q3w9ZJ",
+        "outputId": "292c707c-2cae-4818-fe23-f9c71efe0f37"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "6de4fc2807bc4bb0825befbbaca366c9",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading metadata:   0%|          | 0.00/635 [00:00<?, ?B/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "289120fb74224df4a9d2aa2821432ba5",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading readme:   0%|          | 0.00/4.26k [00:00<?, ?B/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:datasets.builder:Using custom data configuration segments--sidewalk-semantic-2-007b1ee78ca1e890\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Downloading and preparing dataset None/None (download: 309.28 MiB, generated: 309.93 MiB, post-processed: Unknown size, total: 619.21 MiB) to /root/.cache/huggingface/datasets/segments___parquet/segments--sidewalk-semantic-2-007b1ee78ca1e890/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec...\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "3de3cc234bda43c1ad0b354dbc474ef6",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading data files:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "c5030cc8ebff4e628da62e8835965f33",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading data:   0%|          | 0.00/324M [00:00<?, ?B/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "23735d2bbcf24587859d5d36bf901fd0",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Extracting data files:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "2cbb298d54ac4771be87a85cbcb5dff4",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "0 tables [00:00, ? tables/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Dataset parquet downloaded and prepared to /root/.cache/huggingface/datasets/segments___parquet/segments--sidewalk-semantic-2-007b1ee78ca1e890/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec. Subsequent calls will reuse this data.\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "f596082d8bda42458543179605fb2dc2",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "  0%|          | 0/1 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from datasets import load_dataset\n",
+        "\n",
+        "hf_dataset_identifier = \"segments/sidewalk-semantic\"\n",
+        "ds = load_dataset(hf_dataset_identifier)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "y5z6SfJpJ5-e"
+      },
+      "source": [
+        "We're using the Sidewalk dataset which is dataset of sidewalk images gathered in Belgium in the summer of 2021. You can learn more about the dataset [here](https://huggingface.co/datasets/segments/sidewalk-semantic)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eq8mwsZU2j6t"
+      },
+      "source": [
+        "Let us also load the Mean IoU metric, which we'll use to evaluate our model both during and after training. \n",
+        "\n",
+        "IoU (short for Intersection over Union) tells us the amount of overlap between two sets. In our case, these sets will be the ground-truth segmentation map and the predicted segmentation map. To learn more, you can check out [this article](https://learnopencv.com/intersection-over-union-iou-in-object-detection-and-segmentation/)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 49,
+          "referenced_widgets": [
+            "4b1915eae45c4710b6a3f8495093956d",
+            "b42d735eeb0043e7b318004de525b55b",
+            "d1148b579b6e41af99f2463a799d6c90",
+            "501ff9d5db294d928f6367741bdd8f37",
+            "a494ba6485a14473abcff9a343e1038e",
+            "6fda21b649114145af09deb02b2d1e95",
+            "dca0b5e19b504879b6e821f43ccbed00",
+            "e9bf0dfb0a574cceb00953779da8d5f3",
+            "8de21d3ac33f47a39fbefa6395d703df",
+            "2da9282150f94994ad230dd70d9ddbbb",
+            "faa9ead661124af59981d5b0cb5d38b9"
+          ]
+        },
+        "id": "8UGse36eLeeb",
+        "outputId": "682ed0ad-b48b-4988-b8e2-aa25d216ae76"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "4b1915eae45c4710b6a3f8495093956d",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading builder script:   0%|          | 0.00/13.1k [00:00<?, ?B/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "import evaluate\n",
+        "\n",
+        "metric = evaluate.load(\"mean_iou\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "r8mTmFdlHOmN"
+      },
+      "source": [
+        "The `ds` object itself is a `DatasetDict`, which contains one key per split (in this case, only \"train\" for a training split)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7tjOWPQYLq4u",
+        "outputId": "cf7abc33-2ce4-40c6-ee66-e8ce47a1c208"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DatasetDict({\n",
+              "    train: Dataset({\n",
+              "        features: ['pixel_values', 'label'],\n",
+              "        num_rows: 1000\n",
+              "    })\n",
+              "})"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "ds"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Yt_phZQsxz5M"
+      },
+      "source": [
+        "Here, the `features` tell us what each example is consisted of:\n",
+        "\n",
+        "* `pixel_values`: the actual image\n",
+        "* `label`: segmentation mask\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nfPPNjthI3u2"
+      },
+      "source": [
+        "To access an actual element, you need to select a split first, then give an index:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 217
+        },
+        "id": "BujWoSgyMQlw",
+        "outputId": "59c0dc81-3be5-4b38-f3bf-037133024e57"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAEAAElEQVR4nGT9Z7Bm63IehnX3m1b44g6T5+R7zsW56dwLXGQQpGyAZDGBgChRLldZkgPtKrv4QyVX2ZaqZPuXbJfKVpUl2iRsmakEiwQE0YgkCJAALm4Abg4nzJlzJs9OX1zpTd3+sfbMPaL2VM1MfWGttdfbq/vpp5/uF//6n/+LX//617RWiAKiC6OrogTm137ore/eff/p9tHLr9y6OHt6+7XjDNz12QYYdi0nvbpY/+SP//T//W/9XWM0APzzf/LrX/q1X3nnwZO833zirU9/9d073/76n7z2yiv/x//N/xZL9+t/8OWXP/7qG2+84X0slPnl/+T/PJw+BTIggogAIILe93px+Kd+7K3PfuINNVk+3O2iLvyjB//P//pXlbaIiIhKobMaAf/4nQcvvvmjk2l5dTH77FtvvvTqazGph7186zvfuvN7v/E/+1//B0fXbnHOIpIyc0YkFlRCKEgAAggFgNNCiEqRMcYZVIiAwMwxxvGqiBQiEarg26EfTk5PTh49WiymWdIf/ovfff+9t//wi/+MSBuL9WLStM3nPvGnXnnljclk+Ydf+P2vf/OLyJxTECZE8nm4fu0aJJ7Oph988OF8uZjPCz/0bdesV5vB58l0LsgAzJIItbW6bRpn7JXjKxfbTVnZ4JMyCQC71jNzihJS1gilq5fLZdvtJvW8bVtjNRFsNtvXXnvFWnv//oO+6xUpo3Xb9lmEM1y/eaQIzs82Qx9u3T48PKqatlssDpC4rAofhq7r9s2+KhZvf+cRKbCmRIQQktaqbbvCuRRjShKGSCiuLBPn2bz+5CffvPv+nf22y0l0k/qH50+VUiiEQE7T1ePj5XSmiGaT6d373XTiX37tKlrqwq7yLF6Orhtrivt3w8X6otlvlweHAGAKR0RImHO2Sl2/dfP9u3f6zg/9wCl+9tOfqQ4P3njjk7vdbrNe33zpY9979NA5FFGAAiDMwpxYBEHlHJc2vXZYn/fwCAEABAAEEHE0lMLao3m9OT8p3XUU6PseEAB4avFzb336zm//8vmTx8urL3DOiKRIKWQEBKUFkDkDIgJWhma1BkIWSBlyBkAABGFE0CAAACAkAoycMpByTdvW9TQGsIVRWj98eJ8zhBBdUXkftdYgyZFCgaHv1+vV1aPjvutjDCICCpp92+53Xd8Bwm63ns2vOlemnJDIWW20boe2KDVksEZzzoRUVuV6t51Mah965wof913bx8iECIhKEwcWwe12K5ByDrPZJHPqup6IQghd1wFISslVDpBylsSZGWL0piq01pOJWSwWfb8jgv1+V9eThw8eLw5nXRs42d22A6Cc2LOfL2prDTOmlBAh52ytizELsI+BmYcheJ9i5BSTs4VeziYaUQGqUs8Oq1lZXL1+4CaU6lVxNLz147emxyzUPXh4Dmj6tgshTyZO6zy5MqOw223Xo2HZwuWcEzMLV7b49Gc/9vad91XTM/P56cXv/sk3P/1jP3h4PH306MGVK7f+8v/8bzR9++SbXyMCAAYEARYQYRbB7W47n5dWFS/M6m2hCAmeWReAMOeU4tF88nCzh3iUQ1ws5jknAeU4v3rz6EffevOD9959+TM/xiwgorVKcSi0AwDvvTWEQAiKgfokFhCQWAA4MUjOGS5dIyFgDJk528KQBiFYLherkzMk3mybP/iD3z87O+lavzw4KIvyfLtKUVIS1pRyTjmllEOIIhhSQkJLbr9vrdYxRmusKWi3W2mliLQiVVW1ccV6vyEkIru8snj08HFZOFu41HsiMsYIZ2OMVhz8oJxGAAIJAVJMIeSY/HK5UBogK2M0Z9P3/ejmF4t5VVbNvu+HMJ3VwxAePby4euXIFXazblarNalwcDTPzG27365z328Oj6bWMmd7cEDWlv2wL0u92+39gDEmrZTRBhEBIbMgMyEGH7/y5T+p6xIQkVDPJ66w1bXbixc+fvXoVu19H3NsY/OkWU+XUyXydLVyRrEoEWhazxlTyJMZsu0RVg+ffPjiy68BQOGs1tpo4wETpIPpoqwmoR2Yc9vuf/mX//F7T9/+3d//Vevstasv/C//V/+7N37ws/e+9idOawAFCMDMgBDT4mjx3ffvPnr6pJhXuqpWq41CzIICMaWolEJUmVEr2p89OAE5nLiu349mR4gG4VMfe3lVXemGXisKMRqOj+5+bzqdXb/+0ubi7PjKoSoKzhBzlCACShABlWBGACAEGO8MEACS7NrOFpOcIpG+OF0hqgf37gmm4+PlB+8PwrDe7NqhM9b4vgelnCtzopyyNabtOhQkIkAkRYv5winKHHPOgDH41EWvlDZWscqBfVFbiwZYCuusLnLOwfuisqhi4YhFiOzQRcmcQyqca9shRwicrDWKeLvdzmZ1ymCt9v3QdwNprOtaEaGAD6EoCwSNkHLCGEVprOtiCHFSO+3q85OnjrSxEEJIDK4qopeM/uDKlfUqxdjvmj55DENUCuu6IiSlFLMIC2o12hkCMkvMmax106uTN3/itfoaPVp/eLp/+uHTB6v97mK9f/jg8Wa9FdbNjrsmr8/3hSslU9/w9ixSUl1u/pvf/rttvwcA7QwaVCBK6ZRSVVfTaYnEmQMi3Lx5Yz6vTs+f9KFP0v69v/uLq8364MYtXc4ETIqQs2hSnGExn/+FP/dnsaj/43/wD//Wr//aF+/doVoxRxFkhpQkRg4xI9Nrt6/rPJRKHCkEFBCjtEKVev+xl1+JKaWQ+mb/wZ3v/PFX/+APvvDPnp7c+/Z3vtp2OyLFzCIIglFgiDlkjkxJiJEAySltldIajKbz86cxRhElTLPZLMZw88atGPODhw98aFnSMAzrdds1SUSsNYoUIYkwMxMRIipEZE6Dvzg9a9pdjCHGIMwiQqTatpvPZ0pR8J5Y+r7run4Y+tm86lovDNduTEllkaS14YyICoCiz97nqqq10TnnqqoWi2XXxb7PCtAa60NARK30drM/P1+HEJbL+cHBHFCms0lVFT70wxBSZAJdFNXqYtc2QwisSGllm12DLAJ5eVCHuAXMPqSqqokIAUSgbduyrOqqFgZEZGYRQSQiijHGGHU9mUwP3ePThyH22pLRulDFdhVCZB86Ms18PtEkikhyYjZa6bIqMuDeR1uob7z9R//F3/tP/yf/o39POyOQEQUAUspVVdf1/HHEb3/wyBl1eHD0+PFZOS2bLn37W3ecOv2//J/+b//aX/5rofO+2Q1d852v/vGXf/XXEGjoutKZzvOTi27NpxdD+/oLr57fPQdWCEhAIMRJUElRazFlVbvj5QEAAAABAEu/azgkN7EQZH1++u1vfOnBw/cBEDE/PXly9fqBqxaKLIICACAC4ZQlJVFKAWYCFs5WwFktyD72wmJN6f3Qdh0RHCyX3/jWviqrqpzttucAIpy1RmSllAIAEWGW6MPx0bEmfXF2BgAouFjMYmrrer7ZbK9ev3Z+frpv2qqqjDG563NMmjBkPjw8Pj4+6vp928TZbLZdt5t1XxRKUApTep+ECRCNcdaanAQB+364dv1ot9unIK62nJJWlHLSohDUyy+92Ow3Z+crW9jlcjqZTO5295AkZ1Gop5O50bprexE4ODg+Pr567/6Dod+uz1fVfKo0AQCSBB9ilHpSa9IxBGN1SsEYxZlRAAkBlFaKiJjFWquvHh1U1WS336LmIXJoGm3QmKJrOo0VQkhDNNoESb1nFq+yan139fqRTzz00U3Nr//zf/iJT/3gq7ffdLpwRbkHSTFU9aSoyoPrt7/5wVld1cX8hlEHjW9hgLOTi7Z5/O4Hj4+PbwiQmSxfev31t376p5y1//SX/itW+rzpf/tf/sueySTKQYfkXaliF1EhCgMYArAK0ejEkjkZawBICTEykCCRcAahEPs7d773/t3vpdzlFN955xs5p69/84u3X3zTWco5xUSIiEg5ZxFBTKTAKEIEBSoJx5S0Nn3TTeeaFAgBA967/2Hq9sez+QcxK6WjD5A55yggZVE552KMOebJpIx+0K6czScA0g8xcwohrTbb2WwSYqjqGkDlnNoukBjOrY85JUaUEPui1K7Q5YR6H4WhaXpncbVfA6CwaK1HVM7CpKQozMXFeQhhsVhwxpCGsqx8iCHEuiwQBIEQsK7Ki4ttCMEo0sY6Z5eLBXPshk5p1EY/OT0n4pdfvvnoATb7ZnWxQaSynMzn067zft31Q+uMQdRvvPGxzP0wDNuNSynljDmJVQoRjbWIqA/m87oonz55YgqjtRkCVsb2vSdUfR8Moipdigm1QjQIqiwLRH92epEhKScppqND/v/95j/4t/+Nf08ZY5QiIslCAsvlwQf3Vg9XrW3S9PBm5dzNwu535/PJjX2z//JXvv7Gx8NiuTRa9237Az/w8l/+H/8777/3/oePTv7k7t0/+N67rWTYtVVdhpB14fKQiUhEQJhQA4AiUlprRYXVQ0YAQAARycwhhgTchO7uB9+7uHgkHGIYCPV8sXz88MOLi8cvvfgp5gwjWgdOAFpEERASCnLChCI5phy7rv3db/3TK1euvvXWZy1pn+XBvbtf+ePfe//dd1hSypGZEUEpzAxEtFqtlKpIKc7cti0JoYKqLKyiEINSejKtJpOyql3OWWm937ZtMwCRCCOiMRoJrcWUQz2x9cQwaleozSZzDlVZGy3tridSTdMpRVprAECFKXBV2xi7ld9rTTmpvu9n87osy9OTk9lsprVt9l3XDcZYpVTfDdOZ2zYXItk6XVQGBHwYHj9+HCKXRR2GvF5vympy8nR1dDw3WnHMkjjmHFNkzrPZrO2aT336zRDCB3cf7PY7ydkWxmjtvdelcXVRaTRKFIlUk2LwvSEz+MHoomv2k7IgoGGIpJTSmgX7LgMSoOKcU8qr9far3/j9o+mNhTMIwMJh6Dml6Ww+xPzeO99RSjvr6kk9m81n9WQyX7740kvv3Tk5Oe9ff+Pll156OUW8e/fepz/5A3/13/l3f+/v/+I//C9/aRPipt1XN24QqvOL1bKegwCzIApABlBICCCcszZmMZ893TAoEIGcmZlTzhnk4vTk/jvfWa/PtSPO2Zq8W69TzE8ef/ix1z6XsyACs0KUiphQEyALAAhSJrJIRnI0hvp++3/9T/7uT/3En/r8539MK6UJN5unWXyMSSuiwuQUgLh0JZEqyzKEMRqy1qYfelTo/UBGgQBzns8mIfn9PqQUm6ZBsDnz0HeAUFgThVPKiLbvm3qi68lks2kQ0ahCa7vfd85pa7X3wRhnHaUUEXE2nRKSsWKM3u0b7RQRGFOVtvA+hBA3m20MaYj9ZKq15rYJIcYssQsNkeq2fGs2zXl/fHylMNB3cX3+dDFfKGWMUYdH05RCjMkZ04UhCQPQBx98eHRl4f3Q7h8G70McRt+viIaUU44aUq6LwigKwQfPutJFVUsWrVO79wI4dAM6JxkFBERiHpQTYFFK58xd39OkDNR/47tf/KGrn0IEQuKcWXLMkHMiQuY8hGFYDWdnZ4pUWVb1fHbrxY9h256eb159vXj/3ju/+etf+7m/9GcP59cOb7xUVGUcusLYYej3u+bw8KpROACjkAiIMOqUGCQSZEg+cYqMyCwoRKCODq9U1WQX+IMP379YneXOM+m6KInI+6hdePDwbs4RkAFBKa0ItEIiQkBCMKQICYlF5PHjs2/+yR99ePeO1vmb3/rK66+/Yq17773v9e3Qx6EfhHMmjUU9sRYRGYEAIEsehi7nrLXJwgTKWAeIOQXnDOesEPt+YMkxsu+7lDIL19OKiEEyCNx5/97yuDbG3rv3KCfYbUNh65RjzjlGIGMskFYIkJUiET49PS3LqizrzWYHhAKYOC7n8/22z3lwziHqGJp+GGbLhdZYz8xMVUbTfD4bur5UZmjB2tIo2O32kNx6vU6caleQoLVms2m1toKMikjQaDd0/XbdHF85eO/d+7NJkVNW6hJhxRAEUFtrM8tmu5/NZwKCIDEkrXC+KNv9LifyvTaExjm0oCBbS9a5GKBtB2ud0ZlQe4bT5mQ9uWqME5Gcc1WVwzCsVhc5eq20AiTCmAVAvO93T/fV7Ojhwwffe/vtru9+4ef+0uM7d3/lH/6jv/E3//2D199sSy0KrDECeTIp/RCrg+M2N1qRiIw5CKEIEMgYy0BAWESjKI2m0LYwAOrJ45O+95gh7JIGRhRmdjGfn5923b4s6pyZVCRLZBSnbLX+2pe+8K0vf/Hateum1A8fPbDWfP3rX7AOlwfl0He/8Zu/8vrHPhlSN5vN+hh8t1VKKa2d0zEGRCAFiIgAiOiczTkrpUVk3zSEVJVFVRUC2Tqdstpuh77zIHrMPLz3Wol1zvvgSoOkY4wgEGJ01oYYtSZESYmDj0ZrwDiZzIchtG3LObatjzGIgK1szpKiDEMQAaVUjElrrZSy1uUIVWGLpYshlLVy5WRPpm9D2w62hKp2jx89Dd1OOxNCElCYpagqY0zbDH3nERQhW4VuUimirm3Kyhlnj49cNZlt1ts4ZolAWgBuXL8efNjvG6UoDaycskaosFpTs4uQs1Yq5VA7W8yK0A/WlDn7wXd9H7QmrcVqFf3+4e7hMb0MgCBCSOvtZrNZPXrwsHBFWVXOWaWsspUAK4WKyFiVOPzmb//GweLgL/3CX//Hv/iff/drf/yZH/ns/Or1+OhBPyRrTNe3ZeFiAkSNAEgoAoiEpFAZzBJjBGERAAEBzhwyJgEBUVqXXe8/8fobP/IjP1lPJq4o7t27b0tz86UXGFJZmIcf3v293/61z37urYOj4xdeeYkFv/W1r3zrK3/wHVJ96rKksqq23W4yrU/PT6ez+sbNI2NV226ssykzEAJDCAGEUStjiUYqFyHnzAxEpJRqurYsq2qiC2djiBWqnIPWlBMDKICxdkQIxJJh5GcpFYXy/TBfzDcfPmIhIur7jhTkBMaaxWxxfnb6xhs3Hz58uFnnkeDYbPaFK4q6QJDBx6rktm3ni2VZuGEIMcXj4+PEXikjGZwzQ79nadrOh5Tn05FKIBCIMRpnRfBstSGkejIpy5ITncX94WJhMJdFKZz3bVOW+uWXX0wpJj+cnp+nJMZoEQFgzZom5UQCixYRadNgswVH01ofXzWVrc5ON6uzeOVavX66qyZHtihi9KSlrMq2y5khRTYWBx82fn9YSBJOMbAPcd/M53NCHYIfhn673eSUjS506YqqxBz6rgnSXb9963v33n3xzos//XO/8Mf/4p/+yE//RFHNjXFlWU/rWpElRdt2R8SKbM5Jk82SrXGvv/mZd95/b7/df+0b35vffkUEEamLaRciXKz7cjqZzEnrz/7gDy8PD0LvC21fuHWrqqYHh4fnTx5AjJbw/p13v/g7v+YK9+//h//7Wz/wmZOzE+1cFlBoyqJuunbow9l6HSHpyjx5/KB008K6ptkDMmoayz05s1HaKqOVERFESDnGLFVZBu9TSkrp6XTqLE0ntXBcr9ciknOcTSZt12dmSWKM6Yd4cG0GAK3fIbDWOLTdres33n3vgTBZRZEZUSmt9vstgJytzpquU4Tz2WLf7EJIxhrgrJQtCgMAyuiU8uHxwZPHJy+/+pK1Ombftk0IKYZALlqnUVhrQs4ovF7tCdX1a9d9ykPwRusY477Z37h2pMAQnBMgkbFlsdqsTWVni2XmEIPf74fVeaMNzZcT62zOSfcxKXKFnTXNfnk4nykdk58tZwQAKlYTPkiGgz1YTrqBtpu+qBSpqAzVM9s0ndJWQIQBkGKgx83pdrcdZpNmvz/QpeS8WC6M1iISwuD7rm/2q/1uvz/f33qp2W2ibw4XB69/8rWv/Mkf/dzP/9XJ1Rt379xdr1cxJkXKWjubzQ4OD0oXpstJVVAKiSMMAxstiXdOS2JzPrjNo4bDAIoudv1kdqONwnJ6ODOvvvSxX/x//O3NagUcCwXOWG1sAqmnB7dffvWv/fV/6zOf++zJ3Xd0jP/4l/7Lf/tv3t5v1lGSsYWzi/fvvt90O1TqfLet6iJHWa8v8otDUZTATACKKAISkXXOWquUIkQWQcScU4wpO9Zaa60Xy8nQx5ykKFQYhslkst00ABhCQMSxYhNTEpHMsSzcZHHQNl1RVIJw7drV+w/ONqsGDDlnbVnlzKv9WWZ4enI6qaaQwFgDAEXpqsql5BGoKAtmnkymhSt3u511Win0wWtDzCDC1lplNaEyRscmlfNyGPY/91d+7itf+uMY0un5qj8fiIiI2qbZt+V2u7dO977DygX2rrR+6FbrC+/Dcn4ITIiXFTetVUpRv/3u+09On7pCJSi6dphO6mHoQx/OznZHV6fO0uxgcnbaf3j/ydVrk7YJSIXSUtRQzYprpPfroEn5EOazydwd8sA555S573oW5pQzZa304L1Inszni4PDgxD6vidIqNhYk9rm9P69zeOzP/zd3//sj/7wr/3Tf3T7pcNi+slm150+Xa1Xq+vXDu68d3+1PismMCnc4eF8WlZOtQ+eXlQHy0i3Pzhdtd3JfrsDxOl0Vk/LqtzcvHZMuTfkfuD1z2y22xAaTeJc0XR9DMEqe3F69ru/989+8od/ZD6fiaT33/7mP/g7/+nTJ3erGp2Dk/P1vt8OIShSoelzTGVRBMYnj0/6/VZSjj6KgDEmhNh2nSucCGfmZt+4okZARTQMQ2kLbQxLKCo6PFyuL06FAZH63seQY4yucJlZcgACrc1+v/ehu324CBG6dlBE3/zGN3Pmsixi8CnlFDtjzHRaDn4ghUPfc84nJ6daU1UV1mkZUl3X3veo1HazOzw8tJaePH283++MsUrjvtk755hTZYthCM6a6fHBbDrVRt57753dfv9Dn/uh4Wtff/jokSip60ppyiDKmqouCmeL0obkO98jy27bFGXR9/5itVYKAYQFQogAoP/g9/8oSDw8WtjGn682KXNZTJMPs3oe/DAMsS6n2mCzJx9Ikn7yeH14WCKaJFzUWkRBppA4BdVu8bNvvPnVs203+KbtzzbnIDKfz6qyartus137IURKiFSXExJ48fZLICojf/OPv4k+NK3/4Z/66aPrL/7u7/+yZL+YzK5/5o35dD6fly+99ONN151cnJ48OVnv5PHj9W6/Rgx1tfjk5z6e4loEYg6M3K28bnDq6tDuf/qnP/ftr/zxh93Dejops1WaXOGgaDDLwfL45Vdem84mH3x411au3XlC+pe/8xvzeV1OS8+71W613e4TcKls6IdKF33jlTEKzXK+aM/cgxBFtPchxjyd1tOZ221bFihcmbKIQOHMYrG4du1KyEPTn7mimE6L/Q6bnT8+unJ+ttaGtNHGuSFFYbbWTWfz9eYi9Xxx3iyXc9CRc3auaJqdNS4nAkW7XVMVbnkw6/uIWeWUtNbRJxEhRSF4EZ7URfAdKbOYzxDTet0Uzu5De3Z2XpYFS8yRUFHI+9KpV1+9fnayfvho7Zz65je/eX623aw2r7/xsfmsDswHR/PVeiWJSVgVmHLaN33mCAA5Q996Z+piVh9fhd1m2/U9MwCSJtJ/5d/8c6Lkt/7Fr/uH/dWr87OzdQy5qi3lvkDttM5BSqta5if31642Oavt0wiHpQohFZnAGFPgAKWebS7asp7fvP3ilYODfbMdCHVBDx5+eH56cfvW7bquY4jAIsAp5V6yP03FZFFX9cROLjanMeRf/cf/9ec/96k3Xv+pL/z+b6+ePplPN03bWKdfvH1jsVxMpsVLn38rZ3n89OLb37p7en5RuhuoihB8TH07DMBZmMhLrfE7X3/nUx+/nlPoh0FyWl2c5RQPD5Y+hsls7uqKlJ5MpmenHw59H7wPGSDnw+OalAeJRaFYkEllGEutvN83pi5n81m/WyXhSVVvmo5jMIS3b9z47A++9s9+54tIKCApsYhcuXJ87cZyPq9W6wGxBlJPn174IRljnz49A0RjFCkZhr7QJqY4n82BKOfsrEUpuy4WpSCgzzmlHHJXFKWPSWtjy6qezrebvWRYLCcgiKAG7/u+hyGmwFW5Z0ZJ4rTb7zvnCuYk0lqrmTkGqCo1WdQx94vZNMZkLaWklDZDn6bT4uz85GJ1cXh0GJo2BB+THwaMKcyX89os7tx51xXKWsMEiLbvwwvT6cc//voXv/DltuuYmRRJzPo7H3ypnta3X1leu7lYr/YppYcPzrp+IGJrrbUqZzm+coypT50g5MzJWRv7ZGtKKROwM9qQOn+8ptR+7Vtf/9n/3s/+4Oc/95u/+RshxMODxdvvvMMhPX7wwesf/xhAiD4QOWFkIQuSu22C5EM6WCxLV54+fvqlxD/2Y3/hJ374p37p7/+dO+9+W5PkdniYzp4+XJsCjw7mB4fV0cHiL/35H921/tEDWG/2oonzwN4TKadd4kiCTuM3/ugLsdsvJ3UW6dv9dtVmH44PDyeLxaysY8za1B977a1vnJz5tBFTVItSFynEvh+47XoRFJ9ZRVKUUpTMybntZhv6pu27oe+QWSt64wdet1YfzKtJXREpIgJMiLjf745y1bQ5DpGjHvJAgNYWYUhDH5SmGFIMnCMfHx3tu912uz48PiKizBxjZMnVpEyZd/utczYnAEDmJMIh8eMnT40x9bw+ulJvtztrqrbtQAmRCcTOFcbIft9tLs4XixkixRhv3Lx5584dyNJ1cTJRRFA6t1ws9vsdS67qYuiDMcbU5H3vB1mvNmT10Hcx+qgIEEXSyenZpJ4WhUo5JUg3b9+8/8GDfbO5d8/vdnsAAkCjTIiskz55cNpsVr7vYkpROXClOCRhHQb2PqCYnHTfxJyzEwuQUs7Nrq2mE2GNinKXrS52IaS+feedd46WVz/1w5/f7doPP/xAlFnO5x975ZW3v/u9ru9ns5mUFTP74IP3OafMWREJS99cKEi6nDWN+/JXvvYXfvan/6P/w3/89//+L/7mr/8KxLBv+tK51ME2NDbk0itoQhJUeEiuRgPOLhYzSSkBAGcGoJdevH3z/Xf29+63Pty5OPMsGqnbb0Py56szp83MWLtb/8Wf+8u1/on/7z/6FU04WQCDH7p0cdGcn+2bdkBQxaQQxJw8KZeCKG02u3XnOyAIKWUBQvif/ru/cPPm9S9++R0QAGDOKeeYc1RG933nBy9EZaG7ZugGr5UhwsViuZZV8BkhEEFdW4HIudcWDg+PLp6ez5elUroZMip9MF/6IaxWW4WiEPp2r5DK2STnbrfrycJu7X3I3g/WmpSi9x2i5gRVPRlCL5hSzD7YzKzAlKVr29YHf3ilbra71cXu4GgewsCSXaF8GMi43ISuaW+9eK0dGqsdESnl2r0XUMIpJ5zUs8XCPHr0qOl8Pwybzb7vgxAgUfY5h6R/+MdfTilFr4YhhhD329y1QRtghu2mf/jhLgSYzeph2KzP+2EIZa2Ncz7G3dZXUycogYPVYp2rqHzjtVeXB7N93/3YT/z4O3ff/+Iff+3o6PjzP/IjIeXValUWFTMIJKXRucQiAtx2awBUBJH79ukjde/Oxz/5+UdPTj7/g3/mb/wv/ubpyeoL//K3taW+D6U2q9U+D50NovMBgPuhH/z81Td+NOSglTHakEKtSCtz/97df/6rfy+cvp+sfvXo6oebswhSVcWLL7zwrbffGcJw+3jxp25/stqfnP3qP3w/9CHn2HXFJJyeNJzVZu37NuUExgAippSYMyCXZVmVlTIFaBvZ931fT2Y//ad/qu/Of+f3visAxhhmHrzXWhOp1WqlCUBrDTmEtG+a0rmqKpnL7WY3my4GMzRNlziGGGazKZG2WufYz+YTa5HQCEejSxFRWs3n04vVhVJmNqtBEIBDDNKhrZAlD33S2jhXKkVN0ypN1tWHR7Wx9PTp6YsvX9nuWudcjqIQjHbOub7piQlAhehFhLP0vQ8xSjbKGExRhFKUXdNfu3YgLN3WF4XZ77uyKL3fxpRCSM45IiqKYjqrQwrTabk9a5RSOmXPwroYCtPNbX31xiSlBJBFEHHxoz95k1kNQ/jxf+3mZh12m2633w0+DUNcHFQP7q2MIa15uSyfvi3nH/j5ZH791uz+0y9PbfXX/s2fufnS8v0P7tULKCayvntqjKnrqXOF0aVSGYkFGACEIeW8223fe/eORCBTH1+7+id/8rXQro+PFwKSUkaRNmRD5BX2QwREhXj//sOvfvBbHBMiCZBxanmweOn2izdvHN64/fJ3nt5/cLrJT3dSLQwIWufBzOaHMxEy9Ef3Hkrfvkn6/OpCm1iUOkTpB0+g+r7PIoo0sMSYR3KfOQ++R3Q3bnzszp33UpLl8vDnf+Evvfba9S//4W8+vti0fRSRnC+z4WEYEKcAnHIqnLq42DMzi6SUODMicWZEtKVBS5ABQLQmjdZ3qW2b2y9eAUFnTQyhH/oY4mKxzJJX51tO6fU3Xv7e9+6myHU9DWnvKtXsYTKZ9X2Dio0pANN8Wbkq1+XkypU3Hj5+2LUeAJhTjOn6tRsEtNn4ST3NqR2LsCHklBMgk8pkEANut3tXuOVsMfRekfZ9qqtiNp237aAytH1fuKKeTpp9WxTlYjFrh26+mG/PG2udBhDmKBKYOeeE2mcOWmtFiiiDcExRFzgpYXJgFdVEV5lT5qy1BH+ra3vSbK36l6en5+83AMqVYdt9Yzeo2s0+9xPFx3/wBe/v/6k/t3jtzTeePGpOTj5U9dx33HWioJzUk8JNM2cj6fTk9MVbt8piev/D9+YH87g/+fm/+uff/IGP/4YxKSUCzJlRqyFIEEgs1bTO1n35934/eT+tJyQQJR4eXfvJH/707ZuTs9OTtUeslySUciKAzPj45IKUJYJsXTddHNTFWz/zE7/xz//ptE1n27OEsWl206KSrBMnlFEvTZBECBhYaa1NUVXTm9df+cC/96M//LlpBV/60h9eu3blyXaFiMJ5GHqldYohhUgARDCdlEoQgKraGmWMUVHYGIXEs4VjM+n6vUjuPTtXzqa1sWYyLYuiQMll4S7OLkY9oFIaCRVJ0+7Pz88QAFEvl4enu0AOJzOtNAHyZOL6fkDCfmhv3Hj54smKruDZ6X67GQBzToygrl+/Op3Nfu93H3WdJy0sgkzex6HLs3nJnJXBSV04Y43VtS7atnHOblXXdf7w8GCzaUKA0lV+GGY15kuFHOSYHz58kpm7vtciSEqzRKNLAEx5IAIiJALmJIIsYqwGxMxjv4tCxYVTLKHQXNQQk1hN1gmj9D4oxbpolVIefAJVTWw1g+XV4tU3b6agwpAAoe/k9GH3pT/4YHOxW2/Q2okrJsz5h3/kh65evf5Lv/TLzfb0ne/t/7MnD37+5//iZDrdbjcsQgKJwSeJOQ8hrE/PZ/aFGwfTzcq/dPOwKt333v7usqQ8rL/19Q+Z5fTkTBBBUc6CZKwziBgykFaVKdoQmth94Z23Ty62124cPz477VOMES+aJiVgzsikiYhoLBdVVXV4cFwUJga5euWF3X71O//id7773cWVa7N/8ftPy3qGeKCVQTKxC8y8mB+KoCuKnNIwhOzj4XyeOcUUu6GfTCaooOkb4Qg5KbLC0rXd4eG871ukLJJZJAQ/mVQvv/zaN7/5Ta1V2/UCDCAPHpy8+OIrfuh3u50B23V+Mpkq0l2nqqpumjNtLXM+Oz3fbbem5JdefvGD9x9uNm0MuXB6Mplcv3YdBJqmObwy3e53yasUZdQnpBi11da51fkmRrDWLJaTuq6nk6HrYtv0IpJSLsvCGKO1Hj36MAyK1KQsVv025KQlqZhyyIyY67rIiUlRylGyeO9BgEiTaKU1IqACRSRMIKDQipA2OMJPrQ0jhBRyhsIumFnSkFP0DKgUEUpCbaioQYjrBV2/vnjz059r9vH+vZNvffX07W8+9V7Kojw+OiydGhuzQPBXfvlX+q4TkbFLh0UAKA9R+th04d0nX6kntXXY9jsfVFlNdvv2H/3Kb83n9ZMnj0SCJgCNnHNoOQyaARkFAYZmo4zrQrc+eXT7+nVrC2Gds0pBMJEAAkRAIIVGUWndZ976lK3mHPNmd/7gw4dHi2s5ix+EuUSqLrYeVxc3bx0opQUxMyvSt166cbK6n/NgC6u1WsznQ9saa/3gR2mP0RbIEiDHxCSECISZoWk9ksQ8UFYx+8l03rZdWZYAIiCIRCh9n64eH+2azZ07dwCBRdTMBB+7rtvv1WRaIREI3r//4NqVZT/45WR+68Xrq9VdQTq6dnUI4d7D+/W0EgERcK5s9w0AzOaTnCNnUQLD0DFzThAklEVprc0cFWlmCD6SwsEPy8U8xJBy5hgyZwQ1n9bnJysA1HFAEW2oRMKhj5mD0igcfWKtjSZCQGRIIQoCZ46YEGmsYDBzZBBAoqytsKTgkx+y9IPWWpGJKQhnJRpRaWMpYUqZmUEDqKitmR3BJ5bL1z9+8/xP03vf7c5Onrz9drvfbz748MOXb7/4yuGN7e6MMWuNvvfCSMoo55C0APshPHl8YYuiKgtkyTl5D5tVv9nF4+OF1gogQJ9DLy2DAivsY07CSQAzGqMMCgRkgeyHIQTPkISjIk1gIpIgCeeq0J98/TOlKy7aIaacOXEeSOnBp8ODw4+98UbnT65eXT5+uFIa275FUF07tLv2vfa9F16+bgvJ7DWSYur2WTIZNfaWITNzzoAAAjkwE7hliUiotWjZ7vsqaFeYg4PDh/efxugRMWdGBECNFN59/05dmxgZEK3Vw9A3TT+b1sJoLCZOIubgcGor9fRkUy2W2mVXuum8Lqri29/7Xjmxi6NZu233bU9aFZUx2sHYB8kYIwMzoSVK1tF+31inQojRc1lZUoioDg5m1uj1Zm+NLks39P7ifFtVVNZl2/Q67VhrA6CoiPXUMbqUY8jiSKEoS4aIQFgRM3AEbNsmRlSkJ5PKGJNzEox6WoJGZmYWEGJg0CCMRmsUkCyAWSQq4xSWGYMhFfKQY2bJgmyLcONVVc703Tvx6f1H9VJ9eO/u8bI6OcGj46NPfuqNsnDvv3sXI56vNjF6sjPU4EOfcopte+3qlZ/5mZ/JOf7hH37p7t0H221jdZpPnRCUhTWsM+CP/eif+cQnXmrabU7xj7705Tvv3i0VEoJ2Sku+cuWKZNTKcuGy9wSKSHs/HF2pX3nt1gd37/omCNijw+N+d+oKk5gV0fn5+e/93r945bUrn/zUD7z6at5tfc6stbos9STfNM1BOYkpMUAI3vtMGoFARITRD6kNPoWYYhYBjYQs+93eORcgWlspxSHEs9NTwJxzPDq60jx+yizC2Zpis97nrJl5Mp2WlUs5LLTRYPqhN1lFkarUywNrSrzhFuv1+cHh9M1PvHL65PTi7KTp97ODGyi5npcC4JxNOYeU2AcAPL5yfP/hw8IoSRx9LKuZc0XOSUSJQNcPxurjoysvvnR8fn5RelfX5Xa71sYog00/WFtVZaUn/lCD3vdrYtMPUZeWhbQ2oIS0sqStpb7vJTNzAkBrXBj8w8enwafJtDg8mrtSxaROT/dAEHMgm1lzHzvlSCNRUlkiCPLgVfRVVSZOOSUBhpyt0Ykx5Xi6elyWxVs/tsg/NP2pn731wbfzm6/82K3bt5TSd95/7/69e6+++NLZ03NEHNo9Jr84KI69etjsNrvmnbffPjl9qrVabS6MKT7++ieIqKyc0oVHDUgFagYh0DeObtTT6v69J6dPt1qgdK6elIWpDpYHn37rJ8QVf/RH/6T1O1SsAX70Rz5x/frk7OnFxWqrQV85WMwqE9qVSJkyxxhTjPP59PR0h/rd69euGWvHkjMiAwEAnJ6eTabWKN02uzREESTSoGRaldttr4wSpn4IxCQSjXGL6WyzXTtXgGcE7npfWBLgbmjLunSF01rFkEjryta59xxFWEJISDKdls4Vvk3bzfbg+DClvu+7h/d31cKVlZlOZ7ttb+wwOZ7Mjucf3rmLIJlzN/R9GydV4XNerfY3j69aq0SYUx5iyn2WLCly2wxaF1VVrbom+KiVyjlXE623CgA3mzWiFKUtK4uku67ru6hvLT+mFHB906d+3+0kBVcXZ5snkQZdJ1dS8t5oSBlIC3NUgLOlmy1vpqD3++35xep8vR/2kti8+cNXl1PYhovN6X1tqZwUzhWlqaxVKJgjE0GCNmNkQUWQGYcogCCQFfFmcw4qIGVVm49//uCgPLt56/Xrh2++9eZnfAyr9erhw/vNervdbB4++IC58dJvv/7AubKcVqQgxP7w8LAq66pQzhXKZgDyiQlFSL76tS989+tfcEaDUSFmbfRsvnjp5ZenTp+dn508PX3ztVelqB38FKA3yhTW/Omf/EFUNLRe/qKxtnQ6Xpzcu1jfe+fRlrkrNF+/Or/58pWQ/GyhtQtkq5GVEI5k0XfeWZOGRJqUWBRURpBoSDFKGEIutRVGQk2IykDw4eGDR4vlxA9DTEEjF4VTyCFGpVUUvv/oPgOQ0sHH0K0nZaV1mbnb71vnJk2zjyEKY86yX3VlbVLOKYlvKPWxpf1sWux3ayrnzhX14VwAROStT392s9o/+PC9SVWmKPuuq9H53b6wNvkQAQ4ODoCoa3xZ6KoszvJGAIwp5guji1xNiv7BGZFoohhiUbi+9SiYctKGrCGt1MRRntormX3KQdu6D13Yb8OmAaWH3Lmp8hQiB0RS2ghEAjxcuvns6pUrR30v+HEsChtCd+/8q9WyL+pJGnzOiWZEaBWRmJSYvfeKpCpdiiFHKMtis2qqclpg6aop95CyBKY275r0bW7clR/9+G7X3n9wv+26nGRxcK2sFvX8MKah8d9p9uuf+NQntpvVnTvvvfraq7vd/uGTp0fT+tHD+3ZiU0pDHxEBlEIkDwAgo44OhHo/rLero8X82rUrKYef/yt/9urtW779s8PQ+75n4KFdzWbHRltiPXh/fvLeay8u79y19zdfbNqTl15eND1G8K6QoR9yzs5Ncko+sw/9fr8dhp5zbNvOLebWuLYdtDWdH7ohMUJi6bqOJVd1GdpgbUEQhz4U14rILMorQ9pITphTSin5FFOMSllmFgAkEoVZeBSsZmYCcc5uN/uyLPwQNHJZ1VGYg4CS9W4jsdYlFUXZNK0yEmPQpLbbZr3ehBBmhwsfM4iwQB99VRSAIEgHxwsi9ejR4xAyoFy9dmW9XltLAqnrGsF+NnfNrifUo+xsGNrSFoCgYxyUKpOIUrbQBtQEMFccJeSc49A1Sfx58xSBQNXst4zACoq5SXrgBEhhOpNimnNiVLEyVB2VwDb4GFLIg499MgdXM2KOHOMAKDkxt7FwRqLNMC1kDk2xnCxTMFeObgPZerKoy8WkmDs1EdDz5cGnlouU8r7p16vVbrvb93613Z5erBQGBZ5SOJjWn/zYaw8ePFhW5QvXrzy69+HgyYeeBSWzcNbKIuGz9kNhDuC5b7Zp6IvSFQWm3BkdsarKqkJgBOjb+uaNl5RWIWXm/MYPvOiH/a4PqL4UeJ2VBySFKrMPUdardjHLIok5931zeDz9xCduF66QnJ3F7XabOZMYAQghG+e8b5YHi2a/s1aNIwTarrfaIKrVeqWcVMYNw0CoxukCnHKI2TDnzFppZgFEZi4KN/jBOacIU+IQ8uHySoy95ND3w2KxTByF+JVXjrrtXiCfPjkx2hwfTjfrZj5fNE272WxdUWmjATIi7vZ7sqaoa2VM5ubk7HQxmzmrL87WjHD79s0QisVBsV610wUpI30fc6ZiVu2bjdMGgBAJAPRFl6DbDcNwtDieOJ5OKxasywoK4RwnxcxHP51cZZF+2GadgCCkffb9kDtV0pAvuv2+KktBYc6p5UJpS67PQ9eGnASBiuLqpJoLQsRYTaZWucPFzdLOy+KgqqYIVmGhbEGgnMGISlAJgzAQcpQgkRUji9SVLfXxleXyk598M8b4Ez/0+b/+C/96Smnofc6MgEqj1oqI/q2//q//2m/91t/6f/8XWpUxJwDy4rUmHNXNCkQyAhJi0+yePHkM4kFYC4oCBChdtbo4OztfM9jMnGIElpxy025+4zd/++77Dyezsm1i28W+3+ecQz8YbcojFfomRQZuP/9Dr2udhn5Yr7YJ7BB9Oa2axjd9j6Sd1b0nUpBC9MjG6LJ0uw2lGLq2r6oigc8pMYO2BJA1GcxeMvmYZ9NZ3/aCiQiHYbCFrSfFcjFvuxYQi7Jab9d1aXLKRLTdra/evH66Wt1eLLdn25ACZlhcmbT73g894mwymaXD+XZzPgxDUbn9uq1Kt2v6XW6Gzvve11Xx9OkTTSYMaX40A+Sr1w7K0i4Wi5T3bRuHLsfIbddxzkoBESIBIumf+cv/xm6/PTk7eXz/wYP1hdlcpBzrsjw6uqKICm1qO2GGnEKla07CklVF5CBTZsU+N0kFUirE4KOfHMyKqp4US8lqUi6tsUBYuIlSRmmLqAQMohLBy9kbwIkxSwqMwMAiGTjmAEpy8sF7QwSZta5SilpphYoFos9KmZu3X7r14m2lSMiMOkwkHMspVVl+8513QgwAlpmVgh/6/Gebpuv7fgh+GHzXtX3bjZrPmPz52fkH9x60QwBgrXRd6Q/ufqCVPT3bjhJ+QIgppaHdbxv0eP5k3/Z+v++899bRyy/eeOutVwGqR/c+cKbkYb9tttroYehDyCG2KUn0QRByyki6adrJtFKKtDaKwFqz3zdKqRyT96FelBfbXUykjQZhpXQX+hRZAqMmJAwhMucYvYgEH+azhUCuKgcAzb5NMXeQCZUhRYxN2+6bZrtpLzbbxXL24ku3SacnF12IYbtdx5KGYXDOEFEeQuZcuNKpJDEpgNmkSCmKiAiISOyHvjHBmA8+eFSWNFsWN2++8PrPvnDy9On779/TOhmtisIQgdZap5xdNbn50uzWi68g+91us9ts1hcX9cERskBIZVkiICIrIgEpq0qbIpEobbRxqDDkaIzTpAWJtEbUIIhAkZMgAAKyAAsSsQiPoFEyaCOcM0BIA6qMApzRMzVtq60hqzOnOMaWmNu4zgwoGlCEhRQRYkZWWhMSS8o5ZRZOQGhEpHBm3+wF4Pj4iAXarvkP/6P/ABgfP3rSdo33YYjpN3/7t997+539bhOGATierdasHLDUpblz5/5mvblx/UXwLAIpJUFBUt2uOTu7GHZ+1XSeGUC9/Mqtn/7vf+rg2D188HDz5JxAxWHIPklS3ssQBKkI/d5YmxNPqnLf9Dln0hCzl4FdYbTGvhu0KgEiEU0mk75rC1vExKgUYxZgAUxRJGPm3Lf91StH+/32jddf+9a33w0+2MKysDYoIolTzrGupyEwABmjd+um2w0PHjwwBRlrOPv37nw4PagQVWLVdU3XtZzzUV056zaxpYpQJCc+WC6364sUktaGgIjA+8hZmn5fFrbd99aWTx4/QVCT6fT4+Oji/DEAlqULPopkPYSklEIQUkrZ4ujq9WvXb1lSGUQAMLMwI6BCAJAEIoIgSiGi0kgEAk4YAMY+Gc4CkkY0gyIokHMGQAFBQQAkAQAxRgdgBmbmzNn7kHMOQ5CEXQzaGNKXQxAQEAESKUREoHEEUe/jfrdt+nbvB07se++DTzmnIXGiEANw+t533gVQIeaD5aLr2r/9t//OrJ4Nw6AUVmVdzuY/+pM//kM/8vm/94v/r9D2zHq375RtC6tA/Pnp6uDgWEQjAiFao4MAKT1dLG+98PK733676WO28sKr1//Mz7x1sXv07vsXKUClppr0xdnq4qJl4elycnCw2O8bayyTgEhOSZEi0lk6BFMY1/W7fkgxpZdef/X99z8UwKHzQwy2pJFjHwfixBRz4sOjo74fmqa9fnx8dPDCfD4FwLouBWUIwXfdYjY31mmjjbPDMKrnxHdBk1JKSOmU/Wa7UYpySNYYERbMqFgp2e32u03om3h8YDSpPob1esNZjHUiosdWS6U7P7Rdf+VouZwf79vd0Od3330fRF27dp2IYszaqOgTc9aFK8YsgzkjImeOWTJIJpGx45gUiCCOlgOktCJHI1HDLCzCKAjMTBAIRCudckYiTYo54/ghkOBjzpmEWDjnmEQAMYtkwQwwViEF0RWTccwaIKpncFshI4AC0EorUomTLcxUT6tJxQAo2vdD23ZN0+w2bYwcUlwcHn76U28Nw5BysFb92n/zT6IPAMwgAkCgtLXVZNJt9lrpT376Mzlwt9u2nIiydZWA6lqPxFqRAGQhgJRSP50c/tRP/8yT05Metq99+vrDR++vNnvEwiq37/puc05kJ4vy6pXbk+mknNUPHn54sVoxgbGmazwRdb0vKoMCfdMNfUycEfHevXsxRAQBwOvXr91//KFSJiWwhdFFseYWEWKMOWdrjQgtF0ff/Ma3l4v54fGiC7uyNNudDy4ZowCVANe1Ozq62u32XdcSYT8M164dTyfT87PzsrT7ri+KggS01iLiCjv0uWsDiDCz94EIAcBaCwBxXCvAm7euAMHm/ZYZkWS9WS0XS0A7+H69XnOGpmkm06qsjNorXVRWBABIRAAZgDMzABGPRLoQITAwCCBy5mbYEinOslwukQBJYg6k1AiRYubAAQFJhBEEQQgIFIJoLYCYmBGJjNPCiKQZGAQRgRlQs2hOUZiZnnWpIxFiVgYQENEoq5Wup+VVfY2zaMKYYtsPIYRxcIMI5pxTijmn/8H/8K/1w9APfuiHdt/2Xdv3XbNvmrbxg99ud4MP7b4lpT7xybeEBTlfv3aFFBTOHh0dg5AxxmhFipyzmhQohJ/6SQBJcXj/g6//f/6r/0yAnZsqY9t9P5kubt98dTo9tGZSu5kBo6wJnt9+9x2GnECLZAa2bpzTort+iMKcxRqdM7Ow0co6HaJ3zhFpIuCcQWkkYoDtbjfmHWenZ3VV5IRFrSfzkpvBGHP71q2nT0/7dlhMJiISE7/wwu0P3nufSHH0fohDP2ilEIlI+m7IGea6ZOEYWYCNUdqAUWa327rC5a5nTmSKEAIzJ0YRSDF/4lM/cPLk4uJ8rZUuC3dxsZlO59a4nLIAts3gnL569aqPoFmCCIqgMAAgqbHjklGh0poEAFApbYwZ+yqZeb1en65PLy4u5vMZgJAS55xSitAqZYlQBEYlJyIiKAFARGU0aS6IxlZmIPzI0B8WkZyFUBNUABhz4szCDAgAkBSPcxlEcvAx9sAERDRKRnPOwiAg42AQImWtEhEAqOsZaIWAePnkANE4ERJzijlnFg4hpsjAXGq97xofgrMmxZRSHoZm1LADSM48zqqMMYLI2cnm9rVPFIUjoxfL42GIVVGVdkZIAopECqfns3nbbnJO1lkEnVNGAgSARCD6+Hi23W2DT1ppY4wATKcTZRBAUHC/30xVrbUdy8n1fNZsGs4yTm0dfK+UquqiG/YsbI1hzqOn9z4oMsL4wd0P902jjc6dOOesdQDgnD09O1FaHRzOFBICIgKnnAFyYo1q6FPhzNixN95DIkQmY3SOfO/ufavNbtenJFU16br1brs7OlqCYFVVgCut3dOTk7aLOoSotSEygokIUFhyghEkA8QxQnka7+kopxSR27dvijCAQgIieTYHRglLZmZmBGRhZh4H5I3Lz8zBh8EP3vuQ4vju+Po4U4qzoBCRGgOEIICA1joBDzH2PgxtLwzACrRSWhtjEFEpBQIpJ86ZRcZ+5PFqEUGIkEhpwyIgggRqHIiGoI02WmulCXJd2asHh0+/8aRpu6Isch5HVYhSemxWTimN3xvrx4fLmz/74usphl23iwzAqLJobZTW5dQezKaz6Ww6mZ48fQCMIISEzJJzjgGIKGdYr7fG4dRVza4pSzOdL8MQQ4jGqpQzEgpkFIaUU0rj06iAALFt+s16d3S8cGXF0I8V25y9c7Zvhq4bRDyhvjg/FxFkQcSicH0/eC9Xjq+uN6tyOt1ud4Vxs/n0pds316v9rmkQ9XrV1XUxm9qUfd97o6wxOoQgkrTBpm2UpuADAnadny+mRlufAzM3TY84M9rkDF0XU2StlCYigZRSaJr90OwAoK4mZVkSESkaXdFoOiKXzglRRGRsfUQChJEVI1Co4HIQ8mid4xhMEWDOzIwzZM7MOaY0csgijAjMDCICkCOIUMzRx9gNIeXcD33ThK73PmQEIywgIElyTjEwgKACzpwSx5RYGAXgWVgEgEwE4zw4REIkhQDAOXNmAiSFRunCUFXg0/uP1ucXk/lMIQoBACKMYxYFEQXGYVqIiBZQI1GmwpTRRis8nUzndV3Xk7KqjBUQIFAp5i/84RdizEDJFbqoypQh+SCMDEKalKbghySpH7r5cjmpq6p0q/WFda7turHefHFxAQKZ0zjflwCzcAhJKRSIx1evEMl2vUlZIDMKpAQioCzVdbXf7Qc/GEN9PwDIbF7tds3B8mC13+bEEWLX9LOqPJjNT882fRsAQIRRZWt1jISQEQgFx0mFIaYQ4nQ6Y973TT+fTcY5IPtmn3NyrtBG+94rVAisU/aZSSltnSm5dErPplMRHt0gKA1IwjB6l3HBUkqjG0JEIjU6M85MGhExpTy+orVGpOceFRCV1mN7EBJorZAUogJgEX4+wTZnQiDPade0yiYkiikdHOecM6JGBBHJSbpuSDEzMwsnDmMt1seYcpbMAJJi4gwClASeGwSAkEJCZKRMCQlFMkAqi/roYHL66NFyuTi+enWxWGQUY+z4iyilCC8HBhEpQKAsCmm8BVlSzlkrNdKvAjnn0Qg4JX92cS4AMcVKTxWKUl5EtFIpxWpalIXebBpAnbP0Q2t03fusrO67gUbdURAUyJGLstQTvd+01mhm7oeh6waDcbVCbfDpw5O28UVpndPz2ST4XDinSOWUrLMxh8EnH5MgDj5ao7uut87WkwmwnD5ZHR8fxyFJzkTofdw3jTAzZwTUxk4Pln0/xJhiTH7YXL9+o+u6rvfAXJR2t2u0EBGlFK3RMUZjdPBBT+r55fJDrusaS2JmGH2+XI5fBLwca4aXsQCeBYXLMCfPlHgwtg48Q05j4Lh8H0BEiFBEISgeUyBmAExJEocxyCrSMaXA42w7zMxEpAmVugxwAGgtldVUnlkMi4xjwMenQTKLMOecMuTImUGYJeWUUsqZ+RKWsWSWnHNikePDWb9fXzk6/IE3P2XLwlgTOCLA6KeRiFgkM40ZIgJlVkAsrJVWSgvwZr0CERBQyogSGOeEhWG1WqXEcUjFJJICbZCIlYKcGUGGwU/qCggXy5lIRmIQUETGoLHYtr4sK8DgnC2Kom16RTSmbNYY770YfVAcPH16trpoZ3VVFroop30XfeisoRCwKIoheubsnEISrfT59txqXVVFWVUxxuTD1cPjF1988enJibP9xapRSiGSACyXR6uLC84CAn3XG+uGwStFm83Gey8ggx/sOIMdFCIO/VBPSwO2dNa3XocgCBkvx2ILQgYiACUAY4Sj7z/uz/6Fy+l5ADgMg3OWhRFpnDA7PuXjh5gzIbA8+wYAIhEQICVhzgmZY4btdpfHZQFEDMz8zIJHigMBBFEJj9AVhDMAA9DoCYFwVHteju3Vl3UFASWAhAgynhxEBDBrrZGUcAZhQphU1WxS33n7O4vpTBFoozIzXj5NggAil2QewdgcCsyQURAwASNzVbqz6BURoUEEpRRzEpayKhYHB49XJ9pqUGKMyh4AGYFNoafTKkZ/dGWZOQ9DbvcdpFiVE2116gIiWGs5MwIYQ0oDc1IKOSGA0kZV0wo1KFLri/Xt2zcX9fzRyYeH12b79jRzbtr2+KAIXib15GI9COf5fEqkUYEtrbYUfIgh1EW1WMyvHM9v3TietGG9fv/wcHHrhYPHD5/6ISoiWxrRgnaMKJdRqqqqwW+7fjicFsYoZiFSKUetad/1GlErpS/RUhaiESsDACilLsPX93HF9/3Ts5gIAKK0yjyinoyCzwPfJXYGgJHkJAIGYUYAzpI4taEfI1fInAUkjtB4pLAARXDcROLSJPBypS/R3DPvhUBKjRYpoxXKMzJWRpNDGo8FgoAgoBSSQqu10Y4IJ65YTGsfBqPRGsWcFVHykQhYWJ49QCyiSDELoCAQImYRAAjB19aFgIdHh/fv36vKmSADp5yTsBirX37lpa9886tXrx8bQzmGvutRgS2NKbTRZK1lTtZapWyz3RPpcar4KCQvCtv3AyIJ5BiHmGJKmUHqwn3s9ZdcpQKns/Ozmzeu1EVx/959QEVGxrI75BSi78NgXJEiI0FOuW8HyQkJfAgpRK3U4IfV6uIP/vAPAQHROWdi8MaI0nhx1hSFrmezbuiVtd2+FwZBzDkhojF6CAEwVxOz3XRKUJECYCIKPmmj9aW3R0RkHHluIIDLUU/PLWk0l5zzR18Zf8aQ9+wg+GziyrizCBGqkSnIzJlFYgwhd/0Q8sCIiQFG9fOzn/FEzAwgCvFytjEAPLumj35SEGBMTS+tCS8NAQThEsQDjskuj3yvIlJIGkkBWjKlK4D54vSpQiqrUsAJM2RWpFBABC7ZExx3ZBh/QUZCZM4IWusYkyQuazubTbab3XwxDX5AQGZ+/87dK1eOysqRAm0oJSmKYvBRiFPyAlokaeMQJcRGGzlYHlV1sW0bABUCz2Zmt9uRqLIsBDDnJma21szmZebQddnWRVGYaTkzWjunp/N5125EwBiq3dQ4M6y3vFkTkcBl3q20zjkJiFJKRGaz+b5pGBKnHNkw82q1P3niZtPZbhMBEZCC52bfaVAIkHK21pZlmZL0MTDzjRtXm909RCCF+10/mUz6xs/qWn8ELSl4ltDJ950XfNSwnkP4EUQBXJJSl3QDACDwWLgRzhk4c0wp5BQ59ymycIxRGEfbBUD1HKJdJl/jGPFnsVMIEHPOo+f5714PClya1+glR283PhxaXdINzz9MSEikgAAJwCg9mVTOkO/2u91mtpgLkjE6Zy6cFWFS+vkBRxbj8lQswMIxkybSeug7RkKSg4MDRAhhEJHMOef8z/75b/3xN//k5u0Faogp+eCV0QwZEJaHiyShLkofUkqd1mq+mJCCSV1tdhuO7JTb71pCIqWU0v3QlaUCwaJwV24cTZeTbuhSjCKy7xunXVkXpDjssxKjNLR9R1YhEQuLgHXFbFYPg59WVTWtRVO/awkpJK8UamU8ZxBWRAgqJipRXIGo1BA6P3itlWTJICLgo59Ma2ttWZdF6WIKytBiOW+atmm6ejLNkjMk/RyJP3NAIAIi+Xk4G41p/P9HwFNEBEQz3vfn7yqgMUmOKQZJMUkIHDnFnOkyqAGLwHgkAUC5ZKsABSBzvly5y8Mic35+Cn52dhwn1T9zYJepwzMnemlbOV/SVciISIaUUkg4qmWs0UVZoAbS8PTpo8wZCPf7ZrEsU0pCPBL9zz3288PS2AaX2WjtyiLlDEUxMggpydHR4cXFKoRASp2vzlPulcuFpSH4zELEpEApGrqBuUaVh8F33TCdOULVhX6zPfN9h4TTyeThg6ezxQQUp8AhRGuUV+QKQAq7bndg5jFCbL1CEMzd0AiGrh0MmaFrbFG00fOYmiJk4clkOptPs0RgCD5IhLbxh4eTmKMtahAJKSYfi9KFKN73+yZobRiEkEhhaVzT9Jf4gog0KAWTumybHWmlDbrCrNeRiIYhlGXJJPq5VY0RbZx4PtJLH72hHzEpuaQXQcZp8YQoIn4YkKjrOhHJmX0IiSCzxJxlxEf8bO2B4PJocvkHvm8xo0LjmRN9jrGevyujVT2nXp+Dv+ex+LlLy2MPDLBSl5wIMJAio3VVFVoTQHr44Mn9+/evXr9GhHU9QVTaiI8p56SUdtrIs7M8e+6+b9YpJdLKgBlrCyDoh5SiBB+Ksrg4P73/4MPNfqMcaq0AgSNzjkXhQDRJ7vpOU9G1vStwMitTotSnlFPpKkCpq7ptu+m8jMMQc1RKx8AhpMOjRQxxdbEqppWYqBFz8s2+qcpKE3k/jOhHa8WZASDmzCDr9dpWNFnWZ08vSlVWrux1rzVlUSH4qpgiDM5hzlFrAITO+xSldO7iYtv3w/VrV4RJEqYYr1271jbrEPq2Y12qlJOx1PXNSDMNw7A4PmYKGgDGPP8ZO3C5KM9CG6FcZlvPUE5WCkTG3q/IfMmUJpYw9CnnPngWQaWILzlTGX3ec/MAFLj0CCBwWccGAgQgRIAx7lwCmrEENJ4D4aOvP5v4+X3z+j5n9hwdIiAoBJJniYUmQmStSSQSAwDXVTWdTId+mB4cZpGUgjVOtH6GqIiZc845Z2stICIBwSWJpVBlzoIYUxz6/snTJ0dHR/cfPvzKV7985/7bp7vzalr52IHiMY4qQ4gszCLsTLHdtcZp61zvOyIFmJBwv29dWcScqqJCQFCqco6J0emqdNdv3W7brQhsTlcxhMLqqqYrVw8f3j8zaGLyXecz0sGiVqQ5wcV6NakrqyixV9pqq3ebFgWR8mq1rusqCzdNM+55FsNweLQkxe3QxeTH7VXKogSQorTCebsOm916s7lA0aVx1hqMYCa6qsqujcPgY4opx6ou9OWElo8AcICRqb6UhwsDiBBRTNF7P5pdjJlZfE6ucCFG7xPC2E0KmQUAOGVBeb7uH3E6z73ViLWREEVwHGQ9JmGj0XzUTY7XxMwj5PxojIbnicZHYvpHnRwijtTauH+dCDtbaK2NsSg8m05mb7wuMI7jZmaWzKQBkfiZCxw5UmOMtXZUsHHKiigLD8OwXm8ePX603qw22+1+t99uNwmGTb9/ePFAV3RZXWBAQFJj7SUUtgREawttAyIhmapQ63WTWGAY/JCHYei7lqOdmGlOEinNjxektU99Nr0tsW3ybtceHs1zHqx1i/lkt+najQcga03MApL2+3a78VevXmEOwslZTUSAUlcT72PfRUQqS9BaD0PUpJqmq6cupjYHcYUq6yrFvD4PnNPQ+xu3jgBssyMffGbgnKcLZ40zenH//gMi1JqEuSrrvuvLqdPwfbD83Od/n/YcfRYKjsW7YRhSTCJCpAExRY6xz5wBUZG6VPUTQR5dFD1bTngWRjMiAhJcJmwgzDCmd/j9oDdeAxHyKIX4ft6Kz53TR6uQz30tIj6PeqM1fDSFBBEkNNrUdU2kAGR9saIsQrI6v5hOpwIRYZxVzlob9cwFjhfA+XLfJUNIxqYYY4j7/X61WsWchhgSZzK6D/7tO99ThcuCiZMzBeecUmy7npR1hU29OGtE2A++KIr9vmvbnnSRUs5AHCKilpyODg6Mtc2+T0Maej+ksJhXN68dBR8Rs2R54YXr9aJutqvtdo2IZWV3Fw0ZVRTWIgnEFKNW5AyGyImRWXXtMJ1UeVC7XV+WBSB0XXt4eIigOAuAKIVtOxwcHJCBkAZmQIJCmxiTH0KMKaXMWXKCojCksiJtjCnLYrftRZgz+i4G4oPjAz3i9EvADDQW9ZAuhZo5xeCjcPYpC2AMEYiYNHMen0UQGBmBUWUzHukZ9URjpvYc/j93XyOPynyZwDOPip1LZynPesnHabFaqzHyjg5pTPs/GgfH43+0GPDcvBBRKf3c/Kw2s1llDJKCHHK3bwpnY0g5Z2MMC5Ma9zOksag1xl4ZC+okq+16d3/HKffdMPiwa/Zt2wlgM7Qxhsxx8HEyP/zEm59dbVdk5PHpdzMzMKTAfR+VlrKcVjX17VCUM9IYM/RdP59Pm31gUH3fT2wJGQ8PjlKC04tzH0KIQQQkUumsBWMKyyoL9GL8vkubzXpamn4Y2t1gjT08XJyuVgkgx1yUFgBOTi5eeunaowenkqVaqNm0DJyN0daRUtYPw263r6uqcMYovb1oq9mUrPS+zaz2u2CUVqRiTCkKoSZFSqMIlLUCUU+enmqtc4rWKWOK/XYYK8K7baNHk8gpjchGKcXCHPMIvKLPIbK2OiYJKQGwIpPGcvJoBTzOyx31c0Bj7RCRmRlQALTSMCpbRIgu934ZrQRAj85GP6PTRr+GiAA0Tr4H4JSjIjumaM+D9fPjPHdmozF9H109Q/QpB0VEmgypaV2VpQNkVPrkyVOjVFmWcbcft5dJKaccFWkNFHMccbpk2e62FxcX62bXdB0C+K5nIQQcQkgpJYbIHJOkxErbtt37kLuuJyYUFGZFyihjlBOWi7PtpJxWZa20jrlHtAfLeVVXp6erBMDM1phqVh9fOXr33Q8JgVR2ThlTuEIh5l23v3L7WhyGzCHmlDiSQjMtOaacsgBFn5wpQtemJCKSOR0eL4MPILKcLofQ7LdtWdZNG2PmnJvFfEZoYz+Iyc7aZheC57TbGQdl6UJZQMQYU04SfBqGoayccxYBq8qu102OmGIA4KKkzBlAGFhEdrudZpYQgtEaLqnk0HZtjIEInSsyQgII44woAUHglICeVQNhzPAEmfG/g52FBRG01ohojHnOhD1H3yIyApdnmsIx6Iw87TNpMioAYYljSRGeJWXyjN9/HqrkmWUTqWeqCso5AeSRZShKW1ZOa41a+q7nlG3phmHY73cHB4c5SQjMIuRU4kxKiQgh5ZQuzi8ePLwfQQC1MQa0HWXbqU+II7agEFiECGh8SJxzT89WXTMYjQQqRtZgqrrs+w5FMUuMcRxxaq0ehgFAlNJjhnxwMN3tV0pjQaVxQKg2605pcgX2PnbNru8774fjazeUVrKYdF3ru74oCltX23VLQpxgTO45iwg+fnhelg4UFFVZWGga7+qq3W3nc5eSd8YRYFk4zsNiWQ8cAY1CqZxuFW83rVJKkY4h5yxaE2dWCo1RFxd7TmPvNxmr9rsoQsKMiNY6nXLQRDHlxBEJREAZpW2ZGPqcWSCBgCggGgkuFoBnZsQiYw3pI2TEJaDOOQugUqrvk9b6X2Hn8RmvIeMgMuZnMU4uPQ5nGN3gpYsazSgjIKIek1aFCM+gOl7ytCjASo0kCCCw0iiojNaFdnVZWmeREAHa7XZWTxCAsy+KypgyM2tDnLMiYkICSiGsm+bB44f7Zi9a5zCmhsCcSZHSSimVM+ccAS/xWIzeOROSdkbNJtOuXQ7dLuc4grbtprt2dORDiBJziKhxMqmaHGLmwjok5eZacmp2W2YGyHU9TUnrgoqyRMVZoiIqrVnv/GI+f//td5ybVKWzioKPhbP7tgs53Ti6rva79X6XBQDCxdmmKOt66kytRMt+12y2jdKmnDgiNW7/eu3K8Wq/vrjYLJeLfTNwxsnEnZ7uJNnprMqJOQsiKm1zZqWRFBljEFROohV67/0Afe+1VoUrUsqHh4d68B5FyBAjjVsgX3oCUox6hNsiQJerOOKhy4r0aFyZs0J5rp955kUQcazOXQa+/xafKQIAo4J0jLmjUSqF9IxhTzmN/ue5H0QEYf5v5ZXPwNbo85QmAQ7ACKgvNYBagJ02k6Ioy0qIUNF+s5KYq8ksxtQPjTUWUSOJIlCYCYgYiHDf9Q8ePNi0eyFhEK2tSGRm76NzOuQ8ZspIqJ+V6jMnBdpovV2t+30/qxap88ba2uqLzUYpDQlRcL/d29JVtiAx3jfWFVoZ7/3Q96V1YUig4MbN4+22GcveHfu6cLPlApF3+91kOok+ck7trhs6P6lKJM2sh3aLLAn2RY3U5RwhZzFaVbULMTZNCypvt01mEUmumkSft6vN4bzad7rthpQzKSrLoukHYxEV+D5YY5Sitm3rugo+IUFV66YxfR9izIA6RK8UBs/WmbLCwhVhUA8fPiIRTor6IG2ffITEevybWaEoEHUZXugZCUDPSsFEBulSYPARNP08Ho0k7fOFHz3T+NQ/z+NGk3HOjXY2fmwc5AUAgJco6plbIrzkZp/hfLjcr0Zrba01WiNCiHH8sLXWGOMKV1ZlUZZ4aaZ8dnbmnB1P5L0vywIBiJQmA6JEkAHatn3w4MF2uwshcGY9QgUBUsoYPeaqxhiltIAkH6flpHDOuYK0nla1EjyYHfjOIyMxceCu72OMKafLvBtU1/rdtremsNbE1ANw1/Vt2202zdD77XatlBGRptkCR+Z0dPVK1/nNZp99sFpbZ0mRUnq365UiUoBKisrqQq02az9E76MwEZH3YblcimBZ1MoZMmoyn4mijIJGRZYMUpR1Wbu+66bTiXOqbb3RWheajFJKXbt2rSjK4FNO0jbBD2EymTjrxsCnlM0JqqpYHpqqpsF3KSXdB0ACYAIEAclZEDUgPdPrfb/4AgDMQHA54Q5AGACVMqN04ftq4GfEFQqCossywCiER2bWSo3NIQCYciJFOUYcI+yohLgUlALHcfNLJlLwLAQTXu63OyazgDL2hZFSzBkyGSJNSo37MSvllCqNI6vHDZG2F+uJq6aLQ0CK3eC6SpmSmYkUCo7q/wyCBucHU11S0/VZSCsbi0RaOeuCD977sYMlpTT4IYUEgNDkrpemaZJIiqlv28pUWISu2TU5DH0wCoIPfRy0Vn3jXWVSypJzjIMpnSa9XTdWW0mShtjFND+cIwWjqdl39aTc7rYiYgyk0M8Ojtu+3aRGaSBUrrAi0VV2Mp2DQu9TSixJaeKiKKpJIciTulJVoZptikkLYBYEKCtnratn02bbGW0AJHFQWpjh6PB4t+2H3nf9kJNYpw8OlykG30eldOh6BBIBRJVSRIKcgtIqBdnvWgDUMQoRM+exEgRAz1I2+Ah44hEgMeeRNQcaHcbYEDHWzp+pG74vpbokAeDSNpGZFREhxRDHVSdEYYYxvMlzduuZ58PLjcSelWmeESMj1QlAapThCDCMkmhjDI1tuzGOvFyMSQGCIqONcN5crK5dOSZtAKHrO61tZuQskIeUUtN0SiltDUuqJpOqrpfMjOb05CylNDpZ51zXdV3XjYbVd32IIaZorEUAyRmJPvnJT21WF7vd5uwCm/1WkSq1m01nGlVdVtvtFjKnBClFV9p9s68QJfsUYyLttMmZU+LpbGKTfXBv71yVmWPwKQcinM4OMiRFajItjbb1pOz7XiQfHC78ELshFa70fRczKwUMfUwCwVgw3W47q6cn2+HsyfbgsFIEk7IgpPV6TaCrqg7Jez/M51PrVAi+0GayrB+3ZyEEVOKHeOPGtZy609OtumytEmYuCgOYY8gx4H43jIutc07MOKZ4DJd8+/Oca1zPkYgHeIaU5bIkjDjy4Cw5K6IRM9GzzrHRwEY7Gzc+/VdIS3gm0bxMFS+/OG7wfonAPqKngO/nB/h91zgqsBAJUY1dFIg47noNADklTeNVISBt1xdOGzeZjLXLvu8tqbZtm32732+7rosxCojSKsbYdb0izSCMahgGH/oQY4rp6OAYEPq+H9srhmEYHXqKUWtd1XXOedj3VVX3fau1TsKaaFlPnHWSJAMrAbQqcgo+aqNTFK3svt3FmEJs5tNZYYoY/Pvv3z04WrBkjWrskooxlmU5xHjy4UVl9Xw+m89mu/2m79uDg4Nmt+/bfnGw9CFYWwbflKUNKVrmYfDd0BOC1qQQyZhJWcXgFUqKvm3CpJ6P6NYY40PohyisjmdXdvs2pZiTHB/f+OCD+x988OHR4VRESFGMUQS0UsEnQClKNXTJD5kIcpLv52ssLCxC/yobNDqKMZaNbmkUJAB8HwARIgNIToSXLDkpIqScIcaklCJCZlAKlUJ51if5/AjPLWa0NyQYZ7PRM/D+/GL4Uts5akoFQYABR/0NjoJqIiTrrNNm1HsWWpdlhVZlyWePn05scfrwUcppt948fPhUGENMIy3bdi2IhOjHySKd90pbpZRzRQyRGTILacPAl9JaIhgnaY67zzIrrZXWOWddlCj5mI4RwjD0TbMPXS8MMeWm3VljVFl0fd/GYbPducIZ0jnk2Wzu+3GHATCFcoUNsb9289Doogm7lHNRVMIy+IE0udoAphh9N7Rl5ULwQx/aJk7mmBJr0MKolEEGRbpwOPSDJGm6bjqbLBdzIthudwJsrSECyTn4RBpQVIxJJMeAD7aPERUpIIQU/Gw67dq2KCZA1ufnNoIpJaVBmIZeUuCjw+MXbt3Sz5dWEQnROFuBnwmznse1ERIRkYCMwW1cxecoW2S83c8ECJdSVmRmkfSMrJAQwvMmBXkmtsFn1PglQcXy/SN/hFu/dFEsCAiAIjlnEQal1JgWIpJWqAgVIAkgyuWIPYWAdP70ybvvvDMtKkDohmF9sTGuEiBhBsLCWGJgFoXKWpdSAkQGUQicM4AoY8wYssekQZEhIyLWWR/C91t4iFLOmTnF0O33bdNZMpUtIQoS9sMGALRSSCqGFIdYTStg6Zp2jPLWOoMqeV8f1F7y8cGk2fsH9x4cXKsKNwn9oI0BH46vHrfNXllpuQVEYdztdv0QDq9cKeq6nrb7i04kj2pmpTCGMK0nfT/0vtdGC4oPISU21ilNVV0pMClmpSjlFGNgzlpbXdphCMdXD1PsjcWm2U8m1eJgfnp+FlOuJ1PvN9ZaH7xzRlsEQFfosiZbov5o5i/MkEQARGHOeaz4fl8oMEIM5me6qGfOiQiAAUdWhLTWKaUxTDxjQy9d3UiX58zMaQyLo3k9r/mMxiGSRwnhCGKem5eIKEVwCedRafV8yAh9hOmALIw5J1GalHmWSaT8zte/tVlvvOmQgEWzqDQ2ehBooxOBBx5l7WPQGaGdALA8M2siYPbeaz1220lKiRC992NBamRrc87MIiDOFteu3jSkzk5P9qntfY9aa62bpqGUUkyFKWpbZ8lKK2tN1w4AeDyZB+Gh64pJ7Wy5SU1ZmWs3lilHZr44OxWixntS5W63Voq06BB8jNHVBk0eUiwqtzpZCbBzRjk9mdQAVd8OWuuD5VJZg1pvzs8Xi3nre51QizJOKWtA2BgVMsXIVW0A7Wq3L2K/mM1OnlwAQFnptt0xxxSA0B4cHOScRJjU/5+tP32y7EryAzFfznLvfUu8iMgdQAGo7mIX2WST05oZG5PZyGxkJpnNHyzpm0wz+sAZNtXdbHazweqqAlAAco3tLXc5i7vrw3kRBVJKg6VlJoDIF++de9z957+F0dy8nLa70K3zTx+/de0Da58fIrLDqgpgQKagBNSIWQANQHqiSZGINZSraaI8NbwN1YT5fCycC7Xmto78edWzx7h5/BnC+XiNKSKIVkKHP+MsP4pa1UyZyUzAkJAUm0M1IZJ3HLxjo4CMiI7BoREZIHz48OHb739i5gIMqqalMTHAESKGGNSMPBOzibJzxOTUqpnUaqimpm1LYiaqUOsyz7XdtWa5lKdng4gYqFo1A2JkCj52oe/7ZalahyGqyjjOgb2jQh2mWrWk0DstVWtFIA8w11JBVeo8LfMyb9bDaX/sN4N37rAfr68udRZwlJIxaLK0GiKYVpM5TZh1nhZAWG0GY4g+lFLZYS5JTeOqu3x+9eNPf1iWBIA+smpNUgDZgNlhreo48tARu5Kqiu6uL28/7edaX332vJTFez+Pc8uS3e12b9++d45rqVK12QKAS9XAPX7SZ6xImZAQHvFua6qYR4gc8dwU/+yuOuscft7vP9FlHrnO2LCrR9o4EAVEeMKr2il8vCDBGlPnsVaWUlrL/0TGQkQiJ1Lo3FWxqtW8SGWLMTpXQJnQMeUsZR5V7e/+7h8EwDtH7ICxLAswsGMjVFNEzMvStk+A6Lpg82gAxIyAjtkxzyVLraWUqRRCLKUYQAiBmL337QJr38tquy739zmXdDod7x+cRwM4nk6qkpbFzNabjSIDQb/q57lgNSqC1Zg8AUx54eAvtgN7rrW+fPn8tD+CuOW0MNKb1y+n0yT3Rx8CVstVcrLddt1fdncPt/OUuhg22zUJ7na7u8Pdx5ubzbBab7vg+OE4bnbru9vbNsOexsktfrMJhGCm85xj50IIASiVmlIts+ZZ00kP96cYw+Fwco4BsAsRHUsx56jv4+k0tWPAzoFZS2dxIYSnS0tN0Tkz47YWNGuuMkTnWe+pjcZHmsv5ZmK2KiJyBsrVmB07V3JVlaZDfnrff971/9fdFTxCE+e+7fzjqS6bKSGL1Ob20DALAHt4uN/vD2aw3W5XXVx30TnMmU3FRA+n0/v370MfiT0RCQD56Nkxs4po1XZqHzNzLNXiYmjCaTAM3ocQYBrT4UBEXdeVWhj9WbMKEGPMOf+xXnsfnX/78VPncFgNzlPswul4HMfj7eFezRiJvOv67uVnLz59uF2gduvBr4bjj58Y7TBP3jPUkMbp8tmKmQBkGqtzaAjE1HVdPlWt1QPPp3l7sVKpftP3w5Cz1lqB6OLZZpkO601cxrK/3e8fxhAQCe9v7jnwi1cvbj/cf3b1ep4nxwYKSAQAOeeh72vV/cPB+VBK9p5vPny0oopmZF999fWHt293l1f7w/7ubu9DMIBm7cGOiWxZFnMWYnGxi0QIoAgdEiFSzkVFBExMTeBJuoPYVKOtAlII8ZEaj4h2pncSNasdIi9SiYzINdmFGbS1z+OWEP7Lw/THY9RGO3gUMoQQnhQyAFBFABqpAY7jOE6TSJ2nWUSDc2aHWkItIZydIx1TfPv2ppTSxV6qSCkuBDVDAxBTs6ZXeIRIyEzBSFQIgRhj8CpVFGsVUqC2hjLgR/rYU/soIq2zzDkT0uXFpXcUO38aT7DUi+3mu++/NYDr58+K1KUU793xeFjSEvoIqnWpteRF4GJ3sSyjHcdSy3yw07EMQ79/OIrI+rJDcJ44g/gQtpt134d+E99/fP9wOpIqI+33pxh7KSXPC3n//PnlvR7GUwlhtch0PKT1RUjj0REcj/vLqwspdTyOu92aEERABQ/7Y83VOWa23dUgRWJ0fRc/+/yzmw8fcinEGPwQuqmWcjrM603XFv8AhkBS9HA/uhiZHiGGWqrIeZ5nIhUA1AZiNf8q5iarOcscGnaAiKoCrfVufM5HEj1RI3g1wILlUeBgpk+cevwZ4+Vncyj8vPFquEObMKRK4zWXUu7uHx72BxUgQu8oDn7dd3103qFD9p6JeJ7Szc2dc0FEPbECqKqIPkJr2vd9KaWdXTNjdo55qlVAWVVKDd63dXtr5QBgvVrN85wf/5d2252vPdW0LCH69fMrLWLVmOuY71T1+tlzUw3Oq8g8jsggNXtjMyVRSQWNAGGeFwQY+ujCahyP3SasLzaH42nVD1aVIo3HUzcM+0NO0/Hy2gHaeljPxzmVfHF9HZ9fILGUksYsCqGPoQ+nUwqhOx5OcQjd0JlBKYUQxbBobd6tlZGdN0UV6LroHVDwvuuWMWPgi+1Frcu7dzerVUDEV69e7Y8PRRKSXVyuDGqVusw6nsqGnffkclkcezMUKaVkM8/0RFkBcg10QDMwBTNzjg2qnjnxXqQAnh1FAZGZa60NbX0iAz6djydW1lNL187fE6wFcIa4fmbt8jPN4SMTq2ERN58+7fd7ACAyFfX9OjiOjgi05kLOm3HfDx8/fUxLckPfandKCQBD1yEagIpYSulpPm2FVUQR6XGLpaUUH/xTvWbiGOKyLD9fjzbyT/u1FhFmU80lpzmRWfDdahh+8YsvtpvNzceHw2EM/uI4PozjPVaJu86IilkXB9TqmIlwmo7P1s8Q1+Dkw83Nkkvf9dNxGWLgjr0juV9mmbp5G1DYOQwdiu4urkTcd99930VWlWdXz3/86W68O5Lhzc1tQXVOs/paMMRumeZpWYLXfvBELZZRmTrvOqMSIpaSi2RwkOdsBt/+/g9NaiEih+PBOSKWq+tV0SUMZqlOSVzPsffOFfdwfyCiJssxA4TCzpFjVSUmQjCAEJjZl1JLVhEFVAMCpFJK20xrlaZlL6UgoikYtDMEiGcgvvXvPy8fTxysRmZv/+rp5nj6w7Zjfpq52sDw6dPNw/2h3XBsgM5HH9fDIHUiQO9cCOHHtz89e/n6/aeProtEDomY9ObTT2+++GWMwUw758fT/vvv//PXv/pzdr5R+70PZtV5R8hmJiDIrUGXtEAppUABwlornp8QVcPtZrN/eLAGl3DNJdWc9g+3IcahHw57+e7b79cXF2i4WW+Zw5JKSQn7Ms6n6P2shVdDxJL2DzGs2PE8n8Zp2j17PtcRJhElYj9suujc6vL6dBiHrROR27vbLg1d73Opz948/3T/8OGHO8c0jVMfVx/e3tx/OKz79eVuNc4TAylICGF8WAQSEDI7lQVDn0uWaqCYLTfjE2YyxdPxROxi6HI5dV1z2XFLWroI6/VqyWMVHae89Ry7cHHJm603yKWqa48mYtv/mSEUqfyYQYsIiLQs4j065zOkJ6KeqjVGm6qaGCESUyOWMDkmQocAqPqYqPuzhr09+k9Emqfn/hHK+qPMq7Uv1mwbtBFH8f37Dz/88CMShxARAar64K8uNkMXRQRUuq67vb39ww8/fPvj2xg3IXTIbKhLmlOamT1icGwodTwdCW2InQBKPVPEnONSzsBY69ZVteRsj45fABqCz7k4ZjVItZRcAICJxnEkRs98vbv0RCnneRqTlF//63/19u37jx8+dHENCCnP24s+ZzTUUoqYxC6WMg1DJ2ZaCiClJB/ff1jyyKHzIcahWyYBc44juxx7JnPTOM9z2m4vskubzcWnTz/VWsBQi2ZLKubZ+cC+8y8vnn26v5kXHU8FAUuR9c4B5LQUq53HisiAaKLeh5vbY8zu+YutgeVUQ6D7+wep6AKGSP3QA8A0T1J1XKp31HEAUnRz0aQCtap7ugxaOZCmb3qkqTiHzMHMwEiqeeef+gnv6cmSz0wNqDGriAjwbFPWlqlnhLLWn09/T0fqCTh9Onb/fy42KKrgXVTVm5ubjx8+iCo7JyqmhmqD6xj0dDw8HD5thj7G+M033/zd3//Hz776k1989dK52LyHj8fjer0RKcwEhnVJV1dXn3/+0oduLtUYVAQRiJiYpJ5pZN77xjl8pMrwPI/r9coTS1UMDplUJee8zEvNhRldF7sQh+cvl2WZpmmzGd6+/cN4OsWmTxfZXe0A7NOnD877/eFw+fJFkoLIcQiGWnPx3r948fKHdz9Q8Ko2rNe5BpVq6scx1Wo55eCh6yK57rCfiN3h/jgfpxBYa3VEVpv1nYnlaiUdRwMtRbJMQ3Sx8zFaqVPf9athEzjcfXo4HI6r1ZqIrq4vljSK1BfPX9zc3C7LnHNtBXS16qa0jNOkVU/HzNF2zy+ARSoYGFBwxCqLe7ow2ufNaIjURHjN0aZxXcyUGZreu/GMn4AA1bPW3lTBkJnNkAhF9GwBpCqirfd/wrfa/QXQ0OxHcpXzYMrMTOCcJ0IENjMF7qLLud7d3d/f3yGR9z7X2nY7nfcINM/z0MfdbnN3e2eIz148/+Wvfr27fIHVcpm476Sku5v3X339ayAmUgfOiI778ccfP37+2a9cF8EqGGotymhqraw3jKrd4I/Qnc7juBwevvria3TEwaeq9WyLpEPf55QCcxdjrTXGGEK4u9fN6urrrxi1AFCtRQHGcX88PVxeXhTJBLCcxrJk5zvnfSW7fPZsfbHa5gsFvL87hWr7/XE1DMNqMy/HGNxyShy7GDEt5fb2vltFBA0MU7KuWx2PE0hGwBAoBj4eDkQmoAbad7Fbd+gUqAaGi4vtENaHm4OWGnxEIDDJee4Hz2A//vhjKdoPcXPhADAED2Y+OkrGPXcViwqgFFFQIaRlNqjKjpz3vpHvnPPNa4XYG4KZee9FVEScc48ywz/ObrXWlFKtlZ1jhCc0wcxElIhKKQ0Kyrkw81MXhef4bn08YQAgpVZA9CGQaRdD7z0AiFRCMMBcqmi9vbl7+/bDeclDrICIMPT9Z69eg2ldZtXUbLoOp8P/83/9f73+7KtrH5BwOs4BJKfTvEzBcRyGXOYiVREur5/7LhhASllNEImCTynN89Lu5vZSuxgJyaz1Bnh1eZWn4/F4f3m5g7kiuppLu4xFBInmafrNP/x9Nwyr3VarlVy6vu/77ni81YouhJLr5dX1xW779v3bvuvevnt/tds9f766n5dpzhebdZEiTochTtOiNRMMXRfWm1jqdDqdJEua8i8++/L9/H48HS+2l6fTIbsUmDYvn4kCMpUlq+rLFy+Pp5PVshm6LBlZtpu1ap1Sba53DvmzV29kkvEw7i63ORci8I4ur3chuDkt7KphFRBQnObUd/2qj7GLacnOkQrXItwwVsDDoaBqjODaqSJqfhjnxbPYmeXSKppzrmkG24/WULfC55hLqcgMpk/vbDtkj1iD/lyEo+dtMT414wBgcKZ9igiCgqlTc8wlZ7DivHeOT+PpdDwyOSNGUueDAADIat0ZVJW62Q7v337rg//tb3+barm4urx69oyjZw4rW+d0rDWt1xvTClq990nynJbh6vnW+TzPquBcQMQQYqmlPQPtqTuXbMIYIzOF4GtOKPlwuC91WQ2rfnWptS5zy7StYOYIw7ojxsP+jtBP0+K9Y+84eGSGqhF9LvPD/V3J1TGvh1VZUh85gC5Sa5q3u+tP796G6O9vblCx5tQFl9Ox5NymoukwPdyeUF3w3dCtTvsjGnQxTMtExH/yyy9//OkndjyVUdHQuSUlI+37OAzd8Xb/anN9s78JFx2D++G7724+3YUQnj27Op1OSORGOy2nSGG96di5rGV/GCVZcN1mvZnynHMupSDAMAxdtzodj8FT29n2A7Mz196+9sG3YwRQANExS62eCREZG7LFKo8YphmoMaDzzvN5I/t48JTItc9DRJ7cItsF0MzKG7voj7TjRxkPETG5p9WKDz5VnbXub+9uPt2KKBp6RkVqFbbveyYap2XVdZ54tVq9//D+mz/8br3efP7i822/6ciLWhfDh59uvv3hdy9evOlWGwCTIii6W226Pt7fTwWggrIhg5VS2J3n0DY9hBAQ2lbeex8QSQk364vr6ytEkJpLTVqqA/AAfYzDMLCHqZxQ9ebjp7ubT59/9gsknKYTEzcJjUqpKW/X227dffPNP/Z9P6dpP03dsHu52YFjIgTFZZlLqUwxpzSBrtDXnKZj7bs+DvHtux+J6OJydzwcTc05P06zOuLo7h4+nU6H7W4tYqf9NGwGUc1TfvbqGQrfvX/YDOvtapOn6eNySwyiYKY1LbUsRUo22T+M9a52itvtNqzCsOpHmdGRoj7cH2OMF6tNyYXZHfbHaZk9WQxxO4QwgNHkYoz2aIjdQMhHNnC7YrCh0vD/o2R3zOhcO4tPyPUj+/QMXznnRP64VWwoVNd1f2zzH7+gkZVSuzhEH5rdWqpZwYro8XR6++5jSsl5LyLeOR9CThkonE4TIjgXAAiBh2Hj3K2Y9cPm5cvP+zgEH8wQDIYYd5vtl59/KflsVJFT6ULXPADVTM0YEQm6viulPCmL2svz3HoGnecZEatmDqFfb2op85Kc8+sVl1IcMyKuVsNvfvvN3/z9v6+13j88fPXZ1103bLcXXd9F45wUYEpJc17G6XSocyWwnMm5fvNstb0cp7mm0kUfuwBMz19cMfmf/nC3WfW1VFPwzplaP/RSbZnnu7tbYrd7tp7zknNxTNcvXv/ww/sl16HI/pBOxxK6st36NNePH2/KVHwISx67VVySpiX7AHnWzXqbazmNU62Fg3fktWgVeP/uYdhEYozOl1o+fjqWbNHjPMqyJHYLeA4hMGhKhRjUFEFdO0lPQ76ZtaGQiFRaHotv/5aIpOrTmXjq33PO+ChQhvPijx+nAWy4vP2XZn/thJ3lVABmatayo8A5AkM1qSYpl3lZbm7ujNxq2zfDuForOz4cphiHv/7b/321Di9fvN4MqzfXz07j7V/9+79G4KvL54xd83ZnZCJ8dnldJadpnseRiLyPtYqs5HQ6pZxaAykizRKn1togup+/YO+9WT0/gUjZJFVRtW61QbMueiR2ju/vH4goxrDdbk305dWzq8sXXdft9w+I1vVOBd69+3G97j7dfEC0ftX/z/+X/+s3//mb29MDdXE8TDcfPtSiv/qzr0/HO+dxverv70YiHMdxWAUR8z5O07S/H/vYm1nKxQXBwNyBY0Bw7378sByW4DpVNNZ+7ZldzeA93R9GrHF92Q2bIJIb9UrN2PmU8sPxYIBEwQRQcBVWtVazVLNKFbdm56zWCuhykTyfnOdSBMyK6uV2UFmGFYMvVcA1ZPnprDAzKDIH51DwnHeDiMzYGvn20T42TAZAZueh74kCo9o4EdoWhfhozvZ0DTzxFIionSdAdo6Dj81BuVRl58p0+nR7c5qmrt+UWr1z7GKpNmfZXj3/5u9/L1n/H/+3//vh/tDFbr1eXV5tih4///qXF8OOAAkJzASkit48HPr+IsZOtBAyU3AR0OPh4aFF7LHjMzvrZ+hae0OIqKqkeSHnnHOlFCYHZkWEEK0IoOW6iEnwrFhubvab1cX/4V//t4R48+nDMAzTOP3i8zfTdLq9v7/5ePPuD9/FldcsInWeDv/ur5e3b99ePb/W6qZpMpCu8zE6N1FO5e1P9xcXa+dxd7VVMZFlnhMYO+fmJXvvwailGDnvLq8GSXZzsw/OO4rznGN0gghg0zyXXHcXq+Ugwzoq28N+IedAAAFrtRC9A1yt16XaeBoZXfC+GTznImoqZMfjYgY5ZbTGj3LO+cOYVuu1c9QNDV9gMHVP3JVH5EkaeFNFuSWNn4ugMlGx+nRRAUApAmcuXnOJAe9dCx155CdJO3lPx6jdju3LOueIuGFYTWbTHBad84hhHKf7u2k6ZTASqQ3BX+bl5uamCAQ/f/j0TnL+1Ve/3F/sx9O4Pxzmcvj86+vPX3/m0JWcvCdGEqlmstpuCD0RMvh2nhWt6cMAUKSZaaFnXJal1voE0bUhtOs6xwxIosrM3runJAgzw3bjMf/0/u04TSXpeuiiX326+TTOs2g10Q8f307jxD4+f/GK67Ifb2+Op2VZ9nl+d/Ph+sX17f39zc0xz8tnb54Llt/8/hv2brVebfqNSvXOD0OvgtM41ypMrKqA0PUeICx5QsTVdtut/MKnfutIw3Qsc55Xrl9t+i44hHjcj9uL7bv5drUd5nzYH9P1ti9Zu7jCoLUWIkzpKAarYXWYTkuaROrQDykfQoibzXoaS82qgsQe1BCYCWPw3pOIDP16SXMkg6oupUSPlgqN+fQ42Yn3yuwfxzdo8axPk127sVoQSBNsPMpK6Wk1a9ZyIXzDhNr6ufVe7bfMbFaZiR0REgCK1FpLzvnjx3f7h/sYO2InpqYqIqXUV69ej5P+1V/9Vd/Hb//w2z7Qs6vr59fPTPV2vnv56tkXb37hkGutuRYyqikveX44nq52L0E1Rt9cJMkEAGKMKZWG7DOzqJyBK0AzfWoSCJGZy8+QW1WptQK2THoDIGM0wvcfP+6Gq3meb999vLm5/fjx3etXz188f75erbfbDZBHc88j/ru/fltRFgfR9ZDS7797O54WzbBdD2Q0HmfXYalK4JcpPXtziZDmaXI8pFRj7No2s+u47yMAGFYFXU6TZJxOo2NUNLUkFbTAokfvhovNJi2p693nX7xYXaxOn04v3myckKltNhd5zoeHA6HLkmLfbTZrRTuO9zknqeYcX19fOkfeu1Jq7ChEU+xUJeXZiJzHZVmWOYdI63j14f7GtZHwaZ3SLi0zaxhBU3WKiHPc7EWbnQicfT7+aEbFzI1j3DSsP1sbt7GgtV/iPTU/kUeagxG5xghkx4BWFU7T+OHt+8Ph6L3zIahB8FHB9vcPnj1o/M/f/M3Q8Y/f/fbcKdYKjAXn9eC//vzr9eoiUACQLDMBFZPb/S1zIEeIJKAIZKqOkZ1Xm5uPHAKCaYuBQDxzs9oGKefSDYPvoqWi5/UAOe/OtA2BOSU1w+BWq90vv/5TVqilXD3f7i63l5ebzWa7Xg05LWKKWpZxuvvxJxUIIZbjpKrDsFr5evliN49l6CIobft11rLUUpJ0XUhTIbRpTqtuVYv1PQFA7HzXhZxTKguiz6V68vNxMVMlAs0hBqA6RJdzReHD8aBgyzyfxpHW/sOHh6urfjV4Qne/vwm8dj6epqOLsdZ6mg/DKrK/fPfunYi6wMRwPI4+UGec58pGrz97ddjfffy4cPRVa0rFu47Qn47JjN3Tnd8Wf09lrh2dJoY5P7igZtpwhMYzYfaIZ8efBrirytMXhEeqgqo6x6qNe9NgetYnPjygGaSUc85EdL/f//jT23laEJ1Vh86YCZFvP30aT6eXz968/en94eHeUc3zaT0MqiIsIqIol1eXb15/6TgEz2b4cH97HPcp5aurKx+G9aY3e7QvNKsiKS1mj0wyAFHbbDbr9fpwOD7tyBHxjMlJFT3PLiklRGHP636VS15yNgCtuUgFs+vrZ6Y6TvtXL968fP5aTWsV08NqFVSVcSnPXz5H88fDbrgqpjd3t3/2xVfTkvh5mKdklrth4JqnY33x+Ytpnt6/f++8e/7yWV5QRG5vby8vL2MXp2nyjrsuLrPUJJmrGjIFZCKvjByiXw9B1d/f7Z+/uma2kjMiPtzeB48MOC9L8Byig6qrdTeNmmopWnx0XNI4nhyHYRhyLfd3+4vdZpmXWhCM1+utWb682nrffbi50QxDv2LyPgKAEpJj5ta8Pw5o9tRbyDnll82a1EKYz49ya8VaWfh5q0s/M0l7ghLgvAdsulRtpmoi5+0kEdQqOSdEMIW7u/0yF2TfPlAAq1U+3Xz43e9//+rVq1LrP37zH55dXf6nv//bdd+paalVGcX0zctXrz5/492GyBsoAALax08fa10M6ueff92UQu1bIMRhGE6no2mrd9CskGOMT8Ng2xa07+Vp5rBHzy0iZGY1AyYOZ5FIlWoAzeS9FlvS4p03s1p1u7kOwQPaxYV9+HRz8eylkc85s3evXr5e5vnm5kYRAjkR/+nunevi5eX1PC/zPA2xv3y2BVeWVMys67plWbquAwA1c85JySiIwCo6T2m16cwJmoFB7PqUyldffw5kqv7206eh66eUh855pjRP3ndImsuyGvpYQ10Ukfo4ZDlO06TqzayU5dnLy6Ff3d7cT2Oz/5s/fvy03XQhxBfPdvvDURSnZckV1oOvtbr2QgFgnueU0tNReGykWpNhIoZAqvhUB733iNasXdpBbFugp/P0c0iC2ZmJGvjApZxF8c00RoTbuhoRx3Fc5tR1fR9dzuXD+0/vP90sKccYSy5a6Z/+6Zu7+48P95+QecxaZRar03RyjpSvXrz8LIZIzEr1NN5N07Hm5fbjh1/+4svNetNkuwCAaMxwbpKaL5w5JEZFx16KgLYoC2ujpYjUlJHQzn6+zdaGU87BhXU/OKRa67ws3A8iknJurpPu8UYHwJxT7MKSUsp59+x6CO5it3v3w0+H4957Dwbeh9VqA6DTeLq7pfn+2CFVhWka110PXPaH01IhxrDe9CLGzm3WF9M8OY8+tpaGBURVT8dp64OhMPkGOANaWjJYSWk5PCwxMKERYE4Ca0S0Yd27wGlfHjEjWcZK1BHy7c1Dv3bEcnPzSRVqUWQ0UN/5uFq9eLkbT4ePn3IRi7Fj9A/3Uy35XKqe8Hd4lDK31qo9siKS08JMqvK0gW5NrnMNCWu5F9Quoac60tq1thMkakb+4PjnB+4soFiv158+fbq9vf/DH3789rvvShpvbm6HfjPnErreO4eI79+/Ww9hPXh2LsaLLkQ1ub27Xac4rFa//ud/fnX9rO+iGaeU7u7fffub39Q5BUJUcUDyyMkh4r6P4zS1cKVWjr3zglBy8c63e+uJ29PA91xLs8l8urAJUVVzzrXWnPLPS39gv99/vLi4+CPszEhEOed5mru+V6mhW738/It4v2bGaZwohGG7+va3v2PGl1999v7HDyqlFA3euw7nvCBGxMKOUyrLXJZlWa9WV5eXSx4BjJjTUkTEs2su5j4QkZ1Ok6GepsPlbnV4eCCCYe0RyQcSo2mEq2uPYLWIdcbMqvbs+fO7+zupEpzPqcYuPnu+VrX9/sQUu95rsRD8r77+09M0/va7H0+niRw9u97WUk+H2Tuqhk5ExnEkohCC/Yx210reU4sdQjADojMb4o9BgWcintf/StMM4IMX4XZGzcw5L1LN2rTV4KGzCHFZlr/927/9q3/373/88T0QrFbDZ29evnn92ddf/2lV2B+PHz9+9N796p/9EsrycHtznMZhGC622zeffdH3K4/wu29/z8ETUCmLaZPVROedSvn8+tW666ILyah1Vw0N2V1cIEBaFkQ0RQRwzq1WqyaLsEcFR/sG26ahYENDnDaFHKKZHk/TsizMjExSiqo6wHlJ//RP//Tll1/Gruv7vnUYh/2h73skqmA5ZxXptxfo3Luf3opCBTuVaffyWqTeHu+vXr1wXG9O+5xyrngaF4f9NC4O6HScAUgEmulhLaCmKtUU0yJM0g0dGJgJM+ckoeerF9ua5u3FRuTQDXHOGoZQC/crP06jd+5qt2NyMYb2RG1Wq3meVGCpSU1jXN3eHUwRCGPnMHAI4Q/f/3R3d2uqXbdmX0uZVTDnstn2JTfxJFG7h9oir90xrag1cMvMnKenNxrBqamBxhhbSyZSiQkNay3MzQ9CS83OeTNt8YANPfLeq9b2N7bv4be//e1f/dVfffftD8fj6b/5b/6bv/iLf9ENnYrkXBDBwO12F199+YVIUUur/uLZ5qLrfbspDTB4b0SAtMxz70Lnu5uHh4fTQxFZrdYvnz37l7/+lz729WxWg1IKIhDizadPdmZwCBKIimodVqHj0PJqfz4si1qtioQm4IKXWlSkioxlulhvu647Ho+liuQsIgiYS6bg7o+HzzYX6NhMpQgRllJj33XM4zg26kQW7dYrMqgo2UbD/N333//u2x+//vrVeuOr5ApVSu243x8WVBcijzqRwbrvaq7QYUrJWpk3y6lER2rK5tM8mWh0G6saGD8d5hdXqxcvL2/v959u5i9/9blJZs/sQ9Vaa2GHBKI5HR8epnmJXZhOS1qyoj7cno77IzGmJYfYDUN/ODycTiOz77uh63halixgoLur4D2E6N2bN2/w8Upn5mVZRGS1Wj3uW6yVwkeisAGAWml9BjLVnInZDGsxJm6EaEADVCbfbNwAwHnuYjTTJntv14D3/ptvvvnw4cPr169V6IsvfnF1dRkiz9PUXpKIdB0OQ3Qc1DzzqmPWWr137WB9/9MfTuPSdT2Y7tYbJqq1Xqy7KbWvT11ccbwCcpITslMtpZRh6BuQ1tZKZopI1khhiIf9QfU8jpRS4GxDguwYidhxa95NhZkNTUT6vp/meZpGeUyLRcT/7r//75iJ2aNaXpI5A4B5mu6P+93l5TAMrTi8f//eef/61etn+cX7T9/94YfbzUX8b//7Xx+Od8dpPM7TNC/PLy9NIE/LajVoi0d0vjW1G9iIVkKqomkW0MYf8I6Dma/FPNXmPDgeEu62RQuB7XbdeDxYNs+EAp2PpnAaT0C4e7YTlW7TAfCHt3vnfC1LGtNmtd6fxpKVTDJmbqQ505Sy8wAGXdchifMKqmbg/vEf/7GU8ubNm4eH+5TS1dX1drtl5maG9oQ7IAIS2RkyAHaU88IETXkh1ayoaA0htqWvIiBAqUJETIyGUnMb7IkcO1bRt2/fnk6nZ8+eIeIXn3/tnU95OY1HkRJCCCF0XeeIPXsAdT4SgSMDdgjkvWeiV29e/W//7q8I+NXzl52PClZK7gKw1Q8f3qPVGPukZqXw2RMJ2keiqqvVysxOp1Pf92CU83nlUGr17ryYf2K3OsdVpOQCCMuymIiZitYuds45U4utCavSGnzv3GYbAaBkAQVHXFWYaLPdduuVC/4J1tntdiL1b/7u3222F/OyP01771GhkqO0VGDs+phzUgWHzaC8+hCCi0ue27cgVTgEMNMCnjjGLi0l5eI8mGm3c+xonpY8SxpLXLNzzteFIeQiDvnV85cfPn5IkHKqr9+8utitPnx87zzUYl3X55QDh5JqrYJIXQxkhEA5zdDSJkFyLkRUSvaBTQnBiMx9+eWXtVbnnPN4OBxyzvd3Dw0LuLu764fOOdzvD4gWonfOpZS6GLfb7fbiwqk5ZBVZdYM4AyhAQMzB9aUUAH8OhlRrkCMSOs/g6ebu9scf3t3e3q7X68YoX+Y0jqdpGWMIIYRWKz/77LMhxP39A6E26xjQ+rMNI3/8w7v7u9s/+eWv15tt54N3bhqn03SbU/rw7r138PUv/kWeMiKioxZQzkxXV5eH436eZ+99a5gIqbl2xxgvLi6WOT8Jis7rHYOSMilWUIPq2EtRqVBJuefWlq26XlQJm50OowAiOFRgxOBY2zQAzgVFXKYp57wsCyLN8/y3f/PXL1+//OzrFyLoXZzzoYBWMEWzXCvKervTI6FJqeKdY8+2GDHHvn9GL06nQ8td8X0Yx9ENHIMj4pxn58G7MC+lDy4OkchSSl2IMTj0PZNPdbl5uP/qizdE3fpq9enmZppLfShSrOtwnsv2ei1V+mEY03E65WHYlVpUjYBKraYiAQHxerud56XMCFh9wPNKBwAJabNZr1e7lErJlYi6riNyVZb1eoOItRQ1G3rLOS+zhKAypzQvtZSum5a03N/fMpOPAZSCD+z4cHgI0V9dXq/Xm+PxIKqXl5e3h/3vv//+8HASkd/+9rcXFxfX19ddXBFR3/UheGbquu7V61dXV7vD7T0zpOWkJkjgyXkXVPXDh5+++eY//2///n//F3/+F5frbXS+rQq6Lh5O6tiD8eXVNfs+OI9IoiJLFhUFFdXVavUEqZiBmtVavfeHwyGn8uR92WYXVUO0Yegk15pTI03QOYTWmojocceliOi9c67JtVVVCfk8YwI0v0l8HI8Qse87M/31r3+9Pxy//92PMUQwqkkQ8epiNy7LcdoHZkK3Xq8QbdrfpHmCri0qwDmHEPYHOJwSOSq5iGhADwDTND9/tttuLjbb9bv3n7qOhyF+/PjeO6+q0zj23YYdPDwc+u1GgWJ0S5ru707Hu3mZU9eF7cXmWceuoxD7Lq5OPx5CdAIVCaRqTmJKIYQudjG6Lm4Yu3fv7lZD8N67eZ6bQrxKBrC03CISoSslO+cbaAmkRM6H2PaAqxUSAYKtLtZ8uWUiVUtL/uKLz3MuPoRlnhzTNC1gkut0PN7nPH377e8vL683m9XQd7/6kz+9ubm/v78fVivHTlWXlNtCipmIsOt6qfU3//kfb95/LCl//923ZnJ5udtu1l99+SUi/q//6//y8eP7f/5nf/bFm89bd11Rs+T9w32p5f3HD10/fPnLf7a9fGYJiFkMTbKJpZqnadpsVk/zbwNDVEvXdblMuZzzKfDRiSlG7zxP08nEQnBmKKUCQgjBVJd5dt63du1JD62qpVTvz+rcJlF8nDTdMs3Haez6rg2hKS1/+Zd/KWIpzWLpt7/97e3th9XFuprWVD17K3U+TiR8vbu83T/0gTbr9XEemRwh3t7fl1IVyDOx49XQDxfdw+EekVbr1fu3+/1+DD29fH29pKmLkZ07TTMSO+cO+2MfhmdXV99/+y2THY+sJUqpplSKipXNZRCUrsfbm49ItrvelWzHh3FZisPQrbqLi36a0/394dnzF6fTFDveDBeOH9Wh5xbVGNGcIyRkh6VkPTt9aimj88453yIs1IiIZlE2AgUTVRUSRYJSpr6PZrDb+qvdRevyliV99vp1CBHBHafj/uGuFOm6YXf1TGs9Ho/kwjD0bVBoe4H9/mDVnu2e1VpfPH8BAEQMltum/H/6n/7Pt3c342nsY0AENQEBUzOzm/3tfjyEVW/A8zJLpYBojsC45NJ1q77rbu9uz92hCBG1jIxlWTbbVa1S8pnEQWffeUMAZkcAS62GYGjNo9XT2fmyuda2zj3XogCkELvOe1rmbI/x1c656TQ55u3uIufcRmNm8iHu9w99111evprH/PH9x2fPrtn5m9u/q7UuhxND8CEu3eKQjbHfhDGPH9/fWK3Hw2lYr0ERKsSuqzUB1FKqmb1//5GJUoWY3DBIqWm77mqtBubZEeqy5GWptbCK9RGCD8pO95BTEuOUmfLi+5iKhN4DUEpT8FFNnY9D9LWklBFAhj6wD7FbpVT2h2Mt4p4gKzADMARHyKVk58hA2vRH5IhYVUtOzjsABFOpAsyPCRXoolMzx+ecnLbTIaJSigg55wxsHMf9w2l/ejgtkosS0el0klpTSrJklVpj8J7Wm+7ycnNzeyuikZ13ntyZLhHcyjEZACJlcYfTd74bnPcACijMPsbokbWWOKyxoCX1zhOYaSW06Cn2wXkG++Ou6dHmhBBx/7BPKT1FA6sqM+VsatJ1sYxJVRVM7ewkgERGLbuh/gyeMDEFAwSSqqVIwzXa2QoxICCAohkxi9TVavjhp+/+/V/9u//xf/wfS85fvH7z+99evv3waXexCRwmWLrVjpXBaqmltaQIuN1uS7IQOucCiKHqercdNvHhoVQREQVDx2G1DsfjMTh32k/DEMdxmeeslcwJdSa1xq5nBu9dDLwZVvvDjIRGEIe4e3kNnOd0QoC+i1ophng6Tqt1l5NqXZjZueBIlmW5uflEQKeH0Xnnvf95SFNLwOJaRVWXJT+uI9gUmblqRghaGxalAFDymYtsCJnMAToCB8wdwTmwqSm8ENFElJCk1PE0GkdqVouqq2EY+uEpfmuz6V+8eL4sS8kJCIFaq84A5rxv8Yo5ZYF6c38XhzW5gC2mpRqh5VLzktM8rV99dnn5DJA8+yYQNVUCMymmwTnXbpEY47IsqggIw9DfP0ytEyICkTPk24zBSi5VxMyKlMf4IDFmGevFap0f16OICEwAgGreta3l/MhyRlElYkIEQz+spUopS4z88vnzGGJKybPPeX716urhp7t3794R4MtXr8ssmmqaj4hIjh35h4eHblitVl3O1ZRAwRMDA7JeP78ajwszl6wIVKSAIimFjq5268M01jynqdoQBQyQmOlhf8/O/+qf/Zkuy93d9/3gnF9fvrhatCzjXIvE4KfxsIqraZpT0ujx4X4PYtvt+rAfAyMzHY+n7WozdKuCmTo6dwZmpore+2XORP7sdW1SRQC9qmJ9dMMCLKXao8ld+9k7p6pqKgaKBhUZmzeCOuey5K7zBO7h4bA/HhEYCLzzpua7rlHtTEGkbtbrz1+/KSVPx7GPXQUjMeccEp0RNTMDYO8fHh5STuv1WgGmWhgRq2aZHqbjaZ6AAIlUtOs6Imr8gnYpr30YD0dRBUMVy7ggUs2lihwYt5uL0+mUUsm5tH2DiFTRgA4Qyjl+/Bwv1bxSTP+4mPLe11oll/bYjNPcxQCAMXZn4zADJMSnrV6tJEoM0bk3L1+i6s2nm2/+w3/6lD4cxwcg7NZxnuZhs+2v4+1HnU8jDjGuVg8fjvl4VDEWc+RLLYyotSyjTqd9yomJrRVZr9VzLbJed9M0mgl72l5ulmU57CfnGMyZpnmZf/jp4+eXVyH2PAAhM0Oq9e5m//LZtWpeRqnTFGMkh/M87i5WBvr61bP37z6VIkV01fUmgg5SziLmml95q1kpJyRskaSAbdv6x/gA731tSXiPmuaGUT0CXQgtsIvIwKqZRxaRWgsSTkWOh+OHm5tTTqgmqXh/jqVAxFoFDGMXNttVzWn/8KBSmfkxOpZaXGatFrwvtfzDf/xPxNzHLrIH0dgFEK1VEMp4vLn9+OHFs89evflKCXOtXQhqBo5LKTFEx27JBgAEqFLNBFC52VEoLPMMgM3hoz1vZjbPY4zeOee9l2Vpda0R19QsegdmjUfUDlaDdgGg74ZmBT1NEz4St4maJ8ajfSG1Xlavrq7A4Lg/sg/TabSmXFJYrbbbze72w4c8zTVlIAi7HRODArNHwM4hYHc6nSI6Jod4KqVWRQDarFfdgKf7T6pyPNqw8t26s5VzvF7mhYhWq1WtZZoWIvf2pw8713sXDTXNy7B2luomdnmaRQsp5QpMFp1HBmT37Pk2Rr7YDad9CoHRRGQBLI7QIbuGwTxZRYbQyhwREjtHjCLabNsRkJlElB6dIBFRQVGRmJqLVvvHBV9qJWyAqpWl7o+Hj59u81JqFgXbrNa51EYrbZ9E3w1XV5fr7Wo5jFqrcwxm54RMAjUFNAMax1NLqyslbdYbRsJm9+G4yGKQ0cp23X/95Z+sNjsmJ1WrVCDwXUBCQIhd9J27uX/QIiZnOTa3PN8+nubFe/8oS7MQAjOXklpJbHWzAQ1tF9QM7KTXzWYzz7OqNhCuMZG6Ljb9Uim1UR0RSVUqCBN579Fg3I8pz8S4Wq1vbm5eXr7E1/yPH/+WmRw5RHd7czefJjIgpM4HI3dzc+OYaxFitxq6+XSY5kXAxlPu12x0DnIDoHlJx4cyH4uZqhTvceP6TMs4jjFy1/uup+OhrFbDPBVG3h9OlfEwjkuaitRlnoP3iOhczPNckmzXsTXRpeZUpk+fRi2+5Bx8BDMVyGUBhT6EM0W4baDNzg4++JjIBEBMZ5xGREUrAJiptjg/cqbnZGgfnSMmA0MgJEeMBkg8TfNhf/h43I/j4p3v+qHxnFjt5yqrEP16s6oi8zI7z8xORUjBkTJUQBNUQvv2u9+9fP4mBG8QQtd55wAgOK8mWfLbd98v6TgMHSLWWlzkPri0LGZAwTMRiZVSDsej5Cq1mlrr0xHZEYTgOuuWlEyhXT+qWmslcsF3hAygSNxIMk+XUMPAhmFoDLY2GLY60GIZLy+vfvzxp2b6QGdjutAONCFuLy7fvTuUuXax//IXX236DdonRJWSf/r06dXLN5t1n+Y0jvPFZrcN/f54AKpzLUtK6+2KwOZx0Vp/8csvEuXDfAMO2ZFWBJTj4VjmSkBmHJwn8LXS8TCVXCVL3/fqTQUd4Xo1EPD+eIyrQUrdXOyQkIsG71NaLq8u56mY15Kz946JOeJq252OdTrl3WZAkIvdesllKcUsL+PoHqno5/jTp9GmtVPwM0V8WwK2XXVjvPxcHlhq9cTb1Tq0YBxiRpynecn5uKTTOEcf2wT6FEH9KN6Hvu9fvnzGjMfDaGaA1NyI6XGjQkRqVkr50z/9k/GYSpHtxa7v+zaiEomIIJaHw91+f3Ox3qW8uJwIsetXSLikVNPSxXh1ffn+3XtRYWaRes65tHNRanwBVZX6XxjjdF3XfOfUgImKFPzZD0JwzKWUUsrT5v6R1aTLsoTgXr58Vsq5Pj6Nh22CdORfvHhJRIBwOOwVJA6xH1bTae66TmuNfo2eXnzx4vRwBLPVegUpxVWYxyRz0o77vl+WNM3TmI4VDYyCg6wt7ohEABAZkdgZ8ng6iYgpLUuqeQq0XY5JEL3r0bR3xMyr1crHoKY8DHmaACDGIFK7blCV/X4ZT3mz6aDSPKZarYoEBwaiKrWmGINoPTs85bw8vVMNwj4TZpqBmjSdHT4x+OhRy/UkrGAiUVnScjgcGkghtS5pGZfxlGbiMz0m53w8HsdxbHZnRBRjvLq66odumk7zPCHhmQDN5IM3gFzyu3fv3v70EyLc3Nx+/4fvV6vNer3puiHELnRBtc7T4Z9+94/v3/+wzNOrl692uytEVJN5mdrrR0STKlJ88OwYUNuw+XiL1Bi74Lv9wwOone9Rwp9pdURESs5yBuv/6IPP3ukj5k6PdjRPjCMAFCk+cCml3X/tF2bW5oN+GLz3peQYw7ff/UZJ/uM3fz9P9me/+jer4XK/P6269deffdW77vnl9dD1UkSzbfrNZths+xU1+Qnq/f1ec0XhOruymKqVDNOooAgAhhb6rlutWjmuoiXXUmo6JauY5jqNSynifPDeOUe5ZABwSADofTiNJxHd74/OuRg6qbbM9ebDNB5zWvJhfxrHtOSl1BSjNxMDPcefxo6JXIuUE2nuyNzusCoFAHJJSPHJyuFs3PAouPDexxhFxQBbQFIpZT6cHg4Pt/d3qSg5L1VaFej7XlVbg9W+mki9ublNy+w8F4TIrvPewFJZyjyh1b//j//xp7c/ffn1VzcfH371p7/uV73voiKCFESVUj9+fD9OBzB9/eqzly8+71cXi1YwQGQwBcOHu/vri03w/vLi4jSN0zw5ZqIzN9oMY/QqSi0hCJG9c97ncmZUmgEgpJQQ3dMM2M7cUtKS09X2ohU4eBSSPLJVERGbGXpbmD7Nj0QoVWoRpuB8IcbTclICdZBzIoOc02p78ebVm+vtxbsff9peXMyncbPd/fbbH+Z9hgUqC5oxc66JFu1WUc2KgSn5ELJIWkpApIiI4qP7+OkjGMTQoSoIIIJYqWa1oHNGkVKpUfOSJ0O0amWZU8rDeiBCIgaotUrs3Re/eJFzvb/bI2IIhATsWNXYc888L6lKdSKiKs67xzv8zPVuXGF4dAJuB6i9m08PKz5yAM8BqgbEFGOspnf7h4e7/cP+wYe47jwgTtJMm7F9/VY12jkDQBUzIzBuaSmMaoBseH84/uGH3//u978BxH/7b//tn//zf73dbuKqcx0zigcQkRD52fXu7U/dGLovPv8q+OGprLMRR373/u00jm9ePE8pHQ9zlWraIjD+mPxbS92sNy+ePb87HVSMkMZp7GPXGnnvXQzhZMaEQCT1bNjc9kIA0HXdfJpSTvTovtx6hnYnOudXq3UD9xvgXkry3ivgsiQf2Km7u3+YUvnrv/3rJY1LWpj5888/P5xOzHQYT+RcF9cOg0tLYPfh5kZQvHM5FzBaUYBgPnhh5WqX6+vTvJjVfugtZeeaDspSSt6F2AfvAxMjIGoWEVXbbi9qTVVVJJpZLXVJSaR65wB0nMYQfIzDsOqW5bQaVl3fzeNCiKVW5/DisiuSfIiefc6FjJ3ZmbcuUl2jpEklcmbWPK4A0DH7lTczFSWiXHLX9c5xWwcxc+NyISIhprRUs3GZP+7vQbEuiUqtUlHMOee8x8eQwTa3xxjH05hS8tEbUKnasalWVQPF1TCkJR2PeyR3fX39/Plz55yPjshMixmB2of378bpruT0/NmLu7uDowMwUheGfgWI4/GgmrfrwbQeT0eR5snRAqnAzNr80ZZIaZnUU9veVxH1VquUWlUtpbk5vxMSPGZItWtbVZd5mZeZiOzxsDaK22q1SkuZanrx6lkrDs2gMBcxIO9917tSp9u7m7/5D3+zP9589eWvaq1/8ed/kUshpJLKP3zzj69fvHxx9RwQRW2eFgQsJVVc+s51XaxVow9VKqKqSKNLHB6Ozjkm4i6CSRW9u9sPQ/+rf/almHy4u//8s88fHk7z2xtTc97tLjfv352uLre11JJLLVKzEJNzWMqSSlZhAnhIOed092kBQzM1ZQBgx973auK9NzUk0ipORZ33ZsbUtKmKQCVVQzXj9saZNToMVau11rTkvu8b2aZ9JF3XnTtgM0Y6Hff39/fLMndhVXIFZ2oamIpUqGfj5Zxz13WNq6mqIQYRARNynpAZLNdFTfsh/vmf/8sQ3JKk64fnz553fc9gnojIqdFpGufp+A9//3dW7fmLN8+vP99uL4gxWzW0rBIiv379PDpfRO4f7oNbededYxGbYlYMFABgHMdciwgwoagi8DwnAGi5d4xIgDkv+dGRQB8jEYgou/9Cntm6KO+9994Rt7ay3euq6hyvVitEIKJ5mWL0b3/66esvv/xl9/VpXIbuYhyPS176OOw2IqLH6XR9eQ1sZjBPcwz+9es3h+k2RtfF9XhqLmWcy0Louo5zzp135EPXRTJJSwUlEIoueBfe/vBDEjngcTyNJWtg9sNQSwKDw+G0XvfBOSnGwb14fjnPhyKmswFoTjml6gNreUyNAAUDRJ+yqQEhTXkuqmkpLsSIoM0pX9VaMK+BqVhOqeuDqT29g0/t9jIvBmfloPd+HEfnXIxxnuZpnD/e3tzdPxiYigACGjgksbPfhguh67pmXtpGJ+ecjxwhkmkzVANA55yaidTT6fTq9WcxrD58ujHD4J3ntiJSgeo7YAfTdAhuePnis+fPXhsYoCGzIqmoWTmdHmZzqeRpnt+83jG5MakRMIKJISEjr9fr4+lUUE1BRVs8jHNuaYio8+v1MI4nKfLkKHauoS1cbl52FxfzsjTo+GkM8t6H3jPzOE/t+z3HczOZ2fF4/Lu/++t/+a/+vOu6EKMxXl/03/7uD76Pl7vrVy9el1LG8fSf/uEfv/nmP/+rf/EvL3e74zJRdHZ34+KVaCm5LPNcRYhIVFzn0eHV1Yv1ekkp930sZQErWhRNDnfj7775vl/3Yvnj9+/TUrySdz5N6QjFsTseZu/RRWeWLna7omIIItIP0bswHiQn8UQF1MCaZ8dqFYFNUL/46vO3P/3I7PrY1UWcSG0CeQAEA+8dIiJjs2Vv5sfwszwSVQ0hVsmtT+q67qzSEVEVIkpTLksd+uF4PIIDQpRa+74rqGigRdtg1bjFZxI9k4KQoUMA0yJJpCA0WYvM8+ycK3neXVwS89t37y62XT/0683aob7/8O6HP3y/LPPVq+dVa64LAofokalUIUBFvru76Xj15ovPRZWI0rxUUSRGgFJy9KHWOo6Tj2GcTmCGCMF7ZtcqJgCUkhGHUouItiRfFW1ZKa0HaGOUqGYpaMBISNiEG+ZciCGV3HVxnucmWKiSzMy70PdDyXm92aDBetiwY/9Lf5wX53z0flh1p+l0d3s/n+bv/vD9/+l/+MWrQH/z939zKKevXn+ey3I8Tgbu4eFhtRrY8Wk+9UPcXV503VpqnaYjsS+ZmGJVZWATBOWaRdWqmidwxFOaNMaSTQVKri9eX7W7++HmLnau1nJ1tRn6zf3tJyZiZCY0wGq16/nrP3mzuexPy0Ha2CDSx87tOndmu1OIkb33RG1ydt4TMy2LIGE7Me26QiQRnefUd506zTl77wipqiGRiOZSmV3NNYQIgCaV0WmFUpNzLsauC4H+aApCBooMZNDi34xIakYCBCCEcTwdj4evv/7Tb3//08V2g0iq2SSCQi2S0+nT+w8P9w+7i+vYufWq72LnXPDBp5KISUSS2f3dQx/Kmy8+IwJCXpZJAEPwSBhirKWYopmFLsJ4bLCtgdZamv9qrTX40JIXAIGQyRCJxBQQzjwiMVPNORVTBCgGpBTYE8CoCmZVxDkXY9D2n4oBQBe7z15/MU/T1e667/tlzib65ee/OI6nDx8/laW6NV9eXv6bv/jXNze3Wuw0jb/5/W/3h/1xOt0cbjXVkvN2M5j2RMTBb+IFejOyJc1pWUrJBgUR2TkSYUer9WaRuizVsb+86LsQp/tTDFxrLdlMcZ4KYWWOh4cRqpF33gEiTdNUcmYkA1KshOwQv/7lq9efrYvp7cPoiHYXm/mYcq45g2t4HZFndrVWkcLsVKvqH+NSn+72ZpSIZKt1UAHD6hx4TyoIgKfjeH//MJc0LnPKKQTPzLGP3nWlVHYtewlCjH2M9VFelkoayJMRoBCzGTggAFUzleq9/9Nf/er92/ury6uXr151PhArOWdgWfJpfyzL8vz5cyJbrzdDNwxdZ0ApJfbcdV1KS67061//q877Vl6ncfbeg5iZSa1oSMSiGdH2D4enPaBzXKtJ/aMGrtbaD0NJBTxXyQDAhGZaoBKAZ0ZEPStdgdr+CAEQgbCKroahPUtt88NMCOD7/uWL19NyJDLnnAqlOTUBu/dxnlPsgpKt+n5P/N27Hz5+/DTmfHN7jyQfb285y3ZYOZN1H9YXFwX5tMzkrWr1gfIC3vuu7w92lAoEEIIvRbphUNkj4na77Xwcbw+IiAQI5gAZ8PCQH+73gNAHdo7MuYf7se+D8xicryqbXX91PRwe9i7AcTmIWIweUHNJpVQiX0pyj6sGV/LZfaWU2kKeSsmPUgLHjKJaijF7AA0RiTglqZItyzLV/cPp5uY2V3E+xL7zTWyr6J0nVjZdd9vmNdp3nfe+TFPr9ZmJzKILBllqISRqKh+RZcneu/E0idqwXiN6jJ49WjXTst/fHI4PD/sHRNxdXj1/9mVcXUyllFzMlIVTSiICQMOw9awpSUkwTzWEjki1Cjv2fJaQq1WR6pilMYJKAWM4J27CkpaYyHmSp3AXBDQyNe8cE0fnikrXdYdpdMzOO1MDgyoSgu9j8EApJVVJKXddaFzT0+k0DCvHDlCZw2YzBJ+qGIEL3nnfqck4j9/84zfv3r4bxzROUxbdbDalLEWXzWr91Zdfrdbb03jKUjl2H397u1lFNMw5rzdrMyt1npfFu8GvBiWbp0WnWaogwOl4nGEixzUJAzkmdi54d387PepdPZ5djOtqGK6vLpwPS06u88qlaPnppw+Xtet7nsYcOpnGuWYlqADqmhUHMzzpnh+bHzbTUkpbxAKKc8TkmZkdVklWKiIGH47H0+mUb+/uU86lVmIXQmiuQNNpyiWvQu99JyIxRkRIaWkfuWNGNC21susYAFFFQJWYUWGel1pr5Hjz6bYftrGLPnQIYgrIqGI155TTXGZUexFe5JJhyoAE2MTKBlLVtEg1k+5irfM0nmY1Wq02OecK4oInMZG6u7piJhNRRee9gWkVACTHzVpYDLClLxGqttYTUM5JLw2hQdXNxZacV63OOVDTWqtqSZkxCpwp7977YVgh2LIswGygqlXNCMF5jF3XEo1UKxI6RwTqnYuxW+bSxe7ZdmtMp/Fwc/9hd3W1212llBARDKbD3iTXwmVKWhUDLvNM7DbrC1VggiXNx4c9iFJ0gFSmlGoNLiCjicbggBmAayrBd8zguG3xtYsO1DoXXYc+WDEx41Lcxa77xRevxmmP4OacU05SgAC6fnANhqm1gVjQ9oA55yb/MrOWYcTkiQkMVFVL8YHJNxxLRfDm7u7+cHCIrRj3YGqmpjVXYLY+ipmIzPMsol0XmuTGAFTZOR99UFVARWt8JQTgvhtOnz7+w9//w+XVyxg6YjIsoqLWgm40xm61Wh8PR0P4/scfiFYXF32IkZhKrgiNbK6N2L4sZclCgdnwdDoxMzDWWkvKqlpJN/1KVYqaIQCRI0JARGVPSAxEXddNU7FHWRgzEzp9jERoa65aS6lz86ZHAK3SHpWled6f1f2diMAfG38lcnmZCauoBh8el2zFBweiXdf95V/+5bLk//QP3wBQFUk5v5PyodQuxiUt+/2eEI+Hh9v9vk0GJU/7+6OW6n2QqoxElucxAWNwXq0EF4SgHCc0QwdMlCWLIVrbyYuZhq5bDXw8plcvnm8vh4eHh/2nw8p1QFmru7097C4u/+VffJnqOE/14/sxBnIQyBEYdF10ItquK1MIIdRHJ+qm1SSilFLzaGjbfmZ2nkyxiOS07Penu7vTw8NxSbkLgRmapkrUyNQNLjpfTR27wAEBkyUDQ7DoPRDXdkYdkzWooxnTKKHb74//y//y/95dXX/2+coHr2A5LyEymlbLjuh4eMh5AYBU05LnaTxdXREAtBqEgMJUpLJ3l7urTx8/igEykGHzx6pmiqaghrbk1PlgBo3jiszmGcC4cWhNCaHmsuqHlBKqCRizQ8DmEHZ2EdNqi6a0hNBpVs8OEKRWFVQiNVWz4EOMXlXAFAHUBICYHCAAiGNfaykli6jzDGDavqzB4XC4vrqqVff7fbca1l99fXv7YeiGi82u1prSktPSx16YP7x/vx7WQ+xvPn5EMD+Ei4sLQVvvtkbAXUgPJ0aEZloPAGpgGLuhi8PxMPYxKvLl1q+3gyN4eDgc90eRLFqBWAWDG4z0Yrv5V//mV8qn4/5k6u5u5+fPNt6HpSyO+Pb2xrVVaQhcC6a06CMW8LTPaeyDZvZ6Bh2MllmOp8Pt7cdpSnJWzAP70ILXDAjRYgxtaTOOR/auqvQczAcfAkCFaiTqihJTleqdNwGRakgpZUTuV/1/+z/8H8dxYR98F0LXuWbV3FyOpR72d3/39/9hSQs5vLy43G43SGBgLdw+5UU9CNhqMwiCKiKTtnhNUQCtqEqGgGrq2eecHTtEAkJF8I5FoBZVraoCqCb95mIV2eWclXBaFlNjRNWzBJwdI7pxPDHXGGNVMTDnXa218SlqLsf50A+dtrS64Bt9nxi9d4AKoADqPFcpZmYGIgXJVE1qdcTk6PJiRwTs8L/7y78sSb0L2+327q7E2JVpRoJNt3boxjyWvIjWft3vnl/PJamimY0P93WZt+stSC1EIAoKZrDq18uSVMAzZ5Vc8umkZSmqsN+PIkoE3gcpsJiWUrp+wOiWjLuXr8bpu82ldysWlQIChgJ29rh5EpifOTCltPjJdpjaSJhSCqGxxXWa5of7w+3tA5Hr4oo9dX3fBNOMzTjqTIcX0S52wQcTRQOoQh0aoLHqsgyhj8NKwMyMiW4/3CLTZnvhHeVa0XFcreOwXm+3nfcGIlVMZNwfp/nUFrx916+G9ZuXX15sL53jKppLUQNBUTFF2O/3fV/MrBVHUWMFQPPBo6Pj8UQEKlLVmBmBDEGhUTaoEYgea1MysyqiZlIlMLdYOjBg7x7V9/C0nFYxqdU1drBqUVGwYppzDsHPOTMTMYERonjv5nmpxRBxtVqLSDMaOROXCHa7nWRFpFqFmcf5tFqtj3VMy0JMjh2hA4VV7DfPNvOyiMiUTuRodbVTx8usWnQe5/v3D7vOq4qYkXeEWkUR+dOnOzNYD+uUUoFSa/nVmy+WMd3fTZ47UVOT6ElE0lJSyvOUf/P3v6FAX/zqqzGnuGLnsRQ1rH23sQoO0XzwtVQVa6DlGR93rjGu2gUWY2ynDQCWJd3f70uRGIYQgnOhilUV55yqBH8ORDWCXFJH0MXonCM2D9TFUEAVbFh1isieiQ3MpBZESKV+/Onjv/jzDTLN45Jr6bttN3Rn/pIaoj1aQI2Hw+HZ8ysDfvXss/VwzRSbiS6hGSgHNlWrdbvdxq4/3R+lqhGSglZkgmKCDhHMu3BxcTEdj4bmvBOV1uw9btzbQYFaylNOAiMZaHNGNTUQrLWq8bDqvQ/LsgBAyUVUHTsDA4MQgoCi0JKWLkZiFjVVISRmcuQZi4gCoVklBmbSc6CrERozgyN2ziAvSxGx7Xa7WW3++q/+PxeX234YLq+uLy8vb+7uxukYYzfNIzG9+uw1BP/h0+3dp1tCnE/Lq8tnq849HPfkXN/3mksZF5Fac/UxOudKXtg7BB2PU1qWGGItzZvOHl1Cz4nG092y5BLCp7QIEqMIiXllDy6PySFC8AGhkfH1yWo75zwMwxM3rR01MxORw+G4LEutyuyZnapq0VSTmnnvqlQRIULHngmJAQlrrWSKgAQYojckZwbRMwFYATWVogi762dtt61g85IdNY9uxwRViomK5pTmYehfvHg5zQ8P4yfTsLt4HvwKkRo9jxANqYK2oFckdM6F4FMpgNguIABTaftiyCmnOSmAgIIWZmZkEWmuOGfGnyE/+tEREajBmWFrAGLVDBFErOrFZvPx06d2tT/1EqLSdd1l3KkpiZkoOiQmUKuloDkABMXoPDCM09jWiPA4yBiWZkYyTePhsGeOxBhiX1Mmhrdvf/r1r//5ZrNx7Lbb7dv3727v7lKa+qHbrNf/9N23b2/23mHw9Px6dzWs371/b4QMkOaFEAyNkaL3gFRFstYVd9H3H9/elSLODWYZsXFiVVRDCKp1t7s8HHKpdtofUYGa4XWtm9UWibOIM6NpSohsCrWWZVnW63Xbwy/L0lAufUymMLOWkyZSmZ2ZlpKD7wDV+2BgtZQkEmP0wQMatVkSFEDBIISIiE0RDNaCn7FF6CIiMTOX7fYi+LAsaZqWGNfMnEtBUkLQampSaz2dRmZW0ePx+PrVV871SKjUWDCGbRQEbTuWWuXjx4+1lHYTg4Ijp6QIyITtOy2lhOCncSmlMLuu65udmve+lOocMVFzYzszYEWf2FcASMwGgGaSSmNZPfUSjekgVdKSzjO1aPDO9wHVnHqppdbaRIpVqorlck5WjzGIFDVtOpUQfKnLNB+HXkMcQgjH4/FP/uyflbNtJO4uLpjo7uH+YrsJ/hfm+PLqyv34QyTcXWyev3wWkD99/2OVguiRKKWpJXci4rBazSmZqSN2ztVSzLxUrXUxIzPoujiOp3biQ4g5J7W6WgXETKqRAyOt1sFBmE/VOXbTlE01xlDPZBJalhSC996Xp+Cklq5WiojcP+wPx6mW2kUOMRIhIpEam51b1JJrrc671qC0W6dWQzz7ARGYVXOR2+fyuJplNfPsiNlQHx7uvYur1aZbdV0XmRUBzFlVHsfTPC/7/cPvfvdPV9fXr199rgYm1bFvHYmJSJUiBcw8kSd3yqdhM6RU8lyGOIBihRy8L2e5EXvv1cQ5bvfEzzmi7bZjJrXmoANqZk10DSANeiBqDohaxXmPjznFDbprB7o1FWd2g1/1XahzrVLP3CSzru/UoFYVTWBWa2myDgBk9OgAgfp++Prrrx9dpVwIYb3ZmEgpZVmWeVl+80+/Gadpvd5cbDcYgwK8uLiCVLu+02WpzhlYYIdAF6uNI/7w4VMMARCWcWbHYMBMzOh4MM1SW7YeqMA0L4Cg1WquKeXqKiL1/SA29ZG11LkyAVxu+3mZEJwj5FRrzkeiEGPnPdZaUjrzDhrjsf1iWZab+4f9w1EE+i4gNQNkmpclpYxE7ROKoUmljR0H7xAQFNBIa0laiMnabtjO7UtzT2hNMhE5wmmZ5zkNw6rr+r4LzjuzQgDEUEVUpOu63/zmnZo67PqwbdR1AgRiMQXnmYDniojb7cV6GA6HPXl2ZisaOh/LIrWA974tiRFRRFKenIvt9OvPbMmZmdkBWClZTZk5wPllE1OIobVgiGBNiUpo+F9HpvtzSp40Ppaa1VIYnaAU1VoLokXiJmNpm6AYYoOsiQia7Tk2+pf3PrSzdXV1lXP+7qcfd7vLFnQ1rFb0CG5HdCktX758vetX+9NxmsaKidhdrNc1l5JSqYWZPBEQQFXnIjgWUYe0Wm2W+fZxlWfMLkaXliJFaoZSIM3VBS59XV90wePh4ahSkHzOMk+LKbnT6djQO+ZCxCJlWeaW7sxEaUmAUHIhpmVZ7m4eUm4Wy2W1HjxArrIsyzTNMXa7Tc/elZobMyR6JqaqFdQG4AKSpaKZYzf0vWq1x0CRM5cLjBiN6XDKMW6GoSdCtaqqACZmpdR5HD++/8kxXV/vqqQhbB1EQ49nYT8goDGRuRijiJSS52kWkZ9+fNv33Xa7BlTTSgZt5dCuE2ZqzLNaixmEcCZXtWNRRUxqOxftP2unpPnMOOfAAMzQqamlWkrJP0eYHx8efKLm5pRi7ImplJJrYefYsLlM1SqNd9qHHggaQ6Ke//KqWn3gJ+QMEUspt7e3tdYYu3c//qSqwzCs1+uG+4yjK6VWNTG8v3+oUr336/X67tPt/f09BGa0ztNmvfLBf7qfkioaQsHjcWztdVsQO0cAknKuYqaGrQctQj6uL69lyY6j1hJdN8+llMoY3JJKy61Ug3Q4IEHjSC45WaOVegcA82laltRqDaDlWjil5m4dY4yh884zO0ekiKYCiqpIiExEgCjmySkKKcauiyHmYnoOUNFapdZCzKnW+7vbUnCz3nkfua1qm+UNQpFqWh3TzacPSPjqxWfPrl4jMpIDMAAFMwQkRQRSJERzLvz29/80L/PDw0O/HlbrPyMiRFuthmKWcgKAq6ur2MUlTcToKTSasj56jWJLjgVwzE8HSx8NV1u3gEiEplJM1Tkm5pyzGeSUcAPM5ySsBveNp7FRUovknIuoEgG7oCJm2PLrmoCbmIi0ionWR4d9QiKtdZ7n4/GYUnr//v39w8Pt3X3XdWlZmOjFs+eXl5dEOM4zLEuZl67vP97vR6mby61TrQSnknOt61XnAS42q9fPdwB4d5wYyCocDyffd3Q2+gciXNI0uLjZrPf7sRYyM9/xZre6uOqc5/tPR0JXUmbUZVYwFBVXRRuZ3XsTEWIwcFpqrdUATDUA5Jz2hwMTOx+qsAKp1DbZl1K88+vVivAspYohGmizQSdHZoJiWaSRYvo+Dn2HAC1xuRVBVVmW1Fg0+/uHYbNDIueDdwFJEcxQRGVapjRPV5e74/42l7LebGM/mGHTOiiAVAHkGFrzlIk4hEAkzPL5Z8/jsHXON7q6POYGmFktpQ+eAaQUZEcEiNZypOAxVBEBci6NUfMkWG2SEBExE0Q1yKpKHNar9ek0qgAi5lTUUmOtNREKIMQYTak1SSllNJynGRHX67XgWcQLAN558AjWlkuNOejRrFEIt9vtNE0xRhML3vUx9l03jZOZHQ+H3eVlH7tw5dN689O794fpdPXmxfXrF8fbOxEdLjddH3LNu/7icreNQ1jG7ByDD2WqU1286tB1p2k0A9G67vq+70VlGHQ8VjECrF0XkXguuYoE5VqKG3pYMiEpoDscDq0kwc8Cea35EomC0bKUWnMt5qJDpBhYwVS56X0J6Sypc060MjvnfVOOtzZdtdRidcoEuN7EYRWJtBnKG8BTsmEjNx+PR3YuhhhjbE2MgZrZNM9I4Jw7LOnDh3eHwxEJu64zRAVArdpMjghNFRFVRFVj9MMQP3vzRZUCIERxHidRZSMT4bPmG0BlE328frY/TqWKGbBjB74V1oaLIlrfD+zw0ZoVnrp7VUWkKlJqIgCt6r0XqUzODKVCkdJaqyc2s6oO/er51dUwDIiQc27mtDmXEFzf9y0TuboawTvHzjWuANfalt3SRkIz2+12kf3peCQm5zyJjeNYSnHer1YrY2vbw816I07f/uEHUMnjLEuxWreXu4BcVKwPSWy4vBSj+9Odna0AWGpFIuciMU/TXHJFZOd4Os0Xu1UMDpXG/VFLKcWcc44DcXZMudrZ0U/BYFna5aHWdgtQa3UcAQGRYujOFo1EudYQgnPciEdglnKqtYTowjmlMkV2QICIogpojNZ1YRgioFUpzZ5PVUkJEB4FCHA6nVbDqt8MYYiIJjWTI0AL3hMxoWNHJWet9fmLl46DWet0IXgPDrM0NxJ8VNLiPM8iBBZKSd6bI0bAvOTYdQTgiIGVkbxz7KkWTaWkXNDYe2rMdyMEYCJcr4ZScquSes42O/9AbL89EzRyoxugqlAFAYNaBIHAUXvNqiWlchqX7Xa18oTHkznIubSrqUniGmDhuPVzpf3WjESSCqrA3d0dAMQQ1pfx2e4y1zIvS7Nj6rteRJa0AOI4LvOSQvTs3Xg4lSUFoGkpPvovvv4yT/Px7ua4pB/ub0/3GZROx6NHj4hgFQ2iC0OMnl0qWmubalmqeA5oZlXqaa5zVgNEVoBsVUzN4OxxKEXTvLTpzwfP3PBmRILgAz9aPDh2asbOOUYAYMdSxURLKTFGA1LAUmspJTIQoHNekcwheBv66By1EbMFa8FjFW9tSi7VkGLXsyMxdQBmouoAWoqaoYJWPR0PN7c3188/M/ViaqCd75idohgYEyFCrTWEcHGxu729qbWls6BU67t+XmZ2TIRo1oUgzIg45bRMpyKYizI7U9BapLGtq4pAF2POyXvfAaAjK+08YRseW0MWfCe1ekcx2BHG9m2JSHMDEVFmFDEmj55VtYgAs5Ta9ytCrKVY8z8AaBuONhnU5tqd8+OUo84FH+D169c55y5GpwAAy7Icx9E5h22hrzUtCzvnnU9p2d99evXm8z//Z78+7u8f7u5Hc1dvXgy77ZzmSjglubrYlf3d6TgxUAheqmSsV7ttP/Rd59aXm7cf3j/qItmxu799QNxyZ8uiREzsAXCZ07IUBDYTF0IUbS7oamrOucd9FzjviMx5ImR/NodwtQqTtcGngYRS6jAMfd8zc8k5AzCoc+iZEUGBahXfdb5Bt49KhFZ828FiJhCapsXQo2NQVVFwBCgigGCEJlWtSheHro/r3WpZ6sPDvYtRzfzWNx+mWgp6PBwO3vvnz58z47LMLe4VAERMlZCorRDaldy+i8N4Wk6TD6uiyJ6t1pRSi8VUReYz5t4UlArGxE+Zho390ZYNqggKxN4eI4YQqfGRHl+DPP2clpRTKiVh1RgdOzTTItZgsLOOAxxiw9JCa7yYz0mwbTgFRHE4nsaaS9dHtcrOLcsCizDifDztLi9fPb++vfsQEbDkoettXXHJDvBwe//dP/120w1OwDEyYghhvQ5apZYCgOtt9+LFZal5mkaptfV5gDAMwzSNx+PYgWP2fT/UYt6703GWWokREV0MLmUBg2rqiJjY8Dwht0KraqWmKtW7s7N+84jyzjmmdjd0sXMNoDdovAYfI4mAKag6xmHVOUa18xjVRvH2DiKiAeSyTOMUY2SK0fchdiYi1Ti0m9MTlqKJkfrY68X19uISCQCByTG7VHIFRXIAqICOaZ7mGJ2qqRbvXd91JUutBY0QgNqWCbmLXT/0RDbqidUAecmF0LR1Anj2zVbTWq22YgDnbIt22bd+6AlZEBF2LrCvRVpuWd/37STpY9xhQwpySdO8OIack3MtLgUAjQhrVVPLOauV4M/A1XiaYhecb4UVmZvYWEV1nEYAWK23SMaOV6tuve6XcQnO1ZrXq/5Pf/l1XnLLkXrx/AUpzWnqI/Uc59MspxRjDIh+tzHTNJeIzqyKFu4sT3Wa5pILO0fEKUsXYxd7563rwvMXVzktdzf79Xp1PB43225ZpKq6LgbRWnMVtRgYEFrSZrtXGvhbay01IZAqmWnrrJvbu6owe0/sWrg8EjMGhzVXRlApJS99PzgHIrXU0g5ie3/bMN+SksbTZKaOHZNjjs03yYylioJ6zyI1l2QIq9XGhb4fBiRvZj4E5x2YVhU0ACRDSTlrEebN5W53PB5Xw6oRFFTNuRgQFM7OetvNNoSQy+JDADAkhdaVUxNMoKkBWmvWG4BUamknwx4F9fAzXbiZMeKzy6vb/eF0GolQ9exh5JxTtZxzKcUHr4rLPA9DZ6alnCNkEcEHVtPaYotA5mVZr0Mp5ceffvj888+6bsXkALAKqJ7/r2EYQggh+hB8exXs+HQcu2FIJddpev3q9WG/H09jWz/62PvO3958Cs4T0spH5wOX0vIYV10/jVPN5fnLZ7WkeV5qKUPfFdFWZnKuzrv1JvYrP47Tsoye+enKEElm5pqjC4t1MeaUzCx20XmaxumsFjeQKs1CuJQcY3Nij6oVCZzrAQRUVNV7T61DqaVYroDTeCLUiwtnpqLypE2Axw1d+xkAxzF7H2KMMUYzrdXAABFK0Sp1nkc0m45jjBGZr7bbod9WAVH1MVaRpmmuKhW01iq1ukAtcu3q6kpVU0qiBoZt4PfBOefGcXx4eNjtdsuyqKqZVC2E5NAVEe9ccFSrAkKDoOFnqWYppSewlH6Wc4aIana928Vh9f7DezUh5CpKiP3QI1qtT7JVv1lvc55bE9IwTwN1j5bNwUXRknPKOQ9D/9VXX/T9ykx9CGBgUEMIrdC3XVkLKzXTc2l2nl1cD6vTPKvq0A8I6HyXc7268inP+/3DF28+64Zh3B9O40RVSGFZqg9US1GVh7u7eXKh8+yc865Oy8V2VfIhLQBUVheXq4v4/e9/v92svI/HcQQ4u5oDkDtO42M9slwLqIUQSn66rgSB7DHGkIhCCK3UUrPkNlUV79hEkRAI8phAMrRCG7iLPRKrapun/CNs3R5cZmSi43FUw67ru+gdUyPXgTVllWmVw3goZUa1LLOiEfkYB6cgdjYFVQQCJAATRbPg/ND142lMaeljMFBVQUMVEDEDk1pCDGCmIp4dxJAXX4p6IgTwzN71gOAYEQwZPTtqCArik1/D02H643L60Qlimmdmvr7cAYBUSTkzcfAewBjaIh4AwBECe+CK1MSJi2pNCEYMgmiEJIyWc9pdXsS4S0lKEW+GRNio03p+PkUk+MH5SAii6IC2F17EDPTZs+dpmT3zel3HafLe+13IJRtqzTl2cTwczCylBSASMgKIaJOqnvZ1peQCE3KIfrXrbx8OXReLnrqVZ8YQw3q7S9MUojOzZc5EjpBcqZUQc5GcMhMhYWMdhdjseMzsMf7KufMRPJcAQrJSspl6dsyume2nnGpZVptViy1h5xCg5JJyJiL3tMBRNVOioEgpi/MdO0byDYlGNAMwMAVbJKnVDx9/rHnabC6mMYNi9FtkX6SY6mkc7+7vnz1/wURm+pS2WFN2QGqASIBKBKbgmVo4OBg0qqtjjnFtCiXXXCsiBPe4SNaCgMHHwIwIxGyAKNjgmKc62Ai3rT62NwrMlnl6zD2WFmCcZkGA9mfBeVMdi/gQYteLVCJGwFpMVJNlNjI2/v929WdNsixHmiCmm5kvEZF5tnuxVGGqpyl8JkX4/38EH5pNcmZkpqZQAC7OlpkR4YuZLnxQjwSaKRDIEeAsEe62qH76LQIJ+kNEgAd4grSlHqzMfd/f3t6GYcgM2whAljqM296ImIh770Wm+lTBbLH729vb6XQiCiS4PF2+/u239ce69z6Mo7v3hr/79ff39e16f3P3vvd92wHj/OV523YNrYOUoQyncd33qL5rq0Pdtr3tmzuGUynVzEspoqpMlNN4gvgHAwlRhFU1raT+WWCYpEpmBsy5h0UEIBI6qxFFGWpi0wdbcN+TLP/PV4a7m4Vp3LddA89DrSNSDSJAhOLpg4ABsG728vL97e3lfn3561//Oo7noYx7W+owQ7i5v7293a+33//ye2K+3xZhwPTTZnQIAAQPAnFXiCAW4kPvT0T5Xdyj7btamBsCNI/8gubaevcg44YI0yyESGIFyb0m1OkPY8n3LZca8TyS4yG+ADtMuY9ViNFDu4YLPo0TNYiIWiftyISARgAjD4DuUcpQiMgc+EjKyKxkAoha6/l8/scg/xFT8O3bt3m6TNOZGXvXcEN3M7vf7/M8J3DQe4/wQPj8u19QAb98vr62YZjU96fTed/vampEquZmnz59/I+//PnvX7+ez+dt7fe39bf//DYOEhEeQcQ/f9yY6y+//PL1628RIb11qKLqAKCmGQpX61BKiQBVy9zK/MQ5pZeSofMASAiZxptrBSVw29cMFGEkCDAPjVQfcKr4c9yo3YqwA65rL2XIypOrEJGbtbaWMgMEh0Zbf758/evf/jKOxc2JwawBWalkO5jZ5Xz+lz/84eny9LYsRESU3nFo4cAZG5TG4Kju3TpLgh3oDkTgELfrbd3XnDQm158JAcIBM77akEotrbc6MLEj4DBUREybHX/YffEjB5SIVF1VCSE95RFB1cNcEdQtCAyAMNq6zuczgB/4OzIgcXiVwqUggkckMJL5wmnHAgGEJYgJHSbM1abdIo7e8/n5OQK37VaHguhta6d5ltL+7d/+LWeQwzB2sw+fPgPiME8/fvtqqsS2rq/MPM2T234UPMJhse97uKHH29tPdTqNZ9qlmUrFWsuyteWmUuPH9++m7qZi4bpt7liYyzQCAheexokIswF0923dTqdTbrUIl8IPq1aMHDMHIHg4BME0TSLCxKn1NFXtDQBIqts/LH7Shft638zifB7HcSqlkEiabDlsvan2/fb2/evXv/a2579yefrlfHo6nS7jMDCL2eYRUsre+7ef3/UBAjGzh2EEBrgpIALVgJZjb2teSpj5tq3jON6X5Xq7Rng4MFMEBEUgqTsAZniHB/TuLFhBII4aCx8uKYnCvCMOt9stZzgIBMkARWJm8+imTmDhYBjugKiqvbWplnVdCQXRA5wAhVlEgDDUetu6Ngj+h9sFUkSEQwSmXR4AEkmmISPix48fW+ut7Ug8AVQpADBN8zyf8qBFpq56Pp2J6O169XAIOJ2ml5eXdd331ty8SCkEPaLdVwb45ddP0zS9fP9PkfHX3335+vMrMhQo67ruu2aUhLl6OCMIMFlX0xhOY77yoQ7HAhIpRdreI3ZEHIYhjSbDw8DyXgPEgYTBgTxCu8c4jg+7RHQ309a2bRzGvEzffU2ZUTvvu6Y+Nim476kW42nG1cmg7cvb20tb1rmMpcjT+el8efrw4fM8P93vbd92DyehZp1ZWARV3Y2YTqfTel9cFcIDUBGSgchcInxdV8Q4nadaBlV1MyJKX8wEAQMhmMLScerILnTnXrz1nlyD3jV/f3pxP3BlaK15xIfnjwuzRVrcMgAHsoYiUMate0SoAoC5iYzDMCBwFvbmRHy0exHuTgBOBP+cghuHX1J0DYgopTCjh7/zfvMgcHdw50xfQzxWPCIXIeaI2LfdWissa1u72rKs+94jYBiHy9Pldr+3fQ0IIDxfxtt1qQNb6y/Xl3Gu43l4e30tVcxsmqZxkgB1d2GUMA+P9P9VPWqs3jsQ1sIYJCzZ9ZgZArIwBIWjRyABEgZQuJv1cIsASU90Ijc3MzevKUl9GOamlzBxuV+X1ns9TWku70agPRNNkiyvBMxU69C0n+Z5rMN5vpzmcynjsrb7tnaIZjrX2VJjkynzQFXqPM2Xp6fX65tweqAt6aFj7rWWSeow1Pk0E/H17QYASARuve9EwswUQIT6SAU7UNLA8HggogmTBkCOJjGPjQhnEm0KDqd52noLC1U1UBTspqFHeZc1hAeEAQEJs1lgLhc1DVDoLJLjgoDMEIFSKjj40X6GMFIlMxOpgN16tD1n4RqAzLzc7gBQHiPwd72MLcs0jGamrZ/m01CHl5e315fXT5++IMLLy0u4csH21rv5+enyyx9/7XHX3moVo9j3+3k6C1Nr7XI+v/24qQXzxYwI2d0kdSZEGSRe87BFxEAwcwICQGZOgCBBrMT1PRzUC7ADhmqAYXj2/Ai5mVLUgbVWYoYIB0zrH3fv6tf7DYmEDrOo8CM/kwAeHWG4+zTNETiOp1+//FKn52EaI2hddw+XWniskT60QBjpUYPTOCUIOY6j6Y4kSAGQTjVATKfLbGrLstahMhMcRmJZrKgqAwDYP8rhx2yY3JOI4AAYcdiTZnpK/jeROHqidh+enzxi35v27hAGMQirm4UzcSkFASxgrANA5CcXKUkLOICMB/ELgUQYkQCQicPsIHQADFL2bXd3pFiW+75uX3/7Gh5cy6fPn75/+8bMnz9//mcsNx7UWSZ6fno6zXPvTWQ4zZdwu99fRei333778f07MV4up6ePz8i03TYmRjQWnGQotSzL3d01YlcP8G3bnp6eiGjbNvn8+XNifUQsUuBhheUQ1vRdmpJfT/joq1mQyDGiRjg4gIcdpviFJMzVUxrlxIzM9tDG5Enee399u6rbPI6VGAiRCJEhKI3XSZsjSpFpmn78+HE+XYZhnk4fp9Mni1ANQhaBTW0YJtcgZopAwhzKicjLy8uyrsQUlhmBYKZpe3nM6VrLD4NE5oYOEcBECSllu/deReXlUgrvrZmaW3L3Mdw87B/rIB8XRBC2vqqWMNS+b20PiFKHUaozdlNETFMMBxc/1nRAMFOOZe1hg/uO7+dM2jPPp7ddtZYSEXvfWuvIpLbe73eEECm1jBq6bdvtdk/mzzzP755kOf/IzwyHQzhcLjQO0/1+XVdOtPZyvtShUiFn/v76om19sOB5mudah3VfpnmK5mQodSCitAOOCMmv9yjM4VE0KLgDHYyzTFsYx1EqRqgHojFXKhWrQQQbxd4dmYSZEZIhmI+GmC1FuJkCEREB3XXZFylDNmERjzDKbupcpdyvqwibWa1jgH/59GWo5+n0zDK4useODMMwLq9vfW8YyTDuAOBqZSiqutzXQABIIDHF7FEKE3E6quW7HIahSvHW3u7X1vXpfPnw4cO67tu2jcMQ5hnIMU51moYIWvfNzBAlvebe66pjQAvgERoBCGoW4G+3Rc0tHCIAtAFEBwTQcA9MQR3W0kKDQtJ+5JHQmX9nXpqYFzkgEmuER4DZ6oYAoa5hAoKI8zAWoqnMIlNIWPi//dd6e7sWkXGaWu9jKTlhJGYLt97dvbCkc1OoDoXHaSh3+dc//YsU+u3r3zzM3JfbWyr5ahlJ+PR0atoocBjG2GAGYR4VbL3eCDmC3l2K+DG/M/eHR3KAuRURrhURmJEII4AQmaUAMgAXIhC1MGGRwpwCs8OHMxlcqd+NcAQgZg+7L7sFDiJBGBmG5a4aZurUtfVt3QDivtzmWeowneeTdnLDAGUSKcO2b+BRSUwN3A1h2zc3d4hxmJe+N9VSS77093yzIyw9T9P3XwNIHeh+B7Vt226327a145A2DwASVuu1FKnyUFggQPgh1YH/v6lOQICHgjuhQSQerynpAYiMbX+QBHM+3boz4lSHjGfHfxJiiAghutm+7UpdagkAFmm9772VRwI8AEgRMElP+tZu9TSNp2l4Ol3OZ+sahKKFAN2MEInTHNSzDMih+rav5iYiX7582fd9a8vl+fJ6fb3e3qZh6G4iiNyePp2WbbWGQ50A4r4tjEjdTbuFtt55GOT9DI9/GLYaIqnqvu0iMo4jIgYYoL9/1VqraPfNYko1vZVyZDmHx/sxngdhOqW/Pym3vu8dZXAkZuoEEtHaHg4IZGSGnZksbNm3pTUusxmYQWtaB3Fw72aGe++pxepNHaKDEdM4jB+fntdt624cDAb8CEo9aseIXOIPkNZer9fbbVUzKqLaX1/f0or8EWoMqMREP+Ht/HTCw5r4qP/yqqJ3Kk4eLQFquu77sq27qXoApT8zHhBBOAFmkkVAtNbc7Hw6GZBaT5uMf1ysD6fWbdsAovTiCJBBaBHp0kuHCi+Fn/v9fm9qn4bfIcx51RhpDyMia52Zgdm1mykgMhMC9q0zlTIMuh4JXOM4Avral9fbzSM+fHje2m5qVIkm+vnXt/2lT/M0neYIIGYzB0Y0ZKGIOHQB+fL3fdeu5prTPUAQ4YCotdQ6IsLDcZ8IMDLjyzAwCJBKQeIACHwULmrJ7zTziNwZaKbX+13NncUcwB3UIcBCIZAAnAMZ8g6dpunf/+P/+Pzxj3//fq1l2rqWdTGL1tUh3KNOIzHubQdEFi6lfPz48WmaRin7su9tp0KH3ub4iujhkZmfHsQEEdvemrp6SBUIgG5uyqVEgNRix0gQtm0DChEOB4s+DKMUcg8ISZ50ZoY5RF8XCprGOgzT7banhAoCCPEoBxAiANUiEAVZxABaV2Y21VLK7uph7GRhPTzMCjEya+/R1cLVTIZSZSSi1FwmXkMsZSjF6ufLE5fJmxmFFHEC0Ijwve95vt7um1skHKmmTd1skcLUizlkAlwgvd3vGm2YxzIwyvTz9cpArz+ubfN1VcB+OuPEw07NR5igLItHoCY1OR7xOK213JGlIhENwzDNcypPxnFMpZyasRBSYg2ZwANMLIwB/5hpuEfQQaXPF5ND09b15+utGyM5eejeQRCAIPTI9waCCLNsefzt7ds4Vhmn8+WslnQuklqAsIVLESKKCbTruzLCzd7e3izRqXcNVjxsGLKRAwDE8AiAfd88QEoR4aY9CZuFcBxGQkKm9LQFxNb6p0/P//rHP3778RMyaYEAIlpv2RCJyM/X1xQ/Mk9DnURufe8c5ITvh0p4IFPFlGPoqUxUyiEBYmHhrqGqgWHm3XWoNSyadnNLhxbtnSpfPnzorfnax2HMVhxtJADmcjrNvUMAmhoiqFlre6Iq9/udWSKwqwkhIEQgcTHXzLbZ930cKzOvtix9HeowU3392zculdx2M7Xt+WmE3XtvYNC3bmbT07heb0Da99COsixL4uB5ACZMgKpDnVNtx8xJwBImgfDCwRTqJMCIEbbv/XwaH85WnnEEOStEovdCBBEBcbltvWMIJrMAHS0UkcJ7Vy3DNEqN8NYbcby8fH97e/3y5Q/n5yeUIoyllnAKC2QaEOWhqdppz6qu9Y5Ey7Ko6jCOZoYE/9yyvVdFqTp8fn5GCBZMxFK7mqqCcxwkvmDMDtA9aq2au9u9qwKAMLt56z3B1VLKfbmnXGzf+uvLm5piAAZkMk8Cnplml1hULTWOhwOqWoj3vQVFTqYYALo2U/QwcEMggsJCTNo13NZ1LUFdNZsgZgoZIrB3BSjMbNYDspECgHh5eVH182kIdCdwBgwQEXJs7fby8rate3qh9d45ZC6zAnvXUaZf/+X3395e/rf//T/2bf3d7z6J1N72vvS2N6riCPdl0z0AKMIPy6v3kJxsesNdHj+1DhDi6q4KZIjW923ftkBABqKoAoRxPCuIcEjeFTLhI1srj7G97bf7KlTDArp7U9cG1s7n8cPzh/k0d92X233f+315/fbzt799/Zu6tT1u121ZDZC5jFJrMDHzQIWRCTn9TxApHGodqcr5aUYmZDHASMjtaE1cH5SDNI4uLGE216Km3RQiujtRoSIK2sHMj0zDbGhb23++vuy9ublp3/et9Zbs6aXvt21Vt9Z3MwWE2/0mgWl35NYjjBkpjWRNm7XmHQEIqUqZ62iq7jtYJw8pwkxqtq7bfVu7aqin7KWHUy0esS4bIhqEQxBiqbUOZyJGpPtyT8UKEGdRMc/j169//+23v5VSiAoBYQAQIZMcc+Eg4i9ffvnl85e273//7bdTnf/46Q8TnWo9f/rXP3WM221FQw75/tv15eWGgdu+NejDUzE1UwiHZHPIMAyPEvtIXy4hafhuZgRYRABCtYNjkdmsh6qQwMN+bxxqrs5kBaopALyHZcIjIgARl/vi3QAoZYAZZzPUMk9T3oL7tq/3Bbzuvb3dvv/tx59LZSInIimFWRCJmNgdgALQ3CFs2w/b/ggbxkpMl6fz3ryZ1aGEmnukNSM8UK4IP58/ffz4cd8Xj/BDhhpBZG5DqbVWM410t8Wjk8pbdNdOLIhHC+2A/2jMAJCIiISpq4rwaZ771rZ9BzWuIKUgGqEjHDMW3xsDiUiGDJo2d0DitMFBgHmaNJw9kDmYclA+DXPvHSKezxe3DSFNotC6urmaIhEXMYhaKwsA4LLc/vM///zrr78vtR7HLTEShUVaP5zmy9PTZRqm7b6s221d158/f67rum97CL/e7uv69v3bDwhgLvtmfcenS+lh9TScP55/+/bNPYgRezDxQYBMD+o8utLEZ99bxoETAJJjoBTBBIgDxmkkBrJwsHhQNXJWY25EREgHQzxBSMRt296utx0DAiCggzHieRhb6z9//jyMuJCIaFlWNf3rX/7z9v3lX//132qZkTDvjxSrmBkyOoah+0PAeaAA6N+/f7teX/fdMp6VDLUrvktPEfd9F5FpkjrAsqiZtTAMZEBFzC5YVSPc1IMO0GgaxvP5vLVFIQph+oI4oQcKMYa/f9lhHDHAPczMIx7Z7IXwiJCphcxUxBGxAhUWCmvbbm1nZhLWAET0iJxbjETeUit/OF5kibIvyxowTyUCWm+BSIc+sQG6Y6zbSuHjVJn558+f7p6RWM2VgYgoANxtWxsAn04XqWFNIyIdh15fX9dte319XdtePpzNelIMRagUAbBhqq9vt4+/fCij9B6mAQQK0FwPD6d4CAEeRhTsbiKVGBGcAompDoW0EQSXygEMjOiIHu6B6RCJHi6Z54GJeOr7Wdiabz0QyYEcNCJqHfat3dd7qULBRDgMVaju23a9v337+vXl5fW//ts4ljmwuPdtCyQUKgHYVCHBagBkIkRTO08Tqf/2208AB4TIHsLT2wpzcERpSOFurr3dx1qHKvf7lUKEi7uBhwzSW9feRQoz1aG48TAPtRbVQoFJJvY4+j2LAxWzNDbI3ArtHrGuq0R0DREONXfTACY213GskZcRIoAhAnAQo5SB1bqZeQiz0/EtwQMwhMWbLve1lhrqwQGGCLjvi5rVUi1czUk4DAiQkAH5tt6Y5b/+1/9rqSWAkCEz9NKbgAVrGbqqWby+/mzLTYh++fxl2VYiWu53INi29Xq7ny4n6xrQ3XyaaT6PgTFOw3mcCPz0dKoj3W9tufXjxErZ4DvuICLZ4nk4AUZEKYzg7kaQ8/cOEEhBSAH/qGDer4MspbNezlHj39/ebupx1L725ePl+en87//r/369v5n7UMeh1tYaEhHS9e1tvS3zOI/DAADTMJZ5VvM8DrMirLXubTlABI8AGIcpzAmhDmMSyAk5JPwRVlBKWddVijDLcluF4HJ++tOf/uXbzx+v13XbO0V4V0OsUuZhPJ1O4zDVOhKHe8+rDwMzjSLxdlVFliRdxcMt1o5ZqWnv4zhu++puIiJDFc5UOuj9kHO1iFoZIpiLO1r0nHAhIDMDRdtaWgxiQKi7HgTUUiT/YE5gk6MsjONpRmaHkCIRYR5t9/PpudZha7sHwN7UGz6k+xmeqKoIDoitt2Xbmejjx48fPnxwdwv79vKjfiinp8v379/31t0xHPJaEy7TdDqdplJHhV5q7f1Vcp5jZhmjPU1TKYUQPSAj6eEgaJuagioVAQQCB+8OSITo+OjiIzyEhTBbdHvHSN/e3v77f/9//ny7W+/MfJ6fP0z/ZWH6+v23t5ef7iZ1fH7+cL+tSCo8rrfXeZg+f/58OV+KFO+63ZcyTcScJui5jjEkPNwNAdIcwJWIgQXTNI+IMGDZezB5SirMxnEUEdO+be35OQYsHy7PArWPdr/fK0vXXlIzvW7edcVrHaon9yCt/OKwYcnF9X6m4JFvZY89hvu+F0J3TwjQTAFEykGcIqJmHR1JRu1BKKpWBiQStZZ+XchYTrKtG3tkKJObH+I8AA9jrrq3PBS2beOCLALhaV0RAGYuPDEXIhkqq2nheodr7613TUvsvTVCYuaPHz+ex3J7ffvx48ePlxcROZ/PAL7u231ZXn78aK0h0L7v1q1OpqZ/+c+/PV1O58sl0MwwzOuJhR+ZlAk0D7USEhOKVOLDYqUAuSJAEMBxyyez0QOBCDmnvHGUT5DKO3zQwLdt+//8b//r/+v//d8Boog8n89PX36ZZ2GxX3/5cBkZAX6+vdUScS7aVQjK01zrL58+fpYyBlZ36G1z4VIqEROBme37nnWNuyMEAdZate1ERAhFyAwLi7VOyRdnyJ0DR/CEny+Xfd9//ny937fWFJH3fSViiONpMLNqB4jedgQgKchs7kySczAz83AicvPDi8LMwnOsx8zadngg9JuqMBQW06TjQWBkEMZ928BNICC8yMRVHMPs0Pww81CrsxQR7Qc0X0px17EOQCRDqRjLumz7JlBLIAs5QFclOvxwM95hGkeMGIaRObZ96T1yYNr25uFMzESLmxKUcfil/tJ7H8fxfr+VUorUfW/RnUXWrQsLRLjh9WX97etPnCM8BEuMyOOWs+d456SbWRkKRcjhbY9uAG6hwMw5Wk4nmXePMiQEOtbQu/VFbuXU7/4f//7v/+2//bdpPhPA73/36/npcn5++vL5yzAOv3z6vN3e9n273lZ1H6dJtb293F5/fCU8TU/PUmcg9jjMqKZp2tveTUWYAZEZCdWMAb9cnoX5r68vRNRAAdAde3R7mES+e+25u2of6mAeLz9+3O6rHZF6XUQSp80c1Mf9HvEg+4twqdK1ezdouazB0fZtT7zGIXJyn5X7kP2DKQqbdhIECTM3MyQUoDxpVBXCWYQIt72PIiLFLONPHR8WgUyER5vCIiUc3RzIs3eZpql1Vcguws20yOjuXTsHYQ5LQtV2MUaEeZp85KQ51Frv97v2TiS3+1JKff5Qlvu91rpt2+vbyziNZqFdfVeSwki1spmKVCI283MZW2sOVof6/PwkydeGxyg6aywWAYB9byeZz/McrQkhInnarB9OwvkLdHcITPUI/BPHJtdWa+1/+f/+LwD4f/+//T/W5f4//elff/n02a0NwzQNI9Q+1wmBdl1b292tdX17e73rDiQwjIYyTOO5lm5KXEphM5iFWKS7CQJBFMobSOMISOKElTOMBMKTUoaIUkrb9+Sn927329a7e6A6MBGoEjPAQW6Og0xHAAdUEe61lstl/v7zh/aW0famgAAe7moBQcxVSm8NIGopH87n0zi83L66EyFRPJCJlKRZCEuifRAYxB7welukju/gSByKphCRIrKtay41dzPTQGbCZMJk44XEph2dKaAcdxwGBBLWWpHs9fWHnXUax0AIyDUdLDIMgyKZ2fPTp1L5/vpiqmqGiKf55BARWEqRWkz1w+XMA1MJ4enGW28dbAxzwCDkeZ4l74VhGNIaOc2gDCJMI6D1jUhLBnwwYEa1Mh3qrKSDEkUctdQ/iq3Hlb8sCxX+L//z/+VPf/rTy48fH87P53kSPlEIeLAIEro7OpVS3X3d2o8f3673qwb/4V+IiXrbQp0QUey2vW7bDoRSrLthN0IETtI9PF+eE9Ee6xDQmsVUB8FIw6sgbNrzDCgydG3bukXyyTyckCTBOYxQeAi1RdgCLBwBE9/4/PEJMDQh+oB973HITOKgHpkOw2jutQ5SawjXUsODRboBdi3HpAsESBB7DoYB+9ZFpJstbS94tLGJAUHEWCoANFWHQEhLINKm4gFAqeYLM2E2c5JaSgVkAEw7+cQmAQzCwZQgtCsJ5HAkBW0pUjerXbfvP34Q4ul0aq2dT2eLQBKf/HK5fP327WxahlLmas0xtC/r3/99MbAy8zRO2/q4Cunxk97AzFxYjChNCQkwgITlve/75593bP2ff7JM3rbtt99+O5/n3//xj8z84cOHcRhKKaWwN1iXZZorEXn4MAxt35N+Pgzj59OHoHquJwnWZjts4zj21pZ1zaMwPLBwEAFSAEQ4EZdaHuqG3QNqqYiorh7BUmodm/a8qe/LFRAHEXNnLgQHL9E8aqn+MJXIU1eYtWs+KFXb3/Z9VwR0gwhAYHN1C2LOzGxzcNeIlEqYzDMTNe3euwcurV3OJ0QMjyJcSnVz7VpLVQtHD4+v375epnkch/w6+767WWVJszgpknzoWqs7997M18R0aq0BNI0yTIMBLMuaTR8HMHJawz4/f5zqyMJJlSMER0AkZtiWNbt4DzczqTUJw+v9XkuVWvd9771DABOjBjsO83iZRwk0DzRXbW2B++tN8NAqaTwE4/+YrDFHoLt6mBs9nnXKbEyIzf/B3M2L7120mRDGjx8/tPenpy/j8DTUYbxcnk8nYQQI4KMZzvIOIJZ1/cuf//PLr7/84Q9/6B8tZIRSNCgIcuumnUQ6+yJTnefe2r7vjAyIuSXmeV6XLa+kcRz63nbtxGyt7b0DHcxCEZzm81TGH9+/Y2FwMzdEVPVaDnzkfd9k1EuOsQPi5eVqcdilAACRgD5EGMC1jqqWaYy9m7tOpYzj0FoXFvOABz21iCRgcT6fl+U+DKPHZmYsvC/7XIZ93xOtLaVEHnIQzIwBByKa8z+IXPdpMGnee9daym7aXZMyWokZKQBMAYBVY93u0zTgoaz0cH+3di6lMNE0jUXKMAy9NSLStlvE2/W6rauZEdPe2zw8jwNfzlPfDQF0M47opKZ4GK+t65rdQS6LiFBTDiQkpIKBzDOhOVoWCvGgTFoEvw/tH8PmfMHbtv788RNleL6ckeU0z+fTqSIChJn3HFdSxoocbMn5fB6G4Xx6fvEtSHbrHFJEAGPrjSHbeuCcQdnhKSKVkUmEi0AV3CCIUKQMguRoXCsXcgSCYagRcLmcRHicpvvrEkDeVQoSICKNQyEkDX2fWLtHmBOzaVcILgIRiEd3aWbLsiBmVkF2GDSO47qulNY9PVztdDq9vr5FaBGOQHDDCHdrezddpIzCDG6FyVXBYuBKD4/FfKQOoG4RkO8eANLEJsvBBPbGgRFQDWAaDQVMS00hZxBD2+9ddVna68vP8ExmPA/TKMwJ7wrx+XxW1WT8jsO0rxtYjHVYSmkvL9ft/vcf3yOQ0KEAU86q3SO4MmjOa1m9M4Vkmvz7HZcXYkS4W2EhQpIABSIKsICIQLWDo/Ku1sp2Eh72wO6+rut//udfArAOM9ZCRbJB94fBATEnWzm7S0Q8nU7TNKv2g3WT1gUQw1DGUt5eX9wPxCyh133bFA6yKwrXWpNnJcJSigf2val1JDA3AAY/CA6q/Xpd1Kw3BQRGCY93D7D35oMexsnukb4NFJYp0aqaHU/v3f8hED9+mHmaJndnITB282EYLpfzvu/MlPYqIqxq9/t9HBlAauWAIAZiLIVLeRrHweOwRs6PpGbJ+YzDU+SIXS5FAKC1pr2IIAaw0N72bBOIMPuz1veXl9d17aUIAiFiNxUzJuJCe0/mKokUhnANj3i7XQFxmkdVW7d1b+s4VY/QvXNQ7/tyfdPu17dNiqTVRK1ifScCSan1+5GTGq8sY5CiDvJQKHhEEBJhWtDkJeiBx2vO2iUfxPV6/ctf/vLy8iJ1LOMkpZKwu+/7xh7xWH9ShNJkLScvcaAY+YK3vXEpgwzYTcZxHMa+78dnO/oqAIBxHNve8sD7kUPT3fbeAVkItbcYSzrZWm/uxszrtr2+vpTr9TScHycTPFQ3Bx001837j6kxAXTvraUbuz3Q/FzZ7x3x+0MYhpEITsPovRPRp8+f7vf7uqyqKlJykggAzJKgORKYtgj0CCYiQtNY1zVvwwO76QoPj7Fsw+/3ex62EdFaL2UsVfbWIslIjyJYVVVtHMdpupgphDXtBmHuhCRMA/Lr2w3TjZMIiJ6fn5Fo27etNSD88OEDLvH1z/8OGNN4uX+/mepUyr712y3zpHoFkAEJSZglS/Ws0WqtgiSIDsCAAEHoHEgFIXZ3IKYIIJbEKMM9Fc/v5X/Wan//29/+8h//IUMlLlxIKMbCiGBmRcp78wiAjmCe0QHyOPz4ft/absIZkoChvt5uwkJl7G4p3oMgBiBGJJZi58u5a3t5vSPw6g0cpqn0bq1rIXYMLKQeL9ebSFHXFiFASHjwSAEIET2QAFJgBQIRlGGWEFLYLIRoLPVOKz7YXblD8tzKtrr1Rpx0HjQzBkBhQnp5++lu+75v256etog41CmCtft9ecvgzlJqa31b2zQNl6dL3rb0UKgyS9e7qrKwgzGksCryJe7dqjkj7L0REyN1Bc3+nREQRYpQbQHq4GDdFDps+/48DTlVcGtmvciAEeM4ariFA8A4TeM4/vnvf133LkTzyEMZOoBqFCnjIADS1Mxdu0oRApBpGIZxlFLyPJ/GQQDVjRCkAEBgIlWHVDB71/wQlk0ypcOnWf4Nb29vP3/8vN/uF6njMImUeZJ5wMKUDIWEiN4PA0SMwPeaZtu2+23zCMnAF0AgjAhCJBHYHQEVHw4cAaGGiNM43t7ubiAFk++Urv/pGscZDOEuCajuaubEPIzDtmyl1mQAERJgEBG4pbA23CHgPJ+kcNd+HkeRgtc3gCil7vsG/8SmL6WoaVfliPfVFuFZDLW299bzfzTzWkvGUamqeyAKgLFQ77rv+7ZtZjpO43tiT86jwiPjBc6nuQ5iGswUcMhQ8/XAO00ePe8iEena9m1FQKzkcZgJu2FI9K5f11XVai0stNyXLjaNBfCANvOV9dbGcbqcL4RYa60fyrYualZK/fTlc1v6vuMgpG1j5giXeRj9iOSLYailoCBhIEMwA8IxYn6ItxAoCcqKABlJ+Wiewt33beu9I+EwjKf5cjpfyjSOdRQqDESEEBAPXB4R8p/e952JkRARWzOzGIahlpp7EZEA7QBjEXJmxywAEGoRETVa69fbMk3jOE4dHuwaxMPpgHJvQD7lrItLLefzWVC23h3jsLbBICIGNjUi8ggEmOe59T3nClKklLK2tq2Luxuiqbo7C7/b/MkjDTlRUO3dPeZ5/rH+MDN8+M4lqSf1S0yFOAeIVkqBCYmptTZNExExEyLc70stw9En1oJkgCGCSLXWmjufOQCi1qG1BgT24AEgQKkDBuS4moiYRQLd3SP+8tfffn7/9i9//MMvv34qtfRm66pEWIrUWrftoMn/8suv93ZHAELpvQ3jIO5MEljE90IwiNxc3dzMZZwG99AIMC/IVcgNCFgAyALJAJCCEzNEEHQMNCLkR7+dsou0ObDWaymn02ld23x+piIU4OlCIYxgmBPGQ/wEEWyq673VMg9Ddfdl2YBlnucIV+2AhgRhvq3LvueYBY8Xppq+yuM0rOvq7iwCCFykIEBAMxVAh2NKzUJNO3MRqcw8zSMXDgDTrmAJIRoFBZla0igYiRD3tr3c3vbe3PXTx49jLW3l5NlN47R2Q6Ts1+DgpjlGzMPo4W3VvbVl3yBCVYVEISycgnq3x+AnkB2BW+8eQSxcAADMA5HnqRJ6LeBRh3J6NIbh0d2QkWodiCBCScIjjixcLEZwBJyn0bGcwsO9xa65togge0AeaD6Nb9cXj/7Ll1/Ol/N6e73dbmomdRinizCY9c7wX/i/vr69eHflnrK63vtYqKGsC4LHeTxdb29dXUrS+HtLUnRvABBHyO3BIMAMCXK31E5GBDERoj+Ik+Hh7uuymFmplUudz0+n04lF6lAJmVAI0gAtfehcTR8APU3zKdmnrbXXl1fAhJHiHz3aw0lRVYdhIJJIOluEmX3Es6mr6rZte9t37aaZQGdFJN6prnF8zsyIO51O27ou93s3dXALAwiNYGGPsK6AwCKFZd3WiECA+22tMpxOp/ttaa2nxkSkbG3ftq1FhwACDBJEFCbDIKIguu7ruVQ3LywIpqqMlJOlxx47kDCR8u4vkhUIMUH4MFRz3LdOREjQe3NoHJLO4gAOcHjvmln6X2zblqRtd4e07w9E8Ef5cVxUiPTrr3+Aj1+W2w3JSq3C7GZu9vb6en768Hx+hlAAnudTHYY6jC/fvltXfFwIDFSYnp/Ofd9uP3xrBccqAMCEQShc3F1tryIMTMhwGJ3gI1AtiCA1qwAHkRwfhEbtPYH7btYt6jgnoURYSqnMBQOIc/QWcZhPhrsL8zgN+75f77fr9e379+9Up2HoiPGwVAxXMzUpNdfWPJ8DYFnXoZY61PE057t3d4S07AoAKFXAj3XshwaGj74dQnvv6960hzvioSISyDzUrOWhOhKCgjFzAJATAIa7mU7TeLlcAPB+u0dETzA+oLKEmYe/3O+RAx6zcZqG05mZ03Qpx0rvfSWnYd/jDoVH5/vwSauEka64y7rN8wwYiJ7mu7n+WA6LDTr+QiGSte/lQcHo2g+UBxzioIWn8iXXLqOUD3UcEZHDY3g6yWmYLxezWO53pjBTdY0AAhqGIdwRUE3neRakLImk0G7bCb1OsyAEIBEXRER0FiqECFAY3MIspbLORMzlHbBBxIfhyYEj762VInWedNkBixQCAiIqLMJi6iwdgpgkSTfEmbMLZk1VX9YbAf34+fOvv32dpqfTZaaHDrOUkm6k7o5MiFiHsmqTOtSBfvn1Mw2y3fpQBxmH1nZALLX2vQWAhiMyHGoRFkIMZYxAbstm1jtpBHBAIUHC9MQKiiBPJW4wtTDvIEERDh7h9uH5Mo1zni7bUDQZHxbTPH78+GzqP378aK2l+QwVLAXRo5ay9mBkqeRq2ZQ4hDCBuXY9YFbzY8ofcbvdz+epFG7Lvm8ZH6kiwIwAxQw0AMyQKYCSJQYHlgaVCiBzkYhAYI+uphTODgAWcUyrjl6eGQiZed+Xt7frdDkDM5QK4ejbnqSawmrm2qc6fnz+GBEvLy9ENNba1rWrsvCv0+/H+fbyej1mOESc4+Q8pogPQBwe+Wnvg5oEeY9bDA46R3pszNOEhLd1CYChVq6FijwgU8t96GkX8jBW3LZt2zYzu96vEHhd70A4jdPlfC712Nm1FuKUHrAwq2pru2NM8xR9Hcdx731dlst4VtXWehlqQmtSRLeGREDEZiLl4/OzoP98u96XhojJLE0p7ZG9goAIxKQKQeAI4aammWRmbm+36++mT+fzRIhJxzif524egO4xjFVEmGKaptSvzvN8vsxmmsolMzMMYQyzo49L/48EXR7muRHHYYY5dY3aWocA976ubZ5OjtERfNdC0Jtu20ZMB0lVuDcTkXGaVS3yroEwjwjq3TypHAcif5A4AIGIHQiJf/vtt18I5/Op9RYdUrm2r1vhYzDTte/7/unTp6xP5nEUIgB4fX0d66RzfP/5ktRkJOJ0FiiZ1Z2svbwKiRDRzJkPeP0AppGyukrwZhzHYRiWrf14fS211GHAImbaextLpfQZYnA3A2+9J4/2fr/nX8gkry+vXfWPf/zjWM4sKCLpJ2juhg7CAGTuvXdnDiYuBCFMFN0hoLfWIfyYJscxVSziEBAxDAMAbnub5nm+fHi7rwcJGRAgHKG7MbFTasQgEILQEVIXmVYchHBfF7Wnve0evtzXPAgjWN3doF/bsgAA5jTX3Od5HqQEc0cFhIAQc7BQt3ecAgGRjzRvePitHQ51RPf7UgNVVRAjcmJI4QHuGJQcwnXdiHld18v5PM2jal7WM2DvbgAAgQiUqVtISCwUDqp4UHzJTIlJA+o4/8sf/2Xpe0DUWtXcIoapOCXPLET4dV3WHz9++eVL2qcXIibKme+ybExymmbxw7XRmbyIUARghHuK7B5V1D8whQQ24nHkuFnrzSCmWjzgx+tta3qZBiI+TafKVEvlwgChoaBBiBjYt/22roBgB7kSLuNzqxoKhYdwcu0NQsYhJa+5vgNsbVtABGWQ4RGpFbuWND9Kw6Jm4R6M6SIBBHjwNfi+rOu2D0OdTwOBNlOUimAY+Uke8fWHxJSIOeGy/JgIDgS3fdvud1Wz1lR7BAEyCRWpqhbdEKDtewIc19dXDBfhWsvlMrbuphoY7zNZyKhZwpQXJGdBiFOFQMj3+96RsnxKb4i9dRHBAAMDwFKElHvvKMRFINAttGutyuyE3PdwdUJi8sDj8ilSdzePqFIgHCAQQ6QUkT/8+sdv1x/MUqRuuC97V99FxqHSy+uPdb3f72+32/12v2WQu7sv+04RHz9+fH19u92WKmPOYby1VkUGKUlTAAR3S8yTHj5d74vpWGQQx3HVmrBIKWtv375/JyIWYaaBy3maa61IAegPqzpblmXdNjOrtabG+nw+Pz09SalBkvJLJ7GA1pqZ5jGZKFfCSEkG167JWELEmsYyEdkAt20DNd337X631r112/t2X/Zlffv58uPr14Ip5Lf3zZM9iB9ZvQyA8rCkJzo8iYn56ek53Ndl680IR6YJQCLoAQ9RbrYcz+UmbK1///7y+vrGImqWvSk9Wqp4cEPywQ51yD+VTz4hqNabP8J5ckyZde3h6fMwPHqfdeZPFi2AhmBDxXmQeSgAqtH3aO69MI7DwCJSqFRiAUZHsN7X5/MZ3SOilkophvOodRqGadu2aZqQ8OXlxczcY1mW6/X68vLinrw0f3o6SZZ7TMRI4BktH5aFeRojE6mqu6X20OwIuXyfi0FAqYJMb29vFjHVmrdnB+/hAklKyyQtba3t205MOZcGgFrL6XTuLdZ1JSnvca+Q+u/8JHBQLovU9NeINKMFAICnpydm+fbt27bvOaUnovM8b9tuXSsLM0sp27oyAtc6jsPz+cm9x+HiAO/nR57/pmqP4XqGMRHRy/11vpw+fnjatkVVCQvWQAdCQWZifNikRTz4F+M4ns/naZzDXzMqStt+Pp/vy93CKg7ZHufqgchhVfSuKVWl99N6s+l0SXglHpvH3M169ulZkAGiqSFHWoLte5M6IMRpHgCKWXTFoDEAPJyAp1qljABhhgEE4La3bVnBfRAe67A3DceAtCGK+301i2EcPzx/2Pe91gqBb2+vqvr09GS935f7OExPTxcAkFoHcBdAcjDTqGmP6aqGkOnIh0I6fQrh4VDoHr33vfdhGodal317fbuKlEfmHqK7mzfXLFvSuvOApxEMY+37KHWaB0T6+fOnqUspHQwRAT17CSIAIHcPT9QD3YMZAwCRXE3D5mGsWoahWhgiFq7MlLrKeR6PiLYijFPSD0V4GmprSJjlM7inLVEQIwOaB0KmDFDhMg61dSei83waCml3YnDzpuYeUiRl0+9qKgCY5tndA4BLMXAqBKDzMH3+eNmaLcvqodYbomDA5gsLYmCzMAyWgqm2IAqIbdtqoUHker2nh0ciCGvfA6AgihEhOTo6uJmCI2KAt66yycDEIg4GaAAoUPK2cbOuzbqlRisJUgdwaOrmhThKLFsDQkI2N/PuHuP8oRaapJRSWBgeeoLz+WRqBFirXK9XyU1/TE7A3MIeP0z0TgB/P4ffD1tTW5ZlWZbPv3whLm/ffyz3hYfZkUsZxnEgxHVb3RXA4p89yhCBmUkKy1QHJlrXtixLGm5zdg6MbqGqwzC908XgYWOZE5sHD8yv1+v17eoEdRgizbPAqfL8dL7f7gkb9jDQA1N1s9RqJex5fCpACI+Hu7CI+IEJE+T4vJTWW2ul1uHLly/Xt21/sCrM/GF6ckSwZipHcmjz0bu2fvaPnz//9W+/pe4UAMw6RCCAGyICCxICklGJ3A+35c4lprkiOVKYeUZ0ezreIhBz652PSxMPHPhxv7fWgJCMgN4zWry1A5hVs+jda0XEsCCicBOReBQ8VARbm6eilW7XFSBqGYY6bMu9t75e38rnz+mj3lsrpYzD6GqZRyHuzu/tCVEas3s4iwhTer4SgT/Ioll2RETXvm17qXWoQ+/6dl2IJAIjMMJ7713VzUvliA4QGZtGxKUUGSoQMnF4aPf7fTsU2ECBHICEGEcQF6RQ5HguubYAABECylCv16t3barN/ZDaeGAAGz/NH7a2r9tu4IiM2XAzZyg5IREfxBJ8/AcC3IyQMrQNIqybMQaEuW3bFjEx0dPTU2+RAcSPEgcAKInwOVrO9fru3ta7vd3uHz9/+PLr59NlzsEUPGiS7oDofBhiQECIFO163mdAGKQagIcyZYATUgakJL1G8uqDQ+NKnDshXQUMEAN772lNkh/2nR8bAPYw6HYzJCqFsJSIAEQWKkPtqgWllOLRtGf5wa52++03Nb18+DJPkwgvy/J0eUJKM1eQx0jyeFsUQugBKeoij4Ry3o+bxKK8taZq43iaT1NAvN2u6iA8BlMlZERVM1VmSf9RIjRDAKh1GIexSHG3sFAzs1iXXYSZBQJBuOsDJYfY9j3raEQMd3cLiFKLmzmiSPnx+lOYpBQ3TZ9FYmRmNXt9fV3WVdEBQYiQQagawmJ9af1cxqkMt33DwEJyuH+YR1OihyyWkAgrshKyyDRNRAyQQnjJABwAp8x+RIjw9+rzPbPpKICIWm9uOg4lHzYEkjMxpUhOted4Jm/Vpt6dREYiACQRnOfRGzIXEUp3/zpP2bObaqgxi7sxMGLO3SPCM3nZHFsupoc07X2UhIiPfJ6a0je3ZqqEGOoE5IbmzoV8dzMFpHCTHn27/twX5eHp8nFd9/vtOk0zAHTT27IcfKx/XjR+JPRBBFgY0+Gw+N4kuvu2bYh4mp+KyL6vr6+v7i6MpdZ5ypkopA8ioiMWJgTEUkqp5QDl1DzAwzNAAR5FdFiAehFGJEQJhMQUUn2f/hyIqGrTOKpq7w15SiZPbnd8BHQtyxIPF8yISMI7Yxr/ODMN42ABrpaOc/AYIdF7NAviMAzjOKLFMIxi7SBBAkJErTVbjfc39G4MBg+a6zuwzCyIEGDmx3slZDUNDXcnxG3dwSG/IyEu27a25m5t35Do6ePT50+fl2vrqqUID0QiPFQWiuiqYIrDMEcAuEF4gGhv4URACEhEGVaQN9C7a2Ze8cfzyefvBgCZszdOU5btANFaJyIpBQDbuqGH9ViXu27b9e2mCtM8ZaWUz0SYgHIiiRAQqh2PJjeLvCNJ4j3jJGssMzuOZcJ1XZd1pTIN41CngZjcIgm47l0EIUqtIwum9x8i9N6btkQrrtcc6EopwiTLfYUIQUIgZmrWU70TESJFTY9oQtVai5q6RyB1TeF10JEF4rmkzudzWtTlcjtaBwCRwqXM8yxctGsrpZYCAKWWjLNT06Q3lSokchoRCaBVQqdjhOBmVutAxO8E4mTCZHGdz4of0VTCRxYWBJkFgnfX9d5YiPZtGIYe/rYs4RgWgOBmphZgbuGq67I+f7hcLqfbfWEmQqxFmmsoFcEiwnxYkjtk1eIiDId1Plasa2vhjggiRCzWDRHTrOr9Q6r21na3nnVYa30Yp8v5tGzrOFQvsO27aYBQDHJ97U31P//PP//tL3/78PH5j3/4Qx7VX79+FSlCpAQcIAAaoIEmRBEEDghAJIk6vAstD74KwDRNUoqqvr7eHHiQgkVMAwAEUJCOrMNwwqi1lAIOgMBZn6nq7XpT1W1TVat1qHVEoFLLkREDqL0jIph7VwRS7QEeQupOTKXy7WUFoGkcI+J+195tmkqotrZD4YE5hStZ0b8DPABRSlnXpS/ra0Ik43iap58/f5bCAXBf7/lNh2HYm73er+NYf/n4ESuEAzo6GMmhGQGg+/2WNyAzJ/sjHnb272eDh1u31togZ1UjdETAWqlwyWFHik67YwAx5QkRAVyEIoZxIiQsUCprN2QCdF0XBJ4uT/lvZRAsGBBiDjUjgoAASEiEuIUDugiKDIvvhITkqpaZZPmZS6lLV3MspUSQdluWpY5jnQsz3+/31vogJ/y3/6lHxOsbljKMU2/t3//j//jXf/3Tl0+fP3786EYC/8MPpsO8mWZRleMqeIfeAVT1fr8PwzDNE0S8XW9v9w2LIIIAMTMwMwRClCIRBOjDUMtDfxRB/TCj6IlwmmuKb9zV3Yehupu2w20r4Z1Sipn3pkyAjqaNCFVtXdeuh61FwoPpIeyhhJhNWWttWdb0ryvC5JGhatefP/3h/dBau16vy7LclnuWIJlaneBQa+1+v17GcZ5mDwAPIDjNJ3BKtCvdNM2MmXpvuXzb3vLg8Yf8ASmIqNQi3cwUIGrljAfHADWfzqd12f24PhIrFxFurZl5220cy+V8uV5vre1SUIjX+3YDqkPNTuIgj4AjGlBkIYcOYUqITFyEk4ciVQCJe1q/Ut5iCVX6w0gMEfd9Z+YiTEhDHdDDat9X1svzxy+/fPzl91TrMI6vb99++9vfvn//fp7Pl8tTOKdOGCLSISj9cyBvVjqsm46OKR6MWyKapgkR1239/uM7MBcpRGklwo6I4EUYgMJzQUsaye5bi0jsuJlpHSsTf/v+7eDDdFPbk/eRQIt5i1QbubfW3XxXrePg0UhEu7bW1b21JqW8uwpWkSJiEK212/W2txbuJAxIEUCAjOTuO/huDRECoGlnosvT07qtiSynnqL3TsypDrjf73kFn8c5IkTk6flJ1bTrPE8PHpWrQqkFGdWNmbvbYfsGkUmcaeqSzY26ArogDaVqb+4+lMJI275zrShSEEvOTJYl3L98/sSM375/v96uz8+XcZ6+/vxRXl/P5zMRtr3fl6VW4XIIIpC4ipcizMiFwcB6W5dlMC11RkwUNrJ7HcfRzN7e3vLozWYkd2wRgYAIKyJts/W2m8N8fkKWrSuJDPNcSkXA1lqRGoGC6pinNUBOexE5m533mUPe3qloS5Am1/X1+na9vY1PH4pIHQZkCAhhqkSFJQtl5rQntt763na3I03ZvDNXB1i3zZdlqO00PyEBEZRS7/0eETnkX65LHjyllHkexhE/nT+PdXq7LZvuiLRs6ziN7wcDDSMiWN/DoXcjZGAWltSuRfhUx0BqZhGAwplRu/YmtRDR6XSa5/l2uyW4XEoRZiiFuWzbYgQznRCgP9CgOjAgpyoAEJCQKoOG75EyGRIMj2ZaUSDYc16uzdTS9BYMg8B3RfMEwIhoWRfrnaXsezNzDGh7a627t21vBrjsTYaRmFVtb20eh9aaqW6hglMAABiibryVItM0nYYR3H/eNndYehuMz/OZqHp088OYJAt5ABARYUEEN3c1EOEqZtu6b8va1KOWWj4Oe1fFjaWM4/zhwwdEvC2LWkzjJPDAhBDB1NDhnc4Rj3Cid7DhOSPdjAAAFjtJREFUXTCds7DvL2/dY0QkZhEhYhYexnFkZnTEHAG1bbtbuHbtXSHeeThETAi0ruvf/va3jx8/+ad4fv4wz/NR7QqlaREAtH1nIiL6w+9//fLlUxlmQlzb9vHTBQDWRa0rsxgYALgdFB0WFj5yaZg5lWrZ227bvq3bPE+Jhfbew10jAuByBJYeo7fEh4mo7RpgdR4fVQMApMcVT9PQmrc9aq3MhEWAGoyTJZoCyMJj4fM8D+PoEWauqto1T4K9tWTkJd9PVauUhqxu6bzFzFIYAoi49yYslSAi7usKTIhoAOogw/DxdFr3vbm6dTz0nm4a26Zw9mkYWBiVEXnfG+Nax5FlsH1/X1jjOOb828PBjvGRup3Pp9bajx/fMUpmH0/DiNx3c2YmHn794+8zq+N6vW7LnnwsBwA3zzTtpMzmIA8Rc9qc1pduFpE2srGs27I1LjXFhoiIBExUWJjI9RCAL+vNQRNTNXcmPs1zOqKZeu8uzLXI58+fLpcLi7TeAkBqQQDmIiLz+bzuu5ghQBnP8/mjWUOAj8/Pzx8u277/8LdwN/KApIhBtrC11Cyn8nxFJmbmKMkzJ8TIqQtLrYP2rq6ZkZR47DAMaVXQez+dL7fl6mFjxHmcJJt4JDxGdcEUw1ABYZpGjSDic50goLW9qwZAHYd5moZCbkGEvXdhOVwSwtve9tZSa3Wa50GK1trdcmbipombRkStoqbqxgT35c7MVUoA7GoezoTnp+dlW7dl4cMwAXPRvF3vrj4OIxJ1dy+0t6YBT5eT2wG8Lfe7+z/4m9p1Gkc3X+9LKbJt63/8x7//4fd/YhkB2dxLrTMAhFt43xsSeECZBkAQx0AzJAr3d1Jv7tGs2cMtYZsw94cWPgK+f3u1iDqMh3AHD42077pD076Fs7uatSD0tLgNYKLyuLfv98VUPzw/DXV4fvqIUowxdUAozEC1DoGo1qGU7EC/vb6cni7elnkaP54/bL3ttw7uyEfuFxLmzMbMqfA7/GZmYUrMqFYvfF97SkYfXVtCX4bM27ImlzIHRwexEUDBmrZYsbWdBzHTiOxy3FXDnaR4wHJf3IFZgtlUQwORihTq4GxQUBhqlbEO7i4idRwcQu+bmUEeUAF735HBw8ADLBDA1dW07fs0VxQkkwjFAPBInI+ZlnW31T6UYR6nnLFEHOOBpN4jsZTStW+32/l82gHCrK1bPKoIU8N8+0Lqni+9MrtIeKj2Zbm/vPz8/Ls/IJeuht6B+v1+//nzx/3+ZuGbNgZyN3nvfeBhVZBqstzlEEFEpgdH+/1yvF2X69u9TCWrEEJyMyL0sL2tYbtbhxAPE6GAYOEiBQAybKyUAoFm0buO8xNwb+FkWpiHcSgi27Jv65r/XI6NAXDX/na9//k//joK1N8XGmK/b69vbwBIQKaW7VTy4h95ZkcLwszLuhLbgARHJmonzgFRxEFIwghXVRJOkXFSWE/znFwaXVRITG0Df3lZtrUlUJwxliQpYWjp+09E2rtlbTsOujcp/Jk+zMNQSp3nQyF4muZ934O5iDQ3/ieOLhN3U1UdOH2XYdv2cS51FNs09BBjAsAwVneNcLNYluUdlzqA3wezvvfeKMZx7KqFBQk1w0rdH3cOhvu2bdNpHsfRWCGgllKnsWtPbPbl9XuZRovYtv37z6+32499661psEHmugARkyC+k/cPrJke2tHEUR7sGN/3vZtO04yIP1/eiHmeT3UaaxkwPB5Mra6dIpLtCQAshcKzb45H/mIEanczWDcnHmQQ8/1IzgXsXf14zdF625Y1OV5DuHZbllVOo1Bp+/r177+1tskwwCEuDUQy10Sq3B3+yUvHwkzt6fJ0Op1e3+7h8MhUDlXNtZuHsT1CplLCpG4vry/qNtbhPM+Xy/nl50vb7TI/9d2b61hKAO6tiUhGAz8Gm7hu2+VyQQBz112vb1e6AFEZx4GZVHXb1n3fe2ssMoIkQdkhIoCJ1Q9G7HHqhBHRh6en1l6MQ4Ddbdu382UmolqqggFEV825JwIQ8eEYENC0I9g0jR8/fNjXVZuGmYar9lKFCfft8DjOzU+IkM5nlDA6nM/nr1+/Xm9vLKXpfjqdni5n1RYIwMDEQy09tXaI2dj/w5QbjjH4g4AGqZsyta7amU/rui3rerqcBilICGQACA57t0EozbQCABmQKIARoUiBdytAgDDsTe/bZgSBIYyAnFK31rqZpTyhlNKb59UMEYMURm7rfrr8Ustwe/txvb0ZRCjtvffW8g5y83R7DAgEOKiCCNY6ApaPhZnXdU0vAwhyTRRADpfaMCJ8z3smJkOIMAAsKOdhYqQ8yj1wOp8YGmicxul+99Y6ERMdhpTI6AippUEmN+g9aSNCzNtue9vV0t85JDGzMIOggMKsXTlAkCw6kiAxUGzbOg0nopt6MCVT2a7X16FUoWIQjyQNSJD5CO0lyoKyh7emtYrUuveOAJ6dLOE4FuYiRZBpqBXhQZdKhhKAWZzPl7///esg8vzxIxCyMDMHxt42QGEoQrRu+7atcvR6cMyP4KHoeswoAgBaa6nKFeOI+PH9NeMkIwIhum5hCEGBgaWCH3UmESVPsgy1FOn9f+Cpvb3eWu/Ah2FpKWMO1vKfLhklysRFpmm6Xq8AMI5jbqbz6dTVfl7vy9qQSNtaigyFl/va2i5S93Xt644YgPDh+YNMk6meymDmnz59AgBVU9N128wOUpCqTtMUdgwVmCWloQZhWetEREBT7UFSRoDtqss4jbybYmveSimpXM1ZeF4A0/nUw8AR5dB4jeMIgeu+3243eFeqlRIRaoaZq4aYl+/e9oGH3neR4oQM0HYbxgPcZ2ZG9ODeVOh47P4QmqcZ0PV6TW+OnKVqxPV+Pfs0jOPlcnGzpe+9sxRiRq7Yel/u99R3pIozzypmmsbJrX/6+EstFVRJuPJoqZnAUmXoPVozDKoySLKj1I4Z5IMmakcTAtb2/Xa7D8MgpZQ63q7rtmmp1cGICiCBRQSwAHN192SiBIS512EYxpEEmzYGDMhAFN/XbV03GljdHsTgg4H5zrUFxG4aEe9Rtr13D2AmqQJMp/PT734Xyfeotczj8PL2uq4rMgV2PJgnhoTM5I7BpK7btl3OcynSXjbyCIU6FKk1a3zmGqrDMEzTnBf3sm8EgIyhNtZ6uVwA43Q6X99uXffw4u4OsWyLhIzDqGpAoOoIMExj9Ka9d1MDKFWIcV1WIt72tu+7lBIAItK0ExIRmVsKpHp0yS7WIhyICZmjW1j01qdh0N6ZKaVcwpKxLu8rFR9F88+fP3vvf/rTn0Rk33eK8FJKrdu2qXZmWtd12Xe3hkTh1LXvbbvf5MPTB2K8b/fMF2FmB5jn8x//KKo+DiMh9O7qgYxMxbrvy87E4Y6RCk08gPUsgyLCTNvWRSig7VsbhmGcJmZW9de3eyA5IhCWwu5UaORRkDyCrSkABCE41mEYp5GYzNx6FCHV5hqK9rrc0o8lc7yQ2DQZmPFwGQEAcPesoGutqepxAGHxCGA6XS5Sa3isy7Kt27q2tiuxbGbNsQiP5/P9fr9u99hupjYMg6n9+7//+3/5L3+ap/HLx+dffvnl7XW57ysSEvG2bV8+f9R1y8P4fes/X57b3hS7lDJOU0A3xzQGanuDB0FNzbta4hrxyGFA7Uhk7h7Owkh4XzaRUoejZRuGQVXBQcPe2e7ZmiGAac8qHgIKkR3scfpwPi+3u5lnsR8Q3hvCA9AmSm5FrfXz58/3+11EAqBbJ3M3O82ao5/X2x1JCNkBEaSrCQsOxQ2aKSMEprWuI2EQFyzzjACMSK7R+46qEQGMrSlAsEOPsPAjCJOY3oHQVD0AxW9//j9J6Pz8zENFQlV9fbne7zfimjk1SJQziuN48xCWykwIJDRPM1EyQww9zLR3c0dF6OpTqcd1EaC9PzYZ4sPEm5lzgJXdU56jLPJ0uYT79x8/7vel98ZEtvd9393dus3zjGBDre5+u92y+i5SaCAz83BXb739/g+/yL/8vhTZ259fblojmKn3frveQlWq/Pj5Y9/2rLF0360bPHSIAOjurfdUO2a337uGYXZh6JHi0SSfYBKAgMlAI0BwXe7PZb48nXr3UgoElFJcPduX3FdMVJhJjh4IEIXFKSK8imPhDx8/vl5vCYQCgHtmR/4P2Vh58+aI2iGI2AN797fb8ulynmd5Xe9t3UqpiYoDBCILD836tu11qESCYAHojskcQQApBYDWtiICCztHmrsGHkNGpuMIhdQrPj5QMFPf9W9//vOvf/xDKZWqMIlpvF3vvdtcGQtKqQiEBAYeqszkEEWklhpmtRTE6H1Pkfm6rIBepCBytD6gqJvtDojEGX2eFln4z62DiOQc6b2xQIDL09P1ev358gIIppZ2xUGo5kDY3YhZBKZpen19tUc6RsKeQx1koHEYxlqY2TyJX4crSx0qIqzryozWbVs3KYWMWlOuJfPlXl5fLpcJAcKdODkGVkTAHZHCAyld2sgskEKSXwWIAQRoHsu2QVitcrlcAHjbGgAwshVL+4mwY7yWnhjEzESAGOYRmhOmCD+fTm/XW1fNeyZ1LQhHHqCHpWzN3QNi29Yy1GGoBtC1b70ZHEWFag9PWx14ADQyjuxuyfp31wAEB2Dy0IDQ3hGJiTuombm5MDsAciGPCA8AcYskQMLBfMeIuN1vP398JeGnj891GpAFA5etXW8rUWURKRk87gjoGH6YY4VaV8BaBCG29f7y83UcTyJi4Uycgptl2VvrDczMpmm0Y5ae8b6HLWB+mN77cQYc7igkzNNp/vljBQAETJXsuq6ZSxYQgSDCFHQ6nbIsy9r8YLAwFuRxHDEwg+zPp8s0LUC0bhsRDYU+fHgWEeECgcuySC3PHz6u+/py/TkO9eu3r6X+Qi6tbQNN6ZhQpcx1uN9X4EAMdwgEogwnhGQ4YLBhREDbmpSsZeN2vf34+VZKOc1zaw0QMyLP3WutQdD2ltYPTKS9d23jNA7DOcwxXLXxQ+Cans+IFBGlSKlja23btgj3ULUeLbMwILR3j/u2Up0IUJLPapmN5wBYSkngN8EmAIjM73MgAnfn0H1tp9Pl+fn55eUFDNDRwt287S2vF3of6eChrcFjuDYOf/yf/02GIU//7vbt5/euHQCIUJAEkAVLYQGCACmCYISO5HVgpCNcs7Xj0bh7mve/Lbet749zCNKsl1kymiaHZe+FQk6sE+uLiMvlQsmjeKy25HX84Q9/mOc5SRZE9OHDh/ezKiHc4x4MB8S8XCicwZiIRbT319fXt7e3+/1uqjnSSRf4/DBVZBqG/DrX2/Ugdh0EphLm4HEItjwyNsejEUde7vmvq2puHu2+ruv9vuxtT1WFu6spM2e6exGRWqNyHcdxHLX3tu95IW7ruq7NNQQOXY2IpA14Tmyzi88HmL8QlnfLLmtduwLA/X7fth0R123PKzvXgJnln3of7ORjTL+u3lUdLQiId22AeDlfEHHbDiplXqmEyeM7dEuPmid8HMe9bzwMa2vBgiPfl+3Hy4uQAAFLGnvAKFLL4KoTlmEaAGpKXQNctbtZLUUVTBUiWm+l1tuyrtuGjHOZh2HovSf2k1dwBDJLUjhKKXmX4YNEKyK1lLcfP67Xt8TWU72ZdIAc6r1727UDruT34UxW2bftpvYZh5KaBTNF95R6mWnT/u31p6lJKWvfEBGFzWxbtlomIPty+jwMpI9JaG5FNRPmL1++3O73ZbnniD23ewYZj8MgMlzvN2IBIne/3bdpFAg8Pz8RAnhQ5xwDA8BO4BimNrAgQt83JsJIWRztW4siTPL0dP77t29DGYQZw7ngNE15t+77nqknOYEQEcxaLYKJ0gJjW/dhqGavuXWT7tda8yME8rgZa60p3RNOwS0AAkoxiLfl+un5wxNexnHo7n3vIQUIAOPgvD8a/ngM13gapoiQMhYSVfv27bt2G+fTOxeMCL07kE9DlUpEqJ4mbLhv27qsGOEWEBwOrWsABMJ92wIx3fty9lKKMMu2tYgoZRgGyoWS/29+JCIiJCYqxLeXHzmofgAE7O5//etf/REHlFTE9/33AOQOq63T86WbuikTR8A8TU+n6WW5ffz43PY2ThMc1n4wjDXP0XngYThBgAw4TUNA/Pz+I1Gj44IuVRNiRkQidzD1OmRuLTDTvu/DMHc31Z2FCbl7/HK+tOYdEJHcjUjMNPe3QlQmDETCQKzz5KquaXPqRMelf7mMyzatm9ZStGkRaX0Ps2Gaah0NNoBLa5oPKiLShnSeJzNblrU3fXq6ZKvUWmPmtAtMFoKqESVfg9NdHIkSfS3JGQlb99t9vV/mkwgvy1qnMQK2tgSGvEeVvB99rfUIKDISkQVU5pfb9eePH89Pn4Y6vbvThntQ1KGWIuZtWdZ924ahZv5l762KiIgZAQR5EEHvHQGen54eZjtBRBkjkDxaMzXDUmqeRvl7AHJa4+dxHofhZ9cIYDnG5LkEe+8Jl7wvoMvlks/rfUKVv+Hjhw/MdL/v8Bi3P13OzRsSz/UkUohIMO+UUDUPDVBAY+FSxggjklrGaZ7rMB4Hqkfbd3+MpABxnme17f1Uq3WIcBbuqlykiJzPMzMHx742ICHMZPFImKOUkoUvEWlP5XBV6CzMXAGUiAkJIX73u1++fnu73W7hhoit7QVJEODIGPfr9ZbKdUFytXEeB6lBvsem6w4AtdZ1Xd9P/aOoOt4FiciyLLmBt4eUjZggkAmY+Ha7PZ3OtRYAJyQInJ3XdZH3rj7vQXr38iIppaI7BC3LRszjOBauImJqyGBu5LLvyV/f1u3e94YIHoHIdRgpUxsydRfMWt9Ux3EippxjvJ83iFBrCYd1291tHCszLeuqbnn0RlioPT9dAL31DsKUbqIPiOR9upc/2Si95xHTI+lzWZbr9e1yOv/49tNV6zhIYUKhQDczV7BDM8Ms27abmZoChTACIPEyDHQ6TXWo4zhKqcuy9N6ZKMNUszQpUp6enn78bOu6lFIAQ2oFiHmYWtF93dyU6eIOSWzvphwH7woAze3EJQjdwsC6al6RKLxs+yAVEfbWCU2hny/DHz5/ehV2U2KS8gm6EmEZoDl5yIenGQHXbR/Hwd1P0zSOIxEXRsCowlVEVc/nS2t7PKaEj8X9D6dxUxORzKMiACJsjyp52/dpHKd56HvbljtRkDbJ4TY/nIz9Ib8MSEM9X5d2v29Ih917TgaSauwW+9aEybynvUeqZYQJMSzcXSFY3bdt7V2X3i7zkEOrvHN77/nUiNiREgVlxmRFNlUzpyAPwIhSJMDNgRDT0zeLevgnrVUurHeu4jvk23s/YM+I17e3bd8LEURsvbdtzbTSUqXW0lpzt77b29vtsP+RlCtjW1ai077TPEla/MBj2hwIpgergojWbc9ZgnsAWiBaqHbdtq1rZ46+tQV8XzYZRwenw58oEEm4AJg6bOuOlJJM2/e9lNJaIwdi3raNmcd5sG5CdD6NmCrfCENCBEIrDDiUp3l0j94MhDS8orDQ3towliLY3S/n09vttO+7u71X6/hPBM/jKiMHC4tADwADijw1m+u27/M0IYJ5N92Dwvfl/we7BXyn6lybRwAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<PIL.Image.Image image mode=RGB size=200x200 at 0x7FBA87B7D690>"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "example = ds[\"train\"][10]\n",
+        "example[\"pixel_values\"].resize((200, 200))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 217
+        },
+        "id": "-p7R9KP0yUOa",
+        "outputId": "c0487523-1ffe-4cb6-bfe7-dec0033a5d67"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAAAAACIM/FCAAALGklEQVR4nN2d25ajOg6Gf9mEpKqnuvfMrHn/B9zd1V2nhAC25oJDgNgcjJyQrYtaKULAH5JsWT5A/0Ejak8AYAuD5fKk/d+xBav6s2UoCrj+pKjLR2urI/sk4Dp2/OsoZe9JVWhSRKQaqJQHOtHalhPXMTsADOJBkQksUcxpSQCtFfVvn2a9u6cJse08cqXZyWUB8PDh2/jKAAAkSNKrg7TPOv/pBIwkA9UWkqQAFdeXYgCMgUrYjjiPpCS0cxxVaV5/slYlBDBygEA7qqxRe0DuJx7HTrguacEoc5VoIgaDixRKAVDqyrsbjqGXuM8SF18NlZQMAJYBewZBVSWwZVKV0w8yPMzjZFKi2F0AqkybAYDoUr0arr4YFu7y//B6DHsLo1PwNH8dkK6wcT9f5TjGzJ7HFEESX1OmqKqFhjLa7FP1h5kAOucEIAWm/EZEEp9tky7hAqmPuEp2NCBFQKphSbEBQ2sCbgTiEwVghmWwYQAoDoeiaUZP+mD5SVkgSQcKj2dpfpCkGLtrotgwM8NUjTxnh6J97uaU4pwy9HVbG00SXzxHSZm7NLKr3VpBA2xRtzdky+JyJctkz6Abcjhrm/qLJ+d3puyQk27bEz51qwEDMHY3CrMA1A/WJQT3N/bj1HFdKlsfyLvaswB2Id2BYFFPOyL3k/NZxtdb3v6Az+5zbGGSHTCrupCRqhPiRPHVmWQ+myieitxzkjGuYDSiNH5ARA7NkLNfRPZcn8n+bqtHzdGkb8f9m1PCibKZAQ++odGaGQCgnjv/MHR0ExtzSNoDhL1la0pbdi2tiWjJ+MrHvQuTgvdMIZmqWRikCQCX59xctznG50jWXK6sQCC6MwhQxxXJzhTHcr7l27bkmkLyS0tlfl3P6pCWWWkI87I7LchtauAljRZTmtosM1AHNRn+mVwTqnrvKkMUQ5a1vgx6PmQfRXl6SonGykSn08sOYKayoFvEKl4Q62kimJ7Tj5M5a5XsNPnzdhavCgol2Oj/eSM6OfGCePq0BGD3fIK1yACovSEy7LhOacCg1DLwlHAvwRdFEn9Osz1Ozb8WyG1RoIkUiRUYMKauowdCddf3uH8y/aMR3D857jwsdcks2QJcwp7BpuqyEynUtZKBYTDATZqoL1WDbrMnx4WFJfmld/tkf3EIRlVh0tnCGpgcTaKXQFR1xBjMXNE3FlMqjTrR2wny695K0SSAiaPFYAnZLIPWB53SGUCZA2QtcIkpiAhNQMktwVAYXMdglDZl1XVerDA7BkBNsB2jYUkAAqzJoQZ5AiIQNXbOsD6CWhgwxAyAz6rqyZDi+pJ52s3Sx/GR5tq9AYGagABmCzvnxkY36WIwV6NGuv3dm/2m6vswc1bsnsVRqFfFEwiq1oHfiqYloZJBCZVtmJL+OwVbzs2ZreHv/xIHqUes6udfDSKuT3WWAKDpchXKPw4mN2yrhzU1/hUgiWr9AGDLLBfj9ZyOTkd9uVGEPFFSp0rmusJ80YMRUmpHdqFigICZpRkAgPQwPc72kiCQr7aSfPqcIFHXQ9ZRh3xixaWkHc4Wc8QnFsjQQyqpSZIId40EQg7LAprg5DmCiUUCcSsEYAuAdhFMLBKIRyERMxFxQLS/xBYcw0XigJDPsgDA6O8x7hkFRGEEhA9R8vQxQEiP9p3yKG4Sy1z9WVIqoiRUIoDQiKsDgPUNDq2SSG3s2EPnbOTLVXeVFdIYTy9QFiM7Lw+iMBUdmuwhQhSFyXzP8RFCFE2YmjxLeSmvEnkQTE4CBp+k7yoPooFpEJzkbUsYpKqypopJ5VnctoRBZqZ2+Sh7W8QBmQ5B6CzelMiCVEPyczLF4k2JKAjNc3UggruLglQXmwNCeSGsEnmQeUG6lY4cJUHqqbHzTj4J90okQaprzQOhUrhXIgii69GVeWdLhymCIPNdHQDoJDvaIwdSe8jsatXKhilyIMsUAummRAxEtRM9Zopwr0QMpF5vsuApW9HIUQqkVsiixiGTbEqkQOox1SVFk21KhEAWewgg3JQIgdQKWdbLoJNg5CgD0ihkYYVqPUsEgoogcpUADwEAyakcIiDNtLXFLVwp1yaKgDTTQJYWi4L2AHCLBEiwQmA9yzNDCiFwjWYJ0/L2jeUmkAiANAoJmaBxFGvcBUAahQRwUCkWOK4HaT0k5OHKNe7rQVYoBEAmVQGvBmmnPgeVSC5wXA3SrroMe7RitrUW5KKQQBs5C9Vba0FahQSWR8y2VoJcFgeEPlipUfeVICs9BHKj7utA1isEELKtlSDtpxXNgYxtrQK5rBBYMRFWaBhuFchlhdia9lnGttaAdBb4rWoMRHKnq0DaT6s46HxnECXi6hCaibYGpP0UFMFfRKRNDAchKYWAjgKj7uEgnc1G1to4v55WkwSDdFeZrQ5g7Z/VOgkG6ShkfSBO5vfafknoitPuHnwy+cLnv1b9PFQj3d/JdLu/Xldt6Riqkc66NSuU9+TdX/sVIVsYiO64iFgmmunlJXg9XKBpdX4ml1AnvP8KTgaHgXT3E5Bco0PZz9BwJQyk+yvRWT5U/PwKIwnyEdXZqsK90ewaef6uA5QcpJHuVmjyi0G+foWMkYaA9HZMkZ+KTPnfAaFXEEjnc4zleMSvb4v36gjwka6HiLWGA+HDj4WrLgNAessIBcdle8Lq5WXRpZebFsW2rOou/PZ70arx5RrpKcRE3BKI0x8LYq/FIP09tB1bY8vJothrMUhPIfKtYV94/yOdSbIUpK+QmJYFAGD98m2eUpaC9Fc+x6qzOsJPP5I5d1kI0ldIbMuqbqL/O8e8Fla//dNjGxYAgMz7HI1sHwSUHWeYzTKQ/gZtt+EA6H3GRI9lIP2zb7WVL8zbdA94EUh/x8OVqesFQqefkzpZBNLfW/pmCgGo+HtqScASkMEWlDcEAZmpPPcSkMFm3zezLAAg+zpedy0AGSjkphwA8Pt9jGQByD0VAgB4/zPy5XyQYTBzSxepS/D56dfJfJC7KwSgD/940GwQGpx5DxDYD68dzAYZKOT2hgUAdPYmVOeCDBVyu3fW9Ivx7stCzgUZnncXywJgfTH9TBAaWtZ9FALQydMuzgTZikIAend3SwNB7qUQAObNqZJ5IMMdr+9mWfB2GGeBDD3kzu+ne3MlzueBDA/cz0UAwLw7Ds4CuVLIfTVCX45e1hyQqz3978sBp3HNAbl6e9J9LQug4uNKJTNArhVyd43Q8cq4ZoBsTiEA7NvwYU6DxHmf70qhfNjHmgEyPHC7fNaI0MdgrsckyDB+30CdBeC6jzUJcv3Cty0oBKBT37imQBwK2YZGQJ+9NOoUyPX3G+EAzJ/ufxMgV+HiViwLAJ27YfAEiEMhm9EI8NYxrgmQa4VsiAPm8/J5HMTxjsrNWBYA+roY12KQLWkE/Nk+11GQjSsEoLzN0I+COL7cFgjoqxn/GQNxhItbqrMAAPxeP9oxkK17CABQ8VqVaQTEFb9vDgSUVfMfR+aiON4ccJPJJ0uF0++HsTeWKceL+SJNxVwpTN9etB/E9SqH6POzAoWTFy8Iud6AEHXm3zrxOrvrDdob1QcAP8h1hwqPCeJSyOZaw654NeI4tmUOH4jzxZkPCOL0kE27iAfEeXTTClkCsslWvRVnkV0vyX1IjTyeh7jL7M6/b1shThBXY/iIIG6FxHyXoYQ4QB5SIQ4QT2C/cV93gLjf2L51jmsQj0K2blnXIB4PeTiNuMPF7SvkCsStkMcD8Sjk8UB8HI8G4hgyBPAAle8QxNeD/6eAPABHv+juDtUjuHofxFdlPQTI/wHFcdIicwcncQAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<PIL.Image.Image image mode=L size=200x200 at 0x7FB95352B7D0>"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "example[\"label\"].resize((200, 200))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vp-fIQzvyTHL"
+      },
+      "source": [
+        "Each of the pixels above can be associated to a particular category. Let's load all the categories that are associated with the dataset. Let's also create an `id2label` dictionary to decode them back to strings and see what they are. The inverse `label2id` will be useful too, when we load the model later."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 49,
+          "referenced_widgets": [
+            "c71c1a959c43465e9fa63a94e72e0681",
+            "22d86a1d282448a190ff5f81d5086f16",
+            "108d9a14e9bd46088a1b3526e9607c48",
+            "f53b548093704a4483f8825f2c7eb3a6",
+            "2be22416cdaf4ab1a48145dcdbafd57f",
+            "31288c6294644f4c890374a08c7ec1ec",
+            "abd78c14e61843ef89699b2ad68d970c",
+            "3dbd784ed0724b7b8f3bf3b5d3d87919",
+            "3f71c41ea8524623b129bfafddf293db",
+            "90d261d919a54a91bacba98abaf6b35c",
+            "d82c57f3e3484f149b5a8d63c97ac582"
+          ]
+        },
+        "id": "Op_AGsW0y5C3",
+        "outputId": "59041978-a8fa-4aad-ef94-80013c58c288"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "c71c1a959c43465e9fa63a94e72e0681",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Downloading:   0%|          | 0.00/852 [00:00<?, ?B/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from huggingface_hub import hf_hub_download\n",
+        "import json\n",
+        "\n",
+        "filename = \"id2label.json\"\n",
+        "id2label = json.load(\n",
+        "    open(hf_hub_download(hf_dataset_identifier, filename, repo_type=\"dataset\"), \"r\")\n",
+        ")\n",
+        "id2label = {int(k): v for k, v in id2label.items()}\n",
+        "label2id = {v: k for k, v in id2label.items()}\n",
+        "\n",
+        "num_labels = len(id2label)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "2Rg_WraEzMb7",
+        "outputId": "9cf28a2d-b433-4df4-c961-c987ba242ef6"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(35,\n",
+              " ['unlabeled',\n",
+              "  'flat-road',\n",
+              "  'flat-sidewalk',\n",
+              "  'flat-crosswalk',\n",
+              "  'flat-cyclinglane',\n",
+              "  'flat-parkingdriveway',\n",
+              "  'flat-railtrack',\n",
+              "  'flat-curb',\n",
+              "  'human-person',\n",
+              "  'human-rider',\n",
+              "  'vehicle-car',\n",
+              "  'vehicle-truck',\n",
+              "  'vehicle-bus',\n",
+              "  'vehicle-tramtrain',\n",
+              "  'vehicle-motorcycle',\n",
+              "  'vehicle-bicycle',\n",
+              "  'vehicle-caravan',\n",
+              "  'vehicle-cartrailer',\n",
+              "  'construction-building',\n",
+              "  'construction-door',\n",
+              "  'construction-wall',\n",
+              "  'construction-fenceguardrail',\n",
+              "  'construction-bridge',\n",
+              "  'construction-tunnel',\n",
+              "  'construction-stairs',\n",
+              "  'object-pole',\n",
+              "  'object-trafficsign',\n",
+              "  'object-trafficlight',\n",
+              "  'nature-vegetation',\n",
+              "  'nature-terrain',\n",
+              "  'sky',\n",
+              "  'void-ground',\n",
+              "  'void-dynamic',\n",
+              "  'void-static',\n",
+              "  'void-unclear'])"
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "num_labels, list(label2id.keys())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FmMUQVLXLj_I"
+      },
+      "source": [
+        "**Note**: This dataset specificaly sets the 0th index as being `unlabeled`. We want to take this information into consideration while computing the loss. Specifically, mask the pixels for which the network predicted `unlabeled` and don't compute loss for it since they don't contribute to training that much. "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's shuffle the dataset and split the dataset in a train and test set."
+      ],
+      "metadata": {
+        "id": "7iCzXnImeWle"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ds = ds.shuffle(seed=1)\n",
+        "ds = ds[\"train\"].train_test_split(test_size=0.2)\n",
+        "train_ds = ds[\"train\"]\n",
+        "test_ds = ds[\"test\"]"
+      ],
+      "metadata": {
+        "id": "MC4OBSUret9N"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4zxoikSOjs0K"
+      },
+      "source": [
+        "### Preprocessing the data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WTupOU88p1lK"
+      },
+      "source": [
+        "Before we can feed these images to our model, we need to preprocess them. \n",
+        "\n",
+        "Preprocessing images typically comes down to (1) resizing them to a particular size (2) normalizing the color channels (R,G,B) using a mean and standard deviation. These are referred to as **image transformations**.\n",
+        "\n",
+        "To make sure we (1) resize to the appropriate size (2) use the appropriate image mean and standard deviation for the model architecture we are going to use, we instantiate what is called a feature extractor with the `AutoFeatureExtractor.from_pretrained` method.\n",
+        "\n",
+        "This feature extractor is a minimal preprocessor that can be used to prepare images for model training and inference."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PJJQ4s9S0Iag"
+      },
+      "outputs": [],
+      "source": [
+        "from transformers import AutoFeatureExtractor\n",
+        "\n",
+        "feature_extractor = AutoFeatureExtractor.from_pretrained(model_checkpoint)\n",
+        "feature_extractor"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "F7kWNDgSzzBo"
+      },
+      "outputs": [],
+      "source": [
+        "from torchvision.transforms import ColorJitter\n",
+        "from transformers import SegformerFeatureExtractor\n",
+        "\n",
+        "feature_extractor = SegformerFeatureExtractor()\n",
+        "jitter = ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.1) \n",
+        "\n",
+        "def train_transforms(example_batch):\n",
+        "    images = [jitter(x) for x in example_batch['pixel_values']]\n",
+        "    labels = [x for x in example_batch['label']]\n",
+        "    inputs = feature_extractor(images, labels)\n",
+        "    return inputs\n",
+        "\n",
+        "\n",
+        "def val_transforms(example_batch):\n",
+        "    images = [x for x in example_batch['pixel_values']]\n",
+        "    labels = [x for x in example_batch['label']]\n",
+        "    inputs = feature_extractor(images, labels)\n",
+        "    return inputs\n",
+        "\n",
+        "\n",
+        "# Set transforms\n",
+        "train_ds.set_transform(train_transforms)\n",
+        "test_ds.set_transform(val_transforms)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HOXmyPQ76Qv9"
+      },
+      "source": [
+        "### Training the model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0a-2YT7O6ayC"
+      },
+      "source": [
+        "Now that our data is ready, we can download the pretrained model and fine-tune it. We will use the `SegformerForSemanticSegmentation` class. Calling the `from_pretrained` method on it will download and cache the weights for us. As the label ids and the number of labels are dataset dependent, we pass `label2id`, and `id2label` alongside the `model_checkpoint` here. This will make sure a custom segmentation head will be created (with a custom number of output neurons)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qMdkERPg3ab3"
+      },
+      "outputs": [],
+      "source": [
+        "from transformers import SegformerForSemanticSegmentation\n",
+        "\n",
+        "\n",
+        "model = SegformerForSemanticSegmentation.from_pretrained(\n",
+        "    model_checkpoint,\n",
+        "    num_labels=num_labels,\n",
+        "    id2label=id2label,\n",
+        "    label2id=label2id,\n",
+        "    ignore_mismatched_sizes=True,  # Will ensure the segmentation specific components are reinitialized.\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "L5umptad3k3g"
+      },
+      "source": [
+        "The warning is telling us we are throwing away some weights (the weights and bias of the `decode_head` layer) and randomly initializing some other (the weights and bias of a new `decode_head` layer). This is expected in this case, because we are adding a new head for which we don't have pretrained weights, so the library warns us we should fine-tune this model before using it for inference, which is exactly what we are going to do.\n",
+        "\n",
+        "To fine-tune the model, we'll use Hugging Face's [Trainer API](https://huggingface.co/docs/transformers/main_classes/trainer). We need to set up the training configuration and an evalutation metric to use a `Trainer`.\n",
+        "\n",
+        "First, we'll set up the [`TrainingArguments`](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments). This defines all training hyperparameters, such as learning rate and the number of epochs, frequency to save the model and so on. We also specify to push the model to the hub after training (`push_to_hub=True`) and specify a model name (`hub_model_id`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6K0B3oqs3PR-"
+      },
+      "outputs": [],
+      "source": [
+        "from transformers import TrainingArguments\n",
+        "\n",
+        "epochs = 50\n",
+        "lr = 0.00006\n",
+        "batch_size = 2\n",
+        "\n",
+        "hub_model_id = \"segformer-b0-finetuned-segments-sidewalk-2\"\n",
+        "\n",
+        "training_args = TrainingArguments(\n",
+        "    \"segformer-b0-finetuned-segments-sidewalk-outputs\",\n",
+        "    learning_rate=lr,\n",
+        "    num_train_epochs=epochs,\n",
+        "    per_device_train_batch_size=batch_size,\n",
+        "    per_device_eval_batch_size=batch_size,\n",
+        "    save_total_limit=3,\n",
+        "    evaluation_strategy=\"steps\",\n",
+        "    save_strategy=\"steps\",\n",
+        "    save_steps=20,\n",
+        "    eval_steps=20,\n",
+        "    logging_steps=1,\n",
+        "    eval_accumulation_steps=5,\n",
+        "    load_best_model_at_end=True,\n",
+        "    push_to_hub=True,\n",
+        "    hub_model_id=hub_model_id,\n",
+        "    hub_strategy=\"end\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Next, we'll define a function that computes the evaluation metric we want to work with. Because we're doing semantic segmentation, we'll use the [mean Intersection over Union (mIoU)](https://huggingface.co/spaces/evaluate-metric/mean_iou), directly accessible in the [`evaluate` library](https://huggingface.co/docs/evaluate/index). IoU represents the overlap of segmentation masks. Mean IoU is the average of the IoU of all semantic classes. Take a look at [this blogpost](https://www.jeremyjordan.me/evaluating-image-segmentation-models/) for an overview of evaluation metrics for image segmentation.\n",
+        "\n",
+        "Because our model outputs logits with dimensions height/4 and width/4, we have to upscale them before we can compute the mIoU."
+      ],
+      "metadata": {
+        "id": "T3gr2e6ggAn0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "from torch import nn\n",
+        "import evaluate\n",
+        "\n",
+        "metric = evaluate.load(\"mean_iou\")\n",
+        "\n",
+        "def compute_metrics(eval_pred):\n",
+        "  with torch.no_grad():\n",
+        "    logits, labels = eval_pred\n",
+        "    logits_tensor = torch.from_numpy(logits)\n",
+        "    # scale the logits to the size of the label\n",
+        "    logits_tensor = nn.functional.interpolate(\n",
+        "        logits_tensor,\n",
+        "        size=labels.shape[-2:],\n",
+        "        mode=\"bilinear\",\n",
+        "        align_corners=False,\n",
+        "    ).argmax(dim=1)\n",
+        "\n",
+        "    pred_labels = logits_tensor.detach().cpu().numpy()\n",
+        "    # currently using _compute instead of compute\n",
+        "    # see this issue for more info: https://github.com/huggingface/evaluate/pull/328#issuecomment-1286866576\n",
+        "    metrics = metric._compute(\n",
+        "            predictions=pred_labels,\n",
+        "            references=labels,\n",
+        "            num_labels=len(id2label),\n",
+        "            ignore_index=0,\n",
+        "            reduce_labels=feature_extractor.reduce_labels,\n",
+        "        )\n",
+        "    \n",
+        "    # add per category metrics as individual key-value pairs\n",
+        "    per_category_accuracy = metrics.pop(\"per_category_accuracy\").tolist()\n",
+        "    per_category_iou = metrics.pop(\"per_category_iou\").tolist()\n",
+        "\n",
+        "    metrics.update({f\"accuracy_{id2label[i]}\": v for i, v in enumerate(per_category_accuracy)})\n",
+        "    metrics.update({f\"iou_{id2label[i]}\": v for i, v in enumerate(per_category_iou)})\n",
+        "    \n",
+        "    return metrics\n"
+      ],
+      "metadata": {
+        "id": "eZeP3LdtgBj-"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Finally, we can instantiate a `Trainer` object.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "aki6vBMbgHJ8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from transformers import Trainer\n",
+        "\n",
+        "trainer = Trainer(\n",
+        "    model=model,\n",
+        "    args=training_args,\n",
+        "    train_dataset=train_ds,\n",
+        "    eval_dataset=test_ds,\n",
+        "    compute_metrics=compute_metrics,\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "DPvhqbUVgIhl"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now that our trainer is set up, training is as simple as calling the train function. We don't need to worry about managing our GPU(s), the trainer will take care of that."
+      ],
+      "metadata": {
+        "id": "y7ebFys1gO25"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "trainer.train()"
+      ],
+      "metadata": {
+        "id": "MVTWgGeQgRpB"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "When we're done with training, we can push our fine-tuned model and the feature extractor to the Hub.\n",
+        "\n",
+        "This will also automatically create a model card with our results. We'll supply some extra information in kwargs to make the model card more complete."
+      ],
+      "metadata": {
+        "id": "I96TvX-KgT56"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "kwargs = {\n",
+        "    \"tags\": [\"vision\", \"image-segmentation\"],\n",
+        "    \"finetuned_from\": pretrained_model_name,\n",
+        "    \"dataset\": hf_dataset_identifier,\n",
+        "}\n",
+        "\n",
+        "feature_extractor.push_to_hub(hub_model_id)\n",
+        "trainer.push_to_hub(**kwargs)"
+      ],
+      "metadata": {
+        "id": "m8YuKExogV4P"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Inference\n",
+        "\n",
+        "Now comes the exciting part, using our fine-tuned model! In this section, we'll show how you can load your model from the hub and use it for inference. \n",
+        "\n",
+        "However, you can also try out your model directly on the Hugging Face Hub, thanks to the cool widgets powered by the [hosted inference API](https://api-inference.huggingface.co/docs/python/html/index.html). If you pushed your model to the Hub in the previous step, you should see an inference widget on your model page. You can add default examples to the widget by defining example image URLs in your model card. See [this model card](https://huggingface.co/segments-tobias/segformer-b0-finetuned-segments-sidewalk/blob/main/README.md) as an example.\n",
+        "\n",
+        "<figure class=\"image table text-center m-0 w-full\">\n",
+        "    <video \n",
+        "        alt=\"The interactive widget of the model\"\n",
+        "        style=\"max-width: 70%; margin: auto;\"\n",
+        "        autoplay loop autobuffer muted playsinline\n",
+        "    >\n",
+        "      <source src=\"assets/56_fine_tune_segformer/widget.mp4\" poster=\"assets/56_fine_tune_segformer/widget-poster.png\" type=\"video/mp4\">\n",
+        "  </video>\n",
+        "</figure>"
+      ],
+      "metadata": {
+        "id": "dFzJ8Xb5g1Vi"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Use the model from the Hub\n",
+        "\n",
+        "We'll first load the model from the Hub using `SegformerForSemanticSegmentation.from_pretrained()`."
+      ],
+      "metadata": {
+        "id": "QXY3erc6g8LP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from transformers import SegformerFeatureExtractor, SegformerForSemanticSegmentation\n",
+        "\n",
+        "feature_extractor = SegformerFeatureExtractor.from_pretrained(model_checkpoint)\n",
+        "hf_username = \"segments-tobias\"\n",
+        "model = SegformerForSemanticSegmentation.from_pretrained(f\"{hf_username}/{hub_model_id}\")"
+      ],
+      "metadata": {
+        "id": "gfbdz9Hpg9mI"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SQJkEqGxQwz6"
+      },
+      "source": [
+        "Next, we'll load an image from our test dataset."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "R57X_iNkqv6H"
+      },
+      "outputs": [],
+      "source": [
+        "image = test_ds[0]['pixel_values']\n",
+        "gt_seg = test_ds[0]['label']\n",
+        "image"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7m7IfMv6R3_5"
+      },
+      "source": [
+        "To segment this test image, we first need to prepare the image using the feature extractor. Then we forward it through the model.\n",
+        "\n",
+        "We also need to remember to upscale the output logits to the original image size. In order to get the actual category predictions, we just have to apply an `argmax` on the logits."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "8nNSSqEUBS2v"
+      },
+      "outputs": [],
+      "source": [
+        "from torch import nn\n",
+        "\n",
+        "inputs = feature_extractor(images=image, return_tensors=\"pt\")\n",
+        "outputs = model(**inputs)\n",
+        "logits = outputs.logits  # shape (batch_size, num_labels, height/4, width/4)\n",
+        "\n",
+        "# First, rescale logits to original image size\n",
+        "upsampled_logits = nn.functional.interpolate(\n",
+        "    logits,\n",
+        "    size=image.size[::-1], # (height, width)\n",
+        "    mode='bilinear',\n",
+        "    align_corners=False\n",
+        ")\n",
+        "\n",
+        "# Second, apply argmax on the class dimension\n",
+        "pred_seg = upsampled_logits.argmax(dim=1)[0]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oyHddde_SOgv"
+      },
+      "source": [
+        "Now it's time to display the result. The next cell defines the colors for each category, so that they match the \"category coloring\" on Segments.ai."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "Ky_8gHCRCJHj"
+      },
+      "outputs": [],
+      "source": [
+        "#@title `def sidewalk_palette()`\n",
+        "\n",
+        "def sidewalk_palette():\n",
+        "    \"\"\"Sidewalk palette that maps each class to RGB values.\"\"\"\n",
+        "    return [\n",
+        "        [0, 0, 0],\n",
+        "        [216, 82, 24],\n",
+        "        [255, 255, 0],\n",
+        "        [125, 46, 141],\n",
+        "        [118, 171, 47],\n",
+        "        [161, 19, 46],\n",
+        "        [255, 0, 0],\n",
+        "        [0, 128, 128],\n",
+        "        [190, 190, 0],\n",
+        "        [0, 255, 0],\n",
+        "        [0, 0, 255],\n",
+        "        [170, 0, 255],\n",
+        "        [84, 84, 0],\n",
+        "        [84, 170, 0],\n",
+        "        [84, 255, 0],\n",
+        "        [170, 84, 0],\n",
+        "        [170, 170, 0],\n",
+        "        [170, 255, 0],\n",
+        "        [255, 84, 0],\n",
+        "        [255, 170, 0],\n",
+        "        [255, 255, 0],\n",
+        "        [33, 138, 200],\n",
+        "        [0, 170, 127],\n",
+        "        [0, 255, 127],\n",
+        "        [84, 0, 127],\n",
+        "        [84, 84, 127],\n",
+        "        [84, 170, 127],\n",
+        "        [84, 255, 127],\n",
+        "        [170, 0, 127],\n",
+        "        [170, 84, 127],\n",
+        "        [170, 170, 127],\n",
+        "        [170, 255, 127],\n",
+        "        [255, 0, 127],\n",
+        "        [255, 84, 127],\n",
+        "        [255, 170, 127],\n",
+        "    ]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f4BzL0ISSePY"
+      },
+      "source": [
+        "The next function overlays the output segmentation map on the original image."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "G3HqZXyQB7gJ"
+      },
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "def get_seg_overlay(image, seg):\n",
+        "  color_seg = np.zeros((seg.shape[0], seg.shape[1], 3), dtype=np.uint8) # height, width, 3\n",
+        "  palette = np.array(sidewalk_palette())\n",
+        "  for label, color in enumerate(palette):\n",
+        "      color_seg[seg == label, :] = color\n",
+        "\n",
+        "  # Show image + mask\n",
+        "  img = np.array(image) * 0.5 + color_seg * 0.5\n",
+        "  img = img.astype(np.uint8)\n",
+        "\n",
+        "  return img"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-yEXFytLSkht"
+      },
+      "source": [
+        "We'll display the result next to the ground-truth mask."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vnSn2A2U0RMw"
+      },
+      "outputs": [],
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "pred_img = get_seg_overlay(image, pred_seg)\n",
+        "gt_img = get_seg_overlay(image, np.array(gt_seg))\n",
+        "\n",
+        "f, axs = plt.subplots(1, 2)\n",
+        "f.set_figheight(30)\n",
+        "f.set_figwidth(50)\n",
+        "\n",
+        "axs[0].set_title(\"Prediction\", {'fontsize': 40})\n",
+        "axs[0].imshow(pred_img)\n",
+        "axs[1].set_title(\"Ground truth\", {'fontsize': 40})\n",
+        "axs[1].imshow(gt_img)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "r3Chx4bXaCYa"
+      },
+      "source": [
+        "What do you think? Would you send our pizza delivery robot on the road with this segmentation information?\n",
+        "\n",
+        "The result might not be perfect yet, but we can always expand our dataset to make the model more robust. We can now also go train a larger SegFormer model, and see how it stacks up."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Just an approximate port of the TF variant: https://github.com/huggingface/notebooks/blob/main/examples/semantic_segmentation-tf.ipynb

I have used some text from that notebook as well as some from the blog post: https://huggingface.co/blog/fine-tune-segformer. The code is all from the blog post. 

The idea behind adding notebook is to attain some consistency in how the `examples` are organized and structured in this repository. Plus the blog post has additional points on the data labeling process (which is great) and the notebook introduced in this PR discards those to keep the content lightweight and more focused. 

Closes https://github.com/huggingface/notebooks/issues/267