### PR TITLE
Move TPU dataset creation out of the strategy.scope() and add TPU telemetry

### DIFF
--- a/examples/audio_classification.ipynb
+++ b/examples/audio_classification.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"audio_classification_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/benchmark.ipynb
+++ b/examples/benchmark.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"benchmark_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/causal_language_modeling_flax.ipynb
+++ b/examples/causal_language_modeling_flax.ipynb
@@ -188,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"causal_language_modeling_notebook\", framework=\"flax\")"
    ]

--- a/examples/image_captioning_blip.ipynb
+++ b/examples/image_captioning_blip.ipynb
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"image_captioning_blip_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/image_classification-tf.ipynb
+++ b/examples/image_classification-tf.ipynb
@@ -184,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"image_classification_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/image_classification.ipynb
+++ b/examples/image_classification.ipynb
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"image_classification_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/image_classification_albumentations.ipynb
+++ b/examples/image_classification_albumentations.ipynb
@@ -281,7 +281,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"image_classification_albumentations_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/image_classification_kornia.ipynb
+++ b/examples/image_classification_kornia.ipynb
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"image_classification_kornia_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/image_similarity.ipynb
+++ b/examples/image_similarity.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"image_similarity_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/language_modeling-tf.ipynb
+++ b/examples/language_modeling-tf.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"language_modeling_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/language_modeling.ipynb
+++ b/examples/language_modeling.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"language_modeling_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/language_modeling_from_scratch-tf.ipynb
+++ b/examples/language_modeling_from_scratch-tf.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"language_modeling_from_scratch_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/language_modeling_from_scratch.ipynb
+++ b/examples/language_modeling_from_scratch.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"language_modeling_from_scratch_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/masked_language_modeling_flax.ipynb
+++ b/examples/masked_language_modeling_flax.ipynb
@@ -188,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"masked_language_modeling_notebook\", framework=\"flax\")"
    ]

--- a/examples/multi_lingual_speech_recognition.ipynb
+++ b/examples/multi_lingual_speech_recognition.ipynb
@@ -180,7 +180,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"multi_lingual_speech_recognition_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/multiple_choice-tf.ipynb
+++ b/examples/multiple_choice-tf.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"multiple_choice_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/multiple_choice.ipynb
+++ b/examples/multiple_choice.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"multiple_choice_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/onnx-export.ipynb
+++ b/examples/onnx-export.ipynb
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"onnx_export_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/protein_folding.ipynb
+++ b/examples/protein_folding.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"protein_folding_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/protein_language_modeling-tf.ipynb
+++ b/examples/protein_language_modeling-tf.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"protein_language_modeling_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/protein_language_modeling.ipynb
+++ b/examples/protein_language_modeling.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"protein_language_modeling_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/question_answering-tf.ipynb
+++ b/examples/question_answering-tf.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"question_answering_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/question_answering.ipynb
+++ b/examples/question_answering.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"question_answering_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/semantic_segmentation.ipynb
+++ b/examples/semantic_segmentation.ipynb
@@ -112,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"semantic_segmentation_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/speech_recognition.ipynb
+++ b/examples/speech_recognition.ipynb
@@ -193,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"speech_recognition_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/summarization-tf.ipynb
+++ b/examples/summarization-tf.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"summarization_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/summarization.ipynb
+++ b/examples/summarization.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"summarization_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/summarization_ort.ipynb
+++ b/examples/summarization_ort.ipynb
@@ -228,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"summarization_notebook_ort\", framework=\"none\")"
    ]

--- a/examples/text_classification-tf.ipynb
+++ b/examples/text_classification-tf.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"text_classification_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/text_classification.ipynb
+++ b/examples/text_classification.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"text_classification_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/text_classification_flax.ipynb
+++ b/examples/text_classification_flax.ipynb
@@ -193,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"text_classification_notebook\", framework=\"flax\")"
    ]

--- a/examples/text_classification_ort.ipynb
+++ b/examples/text_classification_ort.ipynb
@@ -238,7 +238,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"text_classification_notebook\", framework=\"ort\")"
    ]

--- a/examples/text_classification_quantization_inc.ipynb
+++ b/examples/text_classification_quantization_inc.ipynb
@@ -255,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"text_classification_quantization_inc_notebook\", framework=\"none\")"
    ]

--- a/examples/text_classification_quantization_ort.ipynb
+++ b/examples/text_classification_quantization_ort.ipynb
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"text_classification_notebook_ort\", framework=\"none\")"
    ]

--- a/examples/time-series-transformers.ipynb
+++ b/examples/time-series-transformers.ipynb
@@ -219,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"time_series_transformers_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/token_classification-tf.ipynb
+++ b/examples/token_classification-tf.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"token_classification_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/token_classification.ipynb
+++ b/examples/token_classification.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"token_classification_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/tokenizer_training.ipynb
+++ b/examples/tokenizer_training.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"tokenizer_training_notebook\", framework=\"none\")"
    ]

--- a/examples/tpu_training-tf.ipynb
+++ b/examples/tpu_training-tf.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"tpu_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/tpu_training-tf.ipynb
+++ b/examples/tpu_training-tf.ipynb
@@ -44,6 +44,24 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also quickly upload some telemetry - this tells us which examples and software versions are getting used so we know where to prioritize our maintenance efforts. We don't collect (or care about) any personally identifiable information, but if you'd prefer not to be counted, feel free to skip this step or delete this cell entirely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import send_example_telemetry\n",
+    "\n",
+    "send_example_telemetry(\"tpu_notebook\", framework=\"tensorflow\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "rZSNCjbiTJ0y"
    },
@@ -125,7 +143,7 @@
     "id": "bpMV3FjYX-Xs"
    },
    "source": [
-    "In order for TPU training to work, you must create the model and `tf.data.Dataset` used for training inside the `Strategy.scope()`. However, other things like Hugging Face `tokenizers` and the underlying Hugging Face `Dataset` do not need to be created in this scope, as they will not be directly accessed by the model during training.\n",
+    "In order for TPU training to work, you must create the model used for training inside the `Strategy.scope()`. However, other things like Hugging Face `tokenizers` and the `Dataset` do not need to be created in this scope.\n",
     "\n",
     "For this example we will use CoLA, which is a small and simple binary text classification dataset from the GLUE benchmark.\n",
     "\n",
@@ -177,7 +195,7 @@
     "id": "Ztn_wVn1rO56"
    },
    "source": [
-    "While preprocessing data you can often operate outside of the the `strategy.scope()`, but model creation **must** take place inside it."
+    "While preprocessing data you can operate outside of the the `strategy.scope()`, but model creation **must** take place inside it."
    ]
   },
   {
@@ -217,7 +235,7 @@
     "Keras methods like `fit()` can usually accept a broad range of inputs - a `list`/`tuple`/`dict` of `np.ndarray` or `tf.Tensor`, Python generators, `tf.data.Dataset`, and so on. **This is not the case on TPU.**\n",
     "\n",
     "On TPU, your input must always be a `tf.data.Dataset`. If you pass anything else\n",
-    "to `model.fit()` when using a `TPUStrategy`, it will try to coerce it into a `tf.data.Dataset`. This sometimes works, but will create a lot of console spam and warnings even when it does. As a result, we recommend explicitly creating a `tf.data.Dataset` in all cases. Remember to create it inside the `scope()`!"
+    "to `model.fit()` when using a `TPUStrategy`, it will try to coerce it into a `tf.data.Dataset`. This sometimes works, but will create a lot of console spam and warnings even when it does. As a result, we recommend explicitly creating a `tf.data.Dataset` in all cases."
    ]
   },
   {
@@ -232,13 +250,11 @@
     "# so we scale it up based on how many of them there are\n",
     "BATCH_SIZE = 8 * strategy.num_replicas_in_sync\n",
     "\n",
-    "\n",
-    "with strategy.scope():\n",
-    "    tf_dataset = tf.data.Dataset.from_tensor_slices((train_data, train_labels))\n",
-    "    tf_dataset = tf_dataset.shuffle(len(tf_dataset))\n",
-    "    # You should use drop_remainder on TPU where possible, because a change in the\n",
-    "    # batch size will require a new XLA compilation\n",
-    "    tf_dataset = tf_dataset.batch(BATCH_SIZE, drop_remainder=True)\n",
+    "tf_dataset = tf.data.Dataset.from_tensor_slices((train_data, train_labels))\n",
+    "tf_dataset = tf_dataset.shuffle(len(tf_dataset))\n",
+    "# You should use drop_remainder on TPU where possible, because a change in the\n",
+    "# batch size will require a new XLA compilation\n",
+    "tf_dataset = tf_dataset.batch(BATCH_SIZE, drop_remainder=True)\n",
     "\n",
     "tf_dataset"
    ]
@@ -456,15 +472,13 @@
     "    }\n",
     "    return tf.io.parse_example(sample, features)\n",
     "\n",
-    "\n",
-    "with strategy.scope():\n",
-    "    # TFRecordDataset can handle gs:// paths!\n",
-    "    tf_dataset = tf.data.TFRecordDataset([\"gs://matt-tf-tpu-tutorial-datasets/cola/dataset.tfrecords\"])\n",
-    "    tf_dataset = tf_dataset.map(decode_fn)\n",
-    "    tf_dataset = tf_dataset.shuffle(len(dataset)).batch(BATCH_SIZE, drop_remainder=True)\n",
-    "    tf_dataset = tf_dataset.apply(\n",
-    "        tf.data.experimental.assert_cardinality(len(labels) // BATCH_SIZE)\n",
-    "    )"
+    "# TFRecordDataset can handle gs:// paths!\n",
+    "tf_dataset = tf.data.TFRecordDataset([\"gs://matt-tf-tpu-tutorial-datasets/cola/dataset.tfrecords\"])\n",
+    "tf_dataset = tf_dataset.map(decode_fn)\n",
+    "tf_dataset = tf_dataset.shuffle(len(dataset)).batch(BATCH_SIZE, drop_remainder=True)\n",
+    "tf_dataset = tf_dataset.apply(\n",
+    "    tf.data.experimental.assert_cardinality(len(labels) // BATCH_SIZE)\n",
+    ")"
    ]
   },
   {
@@ -650,11 +664,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with strategy.scope():\n",
-    "    tf_dataset = tf.data.Dataset.from_tensor_slices(\n",
-    "        {\"filename\": gs_paths, \"labels\": labels}\n",
-    "    )\n",
-    "    tf_dataset = tf_dataset.shuffle(len(tf_dataset))"
+    "tf_dataset = tf.data.Dataset.from_tensor_slices(\n",
+    "    {\"filename\": gs_paths, \"labels\": labels}\n",
+    ")\n",
+    "tf_dataset = tf_dataset.shuffle(len(tf_dataset))"
    ]
   },
   {
@@ -718,11 +731,9 @@
     "    array = tf.transpose(array, perm=[2, 0, 1])  # Swap to channels-first\n",
     "    return {\"pixel_values\": array, \"labels\": sample[\"labels\"]}\n",
     "\n",
-    "\n",
-    "with strategy.scope():\n",
-    "    tf_dataset = tf_dataset.map(decode_fn)\n",
-    "    tf_dataset = tf_dataset.batch(BATCH_SIZE, drop_remainder=True)\n",
-    "    print(tf_dataset.element_spec)"
+    "tf_dataset = tf_dataset.map(decode_fn)\n",
+    "tf_dataset = tf_dataset.batch(BATCH_SIZE, drop_remainder=True)\n",
+    "print(tf_dataset.element_spec)"
    ]
   },
   {
@@ -884,11 +895,9 @@
     "dataset = dataset.map(tokenize_function)\n",
     "\n",
     "# prepare_tf_dataset() will choose columns that match the model's input names\n",
-    "with strategy.scope():\n",
-    "    # Remember, creating the actual tf.data.Dataset always goes in the scope too!\n",
-    "    tf_dataset = model.prepare_tf_dataset(\n",
-    "        dataset, batch_size=BATCH_SIZE, shuffle=True, tokenizer=tokenizer\n",
-    "    )"
+    "tf_dataset = model.prepare_tf_dataset(\n",
+    "    dataset, batch_size=BATCH_SIZE, shuffle=True, tokenizer=tokenizer\n",
+    ")"
    ]
   },
   {

--- a/examples/translation-tf.ipynb
+++ b/examples/translation-tf.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"translation_notebook\", framework=\"tensorflow\")"
    ]

--- a/examples/translation.ipynb
+++ b/examples/translation.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"translation_notebook\", framework=\"pytorch\")"
    ]

--- a/examples/video_classification.ipynb
+++ b/examples/video_classification.ipynb
@@ -179,7 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import send_example_telemetry\n",
+    "from transformers.utils import send_example_telemetry\n",
     "\n",
     "send_example_telemetry(\"video_classification_notebook\", framework=\"pytorch\")"
    ]


### PR DESCRIPTION
This PR makes the change suggested by @awsaf49 on Twitter (moving dataset creation out of the `scope()` - we confirmed in testing that it didn't need to be in there). It also adds optional example telemetry so we can keep track of everything!