### PR TITLE
Update torch_xla to a Colab compatible version

### DIFF
--- a/examples/accelerate_examples/simple_nlp_example.ipynb
+++ b/examples/accelerate_examples/simple_nlp_example.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "! pip install datasets transformers evaluate\n",
     "! pip install cloud-tpu-client==0.10 torch==1.13.0\n",
-    "! pip install https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-1.13-cp38-cp38-linux_x86_64.whl\n",
+    "! pip install https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-2.0-cp310-cp310-linux_x86_64.whl\n",
     "! pip install git+https://github.com/huggingface/accelerate"
    ]
   },

--- a/examples/accelerate_examples/simple_nlp_example.ipynb
+++ b/examples/accelerate_examples/simple_nlp_example.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "! pip install datasets transformers evaluate\n",
-    "! pip install cloud-tpu-client==0.10 torch==1.13.0\n",
+    "! pip install cloud-tpu-client==0.10 torch==2.0.0\n",
     "! pip install https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-2.0-cp310-cp310-linux_x86_64.whl\n",
     "! pip install git+https://github.com/huggingface/accelerate"
    ]


### PR DESCRIPTION
# What does this PR do?
This PR updates torch_xla to a Colab compatible version.
As Google Colab upgraded to Python 3.10, the link in the example needs to be updated to allow an installation of `torch_xla`. Cuurently it fails with `ERROR: torch_xla-1.13-cp38-cp38-linux_x86_64.whl is not a supported wheel on this platform`

## Who can review?
@sgugger

