### PR TITLE
Each batch is padded with its longest example

### DIFF
--- a/examples/token_classification.ipynb
+++ b/examples/token_classification.ipynb
@@ -1078,7 +1078,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we will need a data collator that will batch our processed examples together while applying padding to make them all the same size (each pad will be padded to the length of its longest example). There is a data collator for this task in the Transformers library, that not only pads the inputs, but also the labels:"
+    "Then we will need a data collator that will batch our processed examples together while applying padding to make them all the same size (each batch will be padded to the length of its longest example). There is a data collator for this task in the Transformers library, that not only pads the inputs, but also the labels:"
    ]
   },
   {


### PR DESCRIPTION
`DataCollatorWithPadding` should be performing dynamic padding within each batch.

# What does this PR do?

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Open a PR directly on the `course` repo (https://github.com/huggingface/course)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
