### PR TITLE
language_modeling.ipynb: fix eli5 dataset name and split

### DIFF
--- a/transformers_doc/en/pytorch/language_modeling.ipynb
+++ b/transformers_doc/en/pytorch/language_modeling.ipynb
@@ -124,7 +124,7 @@
    "source": [
     "from datasets import load_dataset\n",
     "\n",
-    "eli5 = load_dataset(\"eli5\", split=\"train_asks[:5000]\")"
+    "eli5 = load_dataset(\"eli5_category\", split=\"train[:5000]\")\n"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

Fixes the name of the eli5 dataset to match what is used on the website: https://huggingface.co/docs/transformers/tasks/language_modeling#load-eli5-dataset

@sgugger