### PR TITLE
fixing the clm-prompt-tuning that was causing unequal lengths in the label token id

### DIFF
--- a/peft_docs/en/clm-prompt-tuning.ipynb
+++ b/peft_docs/en/clm-prompt-tuning.ipynb
@@ -197,7 +197,7 @@
     "        model_inputs[\"attention_mask\"][i] = [0] * (max_length - len(sample_input_ids)) + model_inputs[\n",
     "            \"attention_mask\"\n",
     "        ][i]\n",
-    "        labels[\"input_ids\"][i] = [-100] * (max_length - len(sample_input_ids)) + label_input_ids\n",
+    "        labels[\"input_ids\"][i] = [-100] * (max_length - len(label_input_ids)) + label_input_ids\n",
     "        model_inputs[\"input_ids\"][i] = torch.tensor(model_inputs[\"input_ids\"][i][:max_length])\n",
     "        model_inputs[\"attention_mask\"][i] = torch.tensor(model_inputs[\"attention_mask\"][i][:max_length])\n",
     "        labels[\"input_ids\"][i] = torch.tensor(labels[\"input_ids\"][i][:max_length])\n",


### PR DESCRIPTION
The code snippet needs a correction in the line:
labels["input_ids"][i] = [-100] * (max_length - len(sample_input_ids)) + label_input_ids Change it to:
labels["input_ids"][i] = [-100] * (max_length - len(label_input_ids)) + label_input_ids This adjustment ensures that the label token ids are padded or truncated based on their own length, aligning with Hugging Face's recommended practice and avoiding issues with unequal lengths in input and label token ids. The same changes need to be corrected in documentation as well is been mentioned  in the https://huggingface.co/docs/peft/main/en/task_guides/prompt_based_methods and https://huggingface.co/docs/peft/main/en/task_guides/clm-prompt-tuning

# What does this PR do?

The Pull Request (PR) corrects a code snippet that pads or truncates label token ids based on their own length, aligning with best practices recommended in the Hugging Face documentation for prompt-based methods and CLM prompt tuning. This correction ensures compatibility with transformer models and resolves issues related to unequal lengths in input and label token ids

- PyTorch NLP & Accelerate: @sgugger
- Tokenizers: @n1t0, @Narsil
`huggingface_hub`: @muellerzr, @LysandreJik


