### PR TITLE
Fixed library installation command

### DIFF
--- a/transformers_doc/en/pytorch/multiple_choice.ipynb
+++ b/transformers_doc/en/pytorch/multiple_choice.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "# Transformers installation\n",
-    "! pip install transformers datasets\n",
+    "! pip install transformers datasets evaluate\n",
     "# To install from source instead of the last release, comment the command above and uncomment the following one.\n",
     "# ! pip install git+https://github.com/huggingface/transformers.git"
    ]
@@ -517,7 +517,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
Added "evaluate"

# What does this PR do?

Updates the command at the top of the notebook  so that it matches the command recommended later in the notebook:
`pip install transformers datasets evaluate`

Without "evaluate", users can get an error when trying to import the evaluate library.
```
ModuleNotFoundError                       Traceback (most recent call last)
[<ipython-input-9-945d22c344e6>](https://localhost:8080/#) in <cell line: 1>()
----> 1 import evaluate
      2 
      3 accuracy = evaluate.load("accuracy")

ModuleNotFoundError: No module named 'evaluate'
```
