### PR TITLE
Resolve Libraries Conflict in chapter3/section3_tf.ipynb

### DIFF
--- a/course/en/chapter3/section3_tf.ipynb
+++ b/course/en/chapter3/section3_tf.ipynb
@@ -20,7 +20,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install datasets evaluate transformers[sentencepiece]"
+    "!pip install datasets evaluate transformers[sentencepiece]\n",
+    "!pip install --upgrade tensorflow\n",
+    "!pip install --upgrade tf-keras"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'"
    ]
   },
   {
@@ -195,6 +207,9 @@
   "colab": {
    "name": "Fine-tuning a model with the Trainer API or Keras",
    "provenance": []
+  },
+  "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As documented in [Issue #19262](https://github.com/keras-team/keras/issues/19262) on the Keras GitHub repository, there was a conflict between the Transformers and Keras libraries. Specifically, executing the following code resulted in an error associated with the `Adam` optimizer:

```python
import tensorflow as tf

model = TFAutoModelForSequenceClassification.from_pretrained('checkpoint', num_labels=2)
loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
model.compile(optimizer='opt', loss=loss, metrics=["accuracy"])
```
I have updated the notebook to resolve this issue. With the modifications applied, the error no longer occurs, ensuring compatibility between the two libraries.