### PR TITLE
Fixed variable name

### DIFF
--- a/diffusers/training_example.ipynb
+++ b/diffusers/training_example.ipynb
@@ -1144,7 +1144,7 @@
         "        mixed_precision=config.mixed_precision,\n",
         "        gradient_accumulation_steps=config.gradient_accumulation_steps, \n",
         "        log_with=\"tensorboard\",\n",
-        "        logging_dir=os.path.join(config.output_dir, \"logs\")\n",
+        "        project_dir=os.path.join(config.output_dir, \"logs\")\n",
         "    )\n",
         "    if accelerator.is_main_process:\n",
         "        if config.push_to_hub:\n",


### PR DESCRIPTION
Fix for variable name in `Accelerate` of `logging_dir`. Current, notebook is throwing  following error:

```
Accelerator.__init__() got an unexpected keyword argument 'logging_dir
```

```
accelerator = Accelerator(
    mixed_precision=config.mixed_precision,
    gradient_accumulation_steps=config.gradient_accumulation_steps, 
    log_with="tensorboard",
    logging_dir=os.path.join(config.output_dir, "logs")
)
```
It should be like as following.

```
accelerator = Accelerator(
    mixed_precision=config.mixed_precision,
    gradient_accumulation_steps=config.gradient_accumulation_steps, 
    log_with="tensorboard",
    project_dir=os.path.join(config.output_dir, "logs")
)
```






