### PR TITLE
Fix links to main repo examples from TF notebooks

### DIFF
--- a/examples/language_modeling-tf.ipynb
+++ b/examples/language_modeling-tf.ipynb
@@ -99,7 +99,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/language-modeling)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/language-modeling)."
    ]
   },
   {
@@ -2465,7 +2465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/language_modeling_from_scratch-tf.ipynb
+++ b/examples/language_modeling_from_scratch-tf.ipynb
@@ -97,7 +97,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/language-modeling)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/language-modeling)."
    ]
   },
   {
@@ -1334,7 +1334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/question_answering-tf.ipynb
+++ b/examples/question_answering-tf.ipynb
@@ -97,7 +97,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/question-answering)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/question-answering)."
    ]
   },
   {
@@ -2429,7 +2429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/summarization-tf.ipynb
+++ b/examples/summarization-tf.ipynb
@@ -99,7 +99,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/seq2seq)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/summarization)."
    ]
   },
   {
@@ -1497,7 +1497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/text_classification-tf.ipynb
+++ b/examples/text_classification-tf.ipynb
@@ -100,7 +100,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/text-classification)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/summarization)."
    ]
   },
   {
@@ -1489,7 +1489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/text_classification-tf.ipynb
+++ b/examples/text_classification-tf.ipynb
@@ -100,7 +100,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/summarization)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/language-modeling)."
    ]
   },
   {

--- a/examples/text_classification-tf.ipynb
+++ b/examples/text_classification-tf.ipynb
@@ -100,7 +100,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/language-modeling)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/text-classification)."
    ]
   },
   {

--- a/examples/token_classification-tf.ipynb
+++ b/examples/token_classification-tf.ipynb
@@ -100,7 +100,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/token-classification)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/token-classification)."
    ]
   },
   {
@@ -1686,7 +1686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/translation-tf.ipynb
+++ b/examples/translation-tf.ipynb
@@ -99,7 +99,7 @@
     "id": "HFASsisvIrIb"
    },
    "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/seq2seq)."
+    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/translation)."
    ]
   },
   {
@@ -1496,7 +1496,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some of the links in our TF examples went out of date! This PR fixes them. Fixes https://github.com/huggingface/transformers/issues/24341

Thanks to @SoyGema for notifying us about the issue!