### PR TITLE
Update TF TPU notebook with public GCS buckets

### DIFF
--- a/examples/tpu_training-tf.ipynb
+++ b/examples/tpu_training-tf.ipynb
@@ -318,9 +318,7 @@
    "source": [
     "`TFRecord` is the standard `tf.data` format for storing training data. For very large training jobs, it's often worth preprocessing your data and storing it all as TFRecord, then building your own `tf.data` pipeline on top of it. This is more work, and often requires you to pay for cloud storage, but it works for training on a wide range of devices (including TPU VM, TPU Node and Colab), and allows for truly massive data pipeline throughput.\n",
     "\n",
-    "When converting to TFRecord, it's a good idea to do your preprocessing and tokenization before writing the TFRecord, so you don't have to do it every time the data is loaded. However, if you intend to use **train-time augmentations** you should be careful **not** to apply those before writing the `TFRecord`, or else you'll get exactly the same augmentation each epoch, which defeats the purpose of augmenting your data in the first place! Instead, you should apply augmentations in the `tf.data` pipeline that loads your data.\n",
-    "\n",
-    "By default, the code below will run on CPU so you can try it on Colab, but if you have a TPU VM feel free to try running it on TPU there. Alternatively, you can try uploading the files to a Google Cloud Storage bucket instead of keeping them in local storage and running on a Colab TPU!"
+    "When converting to TFRecord, it's a good idea to do your preprocessing and tokenization before writing the TFRecord, so you don't have to do it every time the data is loaded. However, if you intend to use **train-time augmentations** you should be careful **not** to apply those before writing the `TFRecord`, or else you'll get exactly the same augmentation each epoch, which defeats the purpose of augmenting your data in the first place! Instead, you should apply augmentations in the `tf.data` pipeline that loads your data."
    ]
   },
   {

--- a/examples/tpu_training-tf.ipynb
+++ b/examples/tpu_training-tf.ipynb
@@ -660,15 +660,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "filenames"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "dW5jDak11VBG"
@@ -733,7 +724,7 @@
     "with strategy.scope():\n",
     "    tf_dataset = tf_dataset.map(decode_fn)\n",
     "    tf_dataset = tf_dataset.batch(BATCH_SIZE, drop_remainder=True)\n",
-    "print(tf_dataset.element_spec)"
+    "    print(tf_dataset.element_spec)"
    ]
   },
   {
@@ -759,7 +750,7 @@
     "    model = TFAutoModelForImageClassification.from_pretrained(image_model_checkpoint)\n",
     "    model.compile(optimizer=\"adam\")\n",
     "\n",
-    "model.fit(tf_dataset)  # Note - will be very slow if you're on CPU"
+    "model.fit(tf_dataset)"
    ]
   },
   {

--- a/examples/tpu_training-tf.ipynb
+++ b/examples/tpu_training-tf.ipynb
@@ -304,167 +304,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "L9IijL2AnCi3"
-   },
-   "source": [
-    "### Stream from your dataset with `model.prepare_tf_dataset()`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "DtJMrPVonXHd"
-   },
-   "source": [
-    "If you've read any of our other [example notebooks](https://huggingface.co/docs/transformers/notebooks), you'll notice we often use the method `Dataset.to_tf_dataset()` or its higher-level wrapper `model.prepare_tf_dataset()` to convert Hugging Face Datasets to `tf.data.Dataset`. These methods can work for TPU, but with several caveats!\n",
-    "\n",
-    "The main thing to know is that these methods do not actually convert the entire Hugging Face `Dataset`. Instead, they create a `tf.data` pipeline that loads samples from the `Dataset`. This pipeline uses `tf.numpy_function` or `Dataset.from_generator()` to access the underlying `Dataset`, and as a result the whole pipeline cannot be compiled by TensorFlow. **Because of this, and because the pipeline streams from data on a local disc, these methods will not work on Colab TPU or TPU Nodes.**\n",
-    "\n",
-    "However, if you're running on a TPU VM and you can tolerate TensorFlow throwing some warnings, this method can work! Let's see it in action. By default, the code below will run on CPU so you can try it on Colab, but if you have a TPU VM feel free to try running it on TPU there."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-_uMLSSiHRU2"
-   },
-   "source": [
-    "First, we initialize our TPU. Skip this block if you're running on CPU."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Xvc_wpu0HiJJ"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "resolver = tf.distribute.cluster_resolver.TPUClusterResolver()\n",
-    "# On TPU VMs use this line instead:\n",
-    "# resolver = tf.distribute.cluster_resolver.TPUClusterResolver(tpu=\"local\")\n",
-    "tf.config.experimental_connect_to_cluster(resolver)\n",
-    "tf.tpu.experimental.initialize_tpu_system(resolver)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "LlFyGsACHri-"
-   },
-   "source": [
-    "Next, we load our strategy, dataset, tokenizer and model just like we did in the first example."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "OzkOZJZkH0ek"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "from transformers import AutoTokenizer, TFAutoModelForSequenceClassification\n",
-    "from datasets import load_dataset\n",
-    "\n",
-    "strategy = tf.distribute.OneDeviceStrategy(\"/cpu:0\")\n",
-    "# When actually running on TPU use this line instead:\n",
-    "# strategy = tf.distribute.TPUStrategy(resolver)\n",
-    "\n",
-    "BATCH_SIZE = 8 * strategy.num_replicas_in_sync\n",
-    "\n",
-    "dataset = load_dataset(\"glue\", \"cola\", split=\"train\")\n",
-    "\n",
-    "model_checkpoint = \"distilbert-base-cased\"\n",
-    "tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)\n",
-    "\n",
-    "with strategy.scope():\n",
-    "    model = TFAutoModelForSequenceClassification.from_pretrained(model_checkpoint)\n",
-    "    model.compile(optimizer=\"adam\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pl6J1EA5InGB"
-   },
-   "source": [
-    "Next, we add the tokenizer output as columns in the dataset. Since the dataset is stored on disc, this means we can handle data much bigger than our available memory. Once that's done, we can use `prepare_tf_dataset` to stream data from the Hugging Face Dataset by wrapping it with a `tf.data` pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "DeoeHixsnGip"
-   },
-   "outputs": [],
-   "source": [
-    "def tokenize_function(examples):\n",
-    "    return tokenizer(\n",
-    "        examples[\"sentence\"], padding=\"max_length\", truncation=True, max_length=128\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "# This will add the tokenizer output to the dataset as new columns\n",
-    "dataset = dataset.map(tokenize_function)\n",
-    "\n",
-    "# prepare_tf_dataset() will choose columns that match the model's input names\n",
-    "with strategy.scope():\n",
-    "    # Remember, creating the actual tf.data.Dataset always goes in the scope too!\n",
-    "    tf_dataset = model.prepare_tf_dataset(\n",
-    "        dataset, batch_size=BATCH_SIZE, shuffle=True, tokenizer=tokenizer\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "7T6EeVG2t1N9"
-   },
-   "source": [
-    "And now you can fit this dataset just like before!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "7AVwd5UpsYt-"
-   },
-   "outputs": [],
-   "source": [
-    "model.fit(tf_dataset)  # Note - will be very slow if you're on CPU"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-pAuOHsvt75z"
-   },
-   "source": [
-    "In summary:\n",
-    "\n",
-    "**prepare_tf_dataset() advantages:**\n",
-    "- Simple code\n",
-    "- Same approach works on TPU and GPU\n",
-    "- Dataset doesn't have to fit in memory\n",
-    "- Can support variable rather than constant padding\n",
-    "\n",
-    "**prepare_tf_dataset() disadvantages:**\n",
-    "- Only works on TPU VM, not on TPU Node/Colab\n",
-    "- Data must be available as a Hugging Face Dataset\n",
-    "- Data must fit on local storage\n",
-    "- If you're using a big TPU pod slice, data loading may be a bottleneck\n",
-    "- TensorFlow will yell at you a bit\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "xIhnkALTvDML"
    },
    "source": [
@@ -531,9 +370,9 @@
     "from transformers import AutoTokenizer, TFAutoModelForSequenceClassification\n",
     "from datasets import load_dataset\n",
     "\n",
-    "strategy = tf.distribute.OneDeviceStrategy(\"/cpu:0\")\n",
-    "# When actually running on TPU use this line instead:\n",
-    "# strategy = tf.distribute.TPUStrategy(resolver)\n",
+    "strategy = tf.distribute.TPUStrategy(resolver)\n",
+    "# For testing without a TPU use this line instead:\n",
+    "# strategy = tf.distribute.OneDeviceStrategy(\"/cpu:0\")\n",
     "\n",
     "BATCH_SIZE = 8 * strategy.num_replicas_in_sync\n",
     "\n",
@@ -600,7 +439,7 @@
     "id": "0AcBCIuGgYk1"
    },
    "source": [
-    "Now, to load the dataset we build a `TFRecordDataset` using the filenames of the file(s) we saved. In this example, we only have a single file stored locally. When using this approach in practice for large datasets, you will want to shard your dataset into multiple files."
+    "Now, to load the dataset we build a `TFRecordDataset` using the filenames of the file(s) we saved. Ordinarily, you would need to create your own bucket in Google Cloud Storage, upload files to there, and handle authenticating your Python code so it can access it. However, for the sake of this example, we have uploaded the example file to a public bucket for you, so you can get started quickly!"
    ]
   },
   {
@@ -621,8 +460,8 @@
     "\n",
     "\n",
     "with strategy.scope():\n",
-    "    # Because we create the dataset from files in local storage, TPU Node / Colab TPU will not be able to read it\n",
-    "    tf_dataset = tf.data.TFRecordDataset([\"dataset.tfrecords\"])\n",
+    "    # TFRecordDataset can handle gs:// paths!\n",
+    "    tf_dataset = tf.data.TFRecordDataset([\"gs://matt-tf-tpu-tutorial-datasets/cola/dataset.tfrecords\"])\n",
     "    tf_dataset = tf_dataset.map(decode_fn)\n",
     "    tf_dataset = tf_dataset.shuffle(len(dataset)).batch(BATCH_SIZE, drop_remainder=True)\n",
     "    tf_dataset = tf_dataset.apply(\n",
@@ -647,7 +486,7 @@
    },
    "outputs": [],
    "source": [
-    "model.fit(tf_dataset)  # Note - will be very slow if you're on CPU"
+    "model.fit(tf_dataset)"
    ]
   },
   {
@@ -738,9 +577,9 @@
    "source": [
     "import tensorflow as tf\n",
     "\n",
-    "strategy = tf.distribute.OneDeviceStrategy(\"/cpu:0\")\n",
-    "# When actually running on TPU use this line instead:\n",
-    "# strategy = tf.distribute.TPUStrategy(resolver)"
+    "strategy = tf.distribute.TPUStrategy(resolver)\n",
+    "# For testing without a TPU use this line instead:\n",
+    "# strategy = tf.distribute.OneDeviceStrategy(\"/cpu:0\")"
    ]
   },
   {
@@ -771,7 +610,7 @@
     "id": "vozfi3Xgzz8w"
    },
    "source": [
-    "Now, let's get a list of the underlying image file paths and labels, and build a dataset of those. Note that we're using local paths here, but this section could just as easily use paths to a cloud bucket!"
+    "Now, let's get a list of the underlying image file paths and labels."
    ]
   },
   {
@@ -783,13 +622,50 @@
    "outputs": [],
    "source": [
     "filenames = image_dataset[\"image_file_path\"]\n",
-    "labels = image_dataset[\"labels\"]\n",
+    "labels = image_dataset[\"labels\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ordinarily at this point you would need to create your own bucket in Google Cloud Storage, upload the image files to there, and handle authenticating your Python code so it can access it. However, for the sake of this example we have uploaded the images to a public bucket for you, so you can get started quickly!\n",
     "\n",
+    "We'll use this quick conversion below to turn the local filenames in the dataset into `gs://` paths in Google Cloud Storage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Strip everything but the category directory and filenames\n",
+    "base_filenames = ['/'.join(filename.split('/')[-2:]) for filename in filenames]\n",
+    "# Prepend the google cloud base path to everything instead\n",
+    "gs_paths = [\"gs://matt-tf-tpu-tutorial-datasets/beans/\"+filename for filename in base_filenames]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "with strategy.scope():\n",
     "    tf_dataset = tf.data.Dataset.from_tensor_slices(\n",
-    "        {\"filename\": filenames, \"labels\": labels}\n",
+    "        {\"filename\": gs_paths, \"labels\": labels}\n",
     "    )\n",
     "    tf_dataset = tf_dataset.shuffle(len(tf_dataset))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filenames"
    ]
   },
   {
@@ -895,7 +771,7 @@
     "In summary:\n",
     "\n",
     "**tf.data pipeline advantages:**\n",
-    "- Very suitable for data that is highly compressed in its native format (images, audio)\n",
+    "- Very suitable for big data that is highly compressed in its native format (images, audio)\n",
     "- Very convenient if the raw data is already available in a public cloud bucket\n",
     "- Works on all TPU instances (if the data is stored in Google Cloud)\n",
     "\n",
@@ -907,13 +783,166 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "L9IijL2AnCi3"
+   },
+   "source": [
+    "### Stream from your dataset with `model.prepare_tf_dataset()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DtJMrPVonXHd"
+   },
+   "source": [
+    "If you've read any of our other [example notebooks](https://huggingface.co/docs/transformers/notebooks), you'll notice we often use the method `Dataset.to_tf_dataset()` or its higher-level wrapper `model.prepare_tf_dataset()` to convert Hugging Face Datasets to `tf.data.Dataset`. These methods can work for TPU, but with several caveats!\n",
+    "\n",
+    "The main thing to know is that these methods do not actually convert the entire Hugging Face `Dataset`. Instead, they create a `tf.data` pipeline that loads samples from the `Dataset`. This pipeline uses `tf.numpy_function` or `Dataset.from_generator()` to access the underlying `Dataset`, and as a result the whole pipeline cannot be compiled by TensorFlow. **Because of this, and because the pipeline streams from data on a local disc, these methods will not work on Colab TPU or TPU Nodes.**\n",
+    "\n",
+    "However, if you're running on a TPU VM and you can tolerate TensorFlow throwing some warnings, this method can work! Let's see it in action. By default, the code below will run on CPU so you can try it on Colab, but if you have a TPU VM feel free to try running it on TPU there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-_uMLSSiHRU2"
+   },
+   "source": [
+    "First, we initialize our TPU. Skip this block if you're running on CPU."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "LBYH9-lXV2m2"
+    "id": "Xvc_wpu0HiJJ"
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "resolver = tf.distribute.cluster_resolver.TPUClusterResolver()\n",
+    "# On TPU VMs use this line instead:\n",
+    "# resolver = tf.distribute.cluster_resolver.TPUClusterResolver(tpu=\"local\")\n",
+    "tf.config.experimental_connect_to_cluster(resolver)\n",
+    "tf.tpu.experimental.initialize_tpu_system(resolver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LlFyGsACHri-"
+   },
+   "source": [
+    "Next, we load our strategy, dataset, tokenizer and model just like we did in the first example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "OzkOZJZkH0ek"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "from transformers import AutoTokenizer, TFAutoModelForSequenceClassification\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "# By default, we run on CPU so you can try this code on Colab\n",
+    "strategy = tf.distribute.OneDeviceStrategy(\"/cpu:0\")\n",
+    "# When actually running on a TPU VM use this line instead:\n",
+    "# strategy = tf.distribute.TPUStrategy(resolver)\n",
+    "\n",
+    "BATCH_SIZE = 8 * strategy.num_replicas_in_sync\n",
+    "\n",
+    "dataset = load_dataset(\"glue\", \"cola\", split=\"train\")\n",
+    "\n",
+    "model_checkpoint = \"distilbert-base-cased\"\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)\n",
+    "\n",
+    "with strategy.scope():\n",
+    "    model = TFAutoModelForSequenceClassification.from_pretrained(model_checkpoint)\n",
+    "    model.compile(optimizer=\"adam\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pl6J1EA5InGB"
+   },
+   "source": [
+    "Next, we add the tokenizer output as columns in the dataset. Since the dataset is stored on disc, this means we can handle data much bigger than our available memory. Once that's done, we can use `prepare_tf_dataset` to stream data from the Hugging Face Dataset by wrapping it with a `tf.data` pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DeoeHixsnGip"
+   },
+   "outputs": [],
+   "source": [
+    "def tokenize_function(examples):\n",
+    "    return tokenizer(\n",
+    "        examples[\"sentence\"], padding=\"max_length\", truncation=True, max_length=128\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "# This will add the tokenizer output to the dataset as new columns\n",
+    "dataset = dataset.map(tokenize_function)\n",
+    "\n",
+    "# prepare_tf_dataset() will choose columns that match the model's input names\n",
+    "with strategy.scope():\n",
+    "    # Remember, creating the actual tf.data.Dataset always goes in the scope too!\n",
+    "    tf_dataset = model.prepare_tf_dataset(\n",
+    "        dataset, batch_size=BATCH_SIZE, shuffle=True, tokenizer=tokenizer\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7T6EeVG2t1N9"
+   },
+   "source": [
+    "And now you can fit this dataset just like before!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7AVwd5UpsYt-"
+   },
+   "outputs": [],
+   "source": [
+    "model.fit(tf_dataset)  # Note - will be very slow if you're on CPU"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-pAuOHsvt75z"
+   },
+   "source": [
+    "In summary:\n",
+    "\n",
+    "**prepare_tf_dataset() advantages:**\n",
+    "- Simple code\n",
+    "- Same approach works on TPU and GPU\n",
+    "- Dataset doesn't have to fit in memory\n",
+    "- Can support variable rather than constant padding\n",
+    "\n",
+    "**prepare_tf_dataset() disadvantages:**\n",
+    "- Only works on TPU VM, not on TPU Node/Colab\n",
+    "- Data must be available as a Hugging Face Dataset\n",
+    "- Data must fit on local storage\n",
+    "- If you're using a big TPU pod slice, data loading may be a bottleneck\n",
+    "- TensorFlow will yell at you a bit\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR updates the TF TPU notebook with public GCS buckets, so users can try a `tf.data` pipeline without needing to handle making their own bucket and authentication and everything.