### PR TITLE
Add links to the TPU tutorial doc now that it's available

### DIFF
--- a/examples/tpu_training-tf.ipynb
+++ b/examples/tpu_training-tf.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "At busy times, you may find that there's a lot of competition for TPUs and it can be hard to get access to a free one on Colab. Keep trying!\n",
     "\n",
-    "This notebook is focused on usable code, but if you'd like a more high-level explanation of how to work with TPUs, please check out our associated tutorial (coming soon!)"
+    "This notebook is focused on usable code, but if you'd like a more high-level explanation of how to work with TPUs, please check out our [associated TPU tutorial](https://huggingface.co/docs/transformers/main/en/perf_train_tpu_tf)."
    ]
   },
   {
@@ -129,7 +129,7 @@
     "\n",
     "For this example we will use CoLA, which is a small and simple binary text classification dataset from the GLUE benchmark.\n",
     "\n",
-    "We also pad all samples to the maximum length, firstly to make it easier to load them as an array, but secondly because this avoids issues with XLA later. For more information on XLA compilation and TPUs, see the associated tutorial. (Coming soon!)"
+    "We also pad all samples to the maximum length, firstly to make it easier to load them as an array, but secondly because this avoids issues with XLA later. For more information on XLA compilation and TPUs, see the [associated TPU tutorial](https://huggingface.co/docs/transformers/main/en/perf_train_tpu_tf)."
    ]
   },
   {


### PR DESCRIPTION
This is a super-tiny PR to add links from the TPU notebook to the tutorial document, now that the tutorial doc PR has been merged.