### PR TITLE
Update installs in pytorch text+image classification notebooks

### DIFF
--- a/examples/image_classification.ipynb
+++ b/examples/image_classification.ipynb
@@ -56,7 +56,7 @@
     "id": "NlArTG8KChJf"
    },
    "source": [
-    "Before we start, let's install the `datasets` and `transformers` libraries."
+    "Before we start, let's install the `datasets`, the `transformers` and the `accelerate` libraries."
    ]
   },
   {
@@ -94,7 +94,7 @@
     }
    ],
    "source": [
-    "!pip install -q datasets transformers"
+    "!pip install -q datasets transformers accelerate"
    ]
   },
   {

--- a/examples/text_classification.ipynb
+++ b/examples/text_classification.ipynb
@@ -6,7 +6,7 @@
     "id": "X4cRE8IbIrIV"
    },
    "source": [
-    "If you're opening this Notebook on colab, you will probably need to install 🤗 Transformers and 🤗 Datasets. Uncomment the following cell and run it."
+    "If you're opening this Notebook on colab, you will probably need to install 🤗 Transformers, 🤗 Datasets and 🤗 Accelerate. Uncomment the following cell and run it."
    ]
   },
   {
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers"
+    "#! pip install datasets transformers accelerate"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

Trainer with PyTorch now requires accelerate to be installed, therefore accelerate is additionally installed at the beginning of the notebooks.

Fixes huggingface/transformers#29174 (partly)

## Who can review?

@sgugger
