### PR TITLE
Fix: replaced text with context in question_answering.ipynb

### DIFF
--- a/transformers_doc/en/tensorflow/question_answering.ipynb
+++ b/transformers_doc/en/tensorflow/question_answering.ipynb
@@ -585,7 +585,7 @@
     "from transformers import AutoTokenizer\n",
     "\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"my_awesome_qa_model\")\n",
-    "inputs = tokenizer(question, text, return_tensors=\"tf\")"
+    "inputs = tokenizer(question, context, return_tensors=\"tf\")"
    ]
   },
   {
@@ -653,7 +653,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
# What does this PR do?

In the Inference section of the tutorial for the TensorFlow section, there is a variable named 'text' but it should actually be 'context' 
<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Open a PR directly on the `course` repo (https://github.com/huggingface/course)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
