### PR TITLE
Fix typo and improve clarity in preprocessing explanation

### DIFF
--- a/examples/multiple_choice.ipynb
+++ b/examples/multiple_choice.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "X4cRE8IbIrIV"
@@ -26,6 +27,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,6 +50,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,6 +67,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -82,6 +86,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -100,6 +105,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "rEJBSTyZIrIb"
@@ -109,6 +115,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "kTCFado4IrIc"
@@ -132,6 +139,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "whPRbBNbIrIl"
@@ -141,6 +149,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "W7QYTpxXIrIl"
@@ -161,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "CKx2zKs5IrIq"
@@ -252,6 +262,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "RzfPtOMoIrIu"
@@ -297,6 +308,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "u3EtYfeHIrIz"
@@ -339,6 +351,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "WHUmphG3IrI3"
@@ -561,6 +574,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -629,6 +643,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "n9qywopnIrJH"
@@ -638,6 +653,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "YVx71GdAIrJH"
@@ -667,6 +683,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "Vl6IidfdIrJK"
@@ -676,6 +693,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "rowT4iCLIrJK"
@@ -708,6 +726,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "qo_0B1M2IrJM"
@@ -719,6 +738,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "2C0hcmp9IrJQ"
@@ -726,7 +746,7 @@
    "source": [
     "We can them write the function that will preprocess our samples. The tricky part is to put all the possible pairs of sentences in two big lists before passing them to the tokenizer, then un-flatten the result so that each example has four input ids, attentions masks, etc.\n",
     "\n",
-    "When calling the `tokenizer`, we use the argument `truncation=True`. This will ensure that an input longer that what the model selected can handle will be truncated to the maximum length accepted by the model."
+    "When calling the `tokenizer`, we use the argument `truncation=True`. This will ensure that an input longer than the maximum length the model can handle will be truncated to the maximum length accepted by the model.\""
    ]
   },
   {
@@ -757,6 +777,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "0lm8ozrJIrJR"
@@ -785,6 +806,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -816,6 +838,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -846,6 +869,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "zS-6iXTkIrJT"
@@ -877,6 +901,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "voWiw8C7IrJV"
@@ -888,6 +913,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "545PP3o8IrJV"
@@ -897,6 +923,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "FBiW8UpKIrJW"
@@ -932,6 +959,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "CczA5lJlIrJX"
@@ -941,6 +969,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "_N8urzhyIrJY"
@@ -971,6 +1000,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "km3pGVdTIrJc"
@@ -1029,6 +1059,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1049,6 +1080,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1102,6 +1134,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "7sZOdRlRIrJd"
@@ -1129,6 +1162,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "rXuFTAzDIrJe"
@@ -1157,6 +1191,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "CdzABDVcIrJg"
@@ -1244,6 +1279,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "wY82caEX3l_i"
@@ -1262,6 +1298,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/multiple_choice.ipynb
+++ b/examples/multiple_choice.ipynb
@@ -738,6 +738,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {
@@ -746,8 +753,15 @@
    "source": [
     "We can them write the function that will preprocess our samples. The tricky part is to put all the possible pairs of sentences in two big lists before passing them to the tokenizer, then un-flatten the result so that each example has four input ids, attentions masks, etc.\n",
     "\n",
-    "When calling the `tokenizer`, we use the argument `truncation=True`. This will ensure that an input longer than the maximum length the model can handle will be truncated to the maximum length accepted by the model.\""
+    "When calling the `tokenizer`, we use the argument `truncation=True`. This will ensure that an input longer than the maximum length the model can handle will be truncated to the maximum length accepted by the model."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Corrects a typo and improves the clarity of a sentence in the pre-processing section of the multiple_choice-tf.ipynb notebook. The revised sentence more accurately describes the role of the truncation=True argument and the relationship between input length and the model's maximum accepted length.