### PR TITLE
PatchTSTMixer fix

### DIFF
--- a/examples/patch_tsmixer.ipynb
+++ b/examples/patch_tsmixer.ipynb
@@ -226,6 +226,7 @@
     "    )\n",
     "\n",
     "    tsp = TimeSeriesPreprocessor(\n",
+    "        context_length=context_length,\n",
     "        timestamp_column=timestamp_column,\n",
     "        id_columns=id_columns,\n",
     "        input_columns=forecast_columns,\n",


### PR DESCRIPTION
context_length parameter is not being set resulting in scaling issues when inferencing and training the model.

What does this PR do?
The context_length param of the TimeSeriesPreprocessor is not being set correctly defaulting to a context_length of 64.
The PR fixes patchtstmixer to be able to be inferenced properly when contructing a pipeline using a pretrained TimeSeriesPreprocessor.

I have a fix on my fork of notebooks.

@NielsRogge