### PR TITLE
Fixing Error in TrainingArguments (Sec.2 / Ch.3) [Colab]

### DIFF
--- a/course/en/chapter3/section3.ipynb
+++ b/course/en/chapter3/section3.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install datasets evaluate transformers[sentencepiece]"
+    "!pip install datasets evaluate transformers[sentencepiece] accelerate -U"
    ]
   },
   {


### PR DESCRIPTION
running this cell in colab
```
from transformers import TrainingArguments

training_args = TrainingArguments("test-trainer")
```
results in the error
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
[<ipython-input-2-11170ce17e38>](https://localhost:8080/#) in <cell line: 3>()
      1 from transformers import TrainingArguments
      2 
----> 3 training_args = TrainingArguments("test-trainer")

4 frames
[/usr/local/lib/python3.10/dist-packages/transformers/training_args.py](https://localhost:8080/#) in _setup_devices(self)
   1785         if not is_sagemaker_mp_enabled():
   1786             if not is_accelerate_available(min_version="0.20.1"):
-> 1787                 raise ImportError(
   1788                     "Using the `Trainer` with `PyTorch` requires `accelerate>=0.20.1`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
   1789                 )

ImportError: Using the `Trainer` with `PyTorch` requires `accelerate>=0.20.1`: Please run `pip install transformers[torch]` or `pip install accelerate -U`

---------------------------------------------------------------------------
NOTE: If your import is failing due to a missing package, you can
manually install dependencies using either !pip or !apt.

To view examples of installing some common dependencies, click the
"Open Examples" button below.
---------------------------------------------------------------------------
```
the fix is to add `accelerate` in this pip install cell (first cell)
```
!pip install datasets evaluate transformers[sentencepiece] accelerate -U
```

@sgugger 