### PR TITLE
Update metric load as per v3.0.2

### DIFF
--- a/examples/summarization.ipynb
+++ b/examples/summarization.ipynb
@@ -179,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "IreSlFmlIrIm"
    },
@@ -213,7 +213,7 @@
     "from evaluate import load\n",
     "\n",
     "raw_datasets = load_dataset(\"xsum\")\n",
-    "metric = load(\"rouge\")"
+    "rouge = load(\"rouge\")"
    ]
   },
   {
@@ -409,12 +409,12 @@
     "id": "lnjDIuQ3IrI-"
    },
    "source": [
-    "The metric is an instance of [`datasets.Metric`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Metric):"
+    "The rouge is a metric and is an instance of [`evaluate.Metric`](https://huggingface.co/docs/evaluate/main/en/package_reference/main_classes#evaluate.Metric):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "id": "5o4rUteaIrI_",
     "outputId": "18038ef5-554c-45c5-e00a-133b02ec10f1"
@@ -461,7 +461,7 @@
     }
    ],
    "source": [
-    "metric"
+    "rouge"
    ]
   },
   {
@@ -476,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "id": "6XN1Rq0aIrJC",
     "outputId": "a4405435-a8a9-41ff-9f79-a13077b587c7"
@@ -496,7 +496,7 @@
    "source": [
     "fake_preds = [\"hello there\", \"general kenobi\"]\n",
     "fake_labels = [\"hello there\", \"general kenobi\"]\n",
-    "metric.compute(predictions=fake_preds, references=fake_labels)"
+    "rouge.compute(predictions=fake_preds, references=fake_labels)"
    ]
   },
   {
@@ -882,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "id": "UmvbnJ9JIrJd"
    },
@@ -904,7 +904,7 @@
     "    \n",
     "    # Note that other metrics may not have a `use_aggregator` parameter\n",
     "    # and thus will return a list, computing a metric for each sentence.\n",
-    "    result = metric.compute(predictions=decoded_preds, references=decoded_labels, use_stemmer=True, use_aggregator=True)\n",
+    "    result = rouge.compute(predictions=decoded_preds, references=decoded_labels, use_stemmer=True, use_aggregator=True)\n",
     "    # Extract a few results\n",
     "    result = {key: value * 100 for key, value in result.items()}\n",
     "    \n",


### PR DESCRIPTION
# What does this PR do?

This PR will fix the loading of evaluation metric as per the new version

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Open a PR directly on the `course` repo (https://github.com/huggingface/course)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes # (issue)

https://github.com/huggingface/notebooks/issues/519

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
