### PR TITLE
Added index: idx, in chap6 section3

### DIFF
--- a/course/en/chapter6/section3_pt.ipynb
+++ b/course/en/chapter6/section3_pt.ipynb
@@ -327,7 +327,8 @@
     "    label = model.config.id2label[pred]\n",
     "    if label != \"O\":\n",
     "        results.append(\n",
-    "            {\"entity\": label, \"score\": probabilities[idx][pred], \"word\": tokens[idx]}\n",
+    "            {\"entity\": label, \"score\": probabilities[idx][pred],\"index\":idx,\n",
+    "             \"word\": tokens[idx]}\n",
     "        )\n",
     "\n",
     "print(results)"
@@ -412,6 +413,7 @@
     "            {\n",
     "                \"entity\": label,\n",
     "                \"score\": probabilities[idx][pred],\n",
+    "                \"index\":idx,\n",
     "                \"word\": tokens[idx],\n",
     "                \"start\": start,\n",
     "                \"end\": end,\n",
@@ -508,6 +510,23 @@
   "colab": {
    "name": "Fast tokenizers' special powers (PyTorch)",
    "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/course/en/chapter6/section3_tf.ipynb
+++ b/course/en/chapter6/section3_tf.ipynb
@@ -329,7 +329,8 @@
     "    label = model.config.id2label[pred]\n",
     "    if label != \"O\":\n",
     "        results.append(\n",
-    "            {\"entity\": label, \"score\": probabilities[idx][pred], \"word\": tokens[idx]}\n",
+    "            {\"entity\": label, \"score\": probabilities[idx][pred],\"index\":idx, \n",
+    "             \"word\": tokens[idx]}\n",
     "        )\n",
     "\n",
     "print(results)"
@@ -414,6 +415,7 @@
     "            {\n",
     "                \"entity\": label,\n",
     "                \"score\": probabilities[idx][pred],\n",
+    "                \"index\":idx,\n",
     "                \"word\": tokens[idx],\n",
     "                \"start\": start,\n",
     "                \"end\": end,\n",
@@ -510,6 +512,23 @@
   "colab": {
    "name": "Fast tokenizers' special powers (TensorFlow)",
    "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# What does this PR do?
Added index: idx, in the code as it was missing from it under the from inputs to predictions section of the fast tokenizer's special powers course.

Fixes # (issue)
Code missing as per the chapter 6 section 3. 

