### PR TITLE
Add tokenizer to language modelling Trainer examples

### DIFF
--- a/examples/language_modeling.ipynb
+++ b/examples/language_modeling.ipynb
@@ -727,6 +727,7 @@
     "    args=training_args,\n",
     "    train_dataset=lm_datasets[\"train\"],\n",
     "    eval_dataset=lm_datasets[\"validation\"],\n",
+    "    tokenizer=tokenizer,\n",
     ")"
    ]
   },
@@ -1106,6 +1107,7 @@
     "    train_dataset=lm_datasets[\"train\"],\n",
     "    eval_dataset=lm_datasets[\"validation\"],\n",
     "    data_collator=data_collator,\n",
+    "    tokenizer=tokenizer,\n",
     ")"
    ]
   },
@@ -1290,6 +1292,20 @@
   "colab": {
    "name": "Fine-tune a language model",
    "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.15 (main, Oct 11 2022, 22:27:25) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "397704579725e15f5c7cb49fe5f0341eb7531c82d19f2c29d197e8b64ab5776b"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/language_modeling_from_scratch.ipynb
+++ b/examples/language_modeling_from_scratch.ipynb
@@ -721,6 +721,7 @@
     "    args=training_args,\n",
     "    train_dataset=lm_datasets[\"train\"],\n",
     "    eval_dataset=lm_datasets[\"validation\"],\n",
+    "    tokenizer=tokenizer,\n",
     ")"
    ]
   },
@@ -1385,6 +1386,7 @@
     "    train_dataset=lm_datasets[\"train\"],\n",
     "    eval_dataset=lm_datasets[\"validation\"],\n",
     "    data_collator=data_collator,\n",
+    "    tokenizer=tokenizer,\n",
     ")"
    ]
   },
@@ -1636,6 +1638,9 @@
   "colab": {
    "name": "Train a language model",
    "provenance": []
+  },
+  "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# What does this PR do?

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Open a PR directly on the `course` repo (https://github.com/huggingface/course)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Propagates a fix for the MLM and CLM examples first reported in the course in https://github.com/huggingface/course/pull/432

tl;dr we were missing the `tokenizer` in the `Trainer`, so the resulting models on the Hub couldn't be loaded.

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
