### PR TITLE
[Flax] Add code block to push pretrained flax model weights to the huggingface hub

### DIFF
--- a/examples/causal_language_modeling_flax.ipynb
+++ b/examples/causal_language_modeling_flax.ipynb
@@ -1550,9 +1550,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (1/10 | Loss: 6.935000419616699, Learning Rate: 0.0002699999895412475)\n"
      ]
     },
@@ -1576,9 +1576,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (1/10 | Loss: 7.108445644378662 | Perplexity: 1246.529052734375)\n"
      ]
     },
@@ -1602,9 +1602,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (2/10 | Loss: 6.334000110626221, Learning Rate: 0.00023999999393709004)\n"
      ]
     },
@@ -1628,9 +1628,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (2/10 | Loss: 6.567610740661621 | Perplexity: 738.8753662109375)\n"
      ]
     },
@@ -1654,9 +1654,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (3/10 | Loss: 5.798000335693359, Learning Rate: 0.0002099999983329326)\n"
      ]
     },
@@ -1680,9 +1680,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (3/10 | Loss: 6.278167247772217 | Perplexity: 557.9488525390625)\n"
      ]
     },
@@ -1706,9 +1706,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (4/10 | Loss: 5.557000160217285, Learning Rate: 0.00018000000272877514)\n"
      ]
     },
@@ -1732,9 +1732,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (4/10 | Loss: 6.062875270843506 | Perplexity: 451.3289794921875)\n"
      ]
     },
@@ -1758,9 +1758,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (5/10 | Loss: 5.543000221252441, Learning Rate: 0.00014999999257270247)\n"
      ]
     },
@@ -1784,9 +1784,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (5/10 | Loss: 5.920379161834717 | Perplexity: 392.97332763671875)\n"
      ]
     },
@@ -1810,9 +1810,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (6/10 | Loss: 5.361000061035156, Learning Rate: 0.00011999999696854502)\n"
      ]
     },
@@ -1836,9 +1836,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (6/10 | Loss: 5.821027755737305 | Perplexity: 356.4353942871094)\n"
      ]
     },
@@ -1862,9 +1862,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (7/10 | Loss: 5.207000255584717, Learning Rate: 9.000000136438757e-05)\n"
      ]
     },
@@ -1888,9 +1888,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (7/10 | Loss: 5.748736381530762 | Perplexity: 332.1453857421875)\n"
      ]
     },
@@ -1914,9 +1914,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (8/10 | Loss: 5.124000072479248, Learning Rate: 5.999999848427251e-05)\n"
      ]
     },
@@ -1940,9 +1940,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (8/10 | Loss: 5.703180313110352 | Perplexity: 317.5106201171875)\n"
      ]
     },
@@ -1966,9 +1966,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (9/10 | Loss: 5.220000267028809, Learning Rate: 2.9999999242136255e-05)\n"
      ]
     },
@@ -1992,9 +1992,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (9/10 | Loss: 5.674434185028076 | Perplexity: 308.7478942871094)\n"
      ]
     },
@@ -2018,9 +2018,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Train... (10/10 | Loss: 4.992000102996826, Learning Rate: 0.0)\n"
      ]
     },
@@ -2044,9 +2044,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "\r",
-      "\r",
+      "\r\n",
+      "\r\n",
+      "\r\n",
       "Eval... (10/10 | Loss: 5.66389274597168 | Perplexity: 305.58953857421875)\n",
       "\n"
      ]
@@ -2097,6 +2097,51 @@
     "It can be seen that in this colab training already reaches a speed of 2.42 training steps per second. Executing [**`run_clm_flax.py`**](https://github.com/huggingface/transformers/tree/master/examples/flax/language-modeling/run_clm_flax.py) on a TPUv3-8 VM should be as fast as 7 training steps per second.\n",
     "\n",
     "For a more in-detail comparison of runtimes please refer to [this](https://github.com/huggingface/transformers/tree/master/examples/flax/language-modeling#runtime-evaluation) table."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may upload the model to the huggingface hub. The model will be uploaded under `https://huggingface.co/<your-username>/<model_dir>`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unreplicated_params = flax.jax_utils.unreplicate(state.params)\n",
+    "model.params = jax.device_get(jax.tree_map(lambda x: x.astype(jnp.float32), unreplicated_params))\n",
+    "\n",
+    "model.push_to_hub(model_dir)\n",
+    "tokenizer.push_to_hub(model_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After uploading, you may use the model to generate a text using pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use a pipeline as a high-level helper\n",
+    "from transformers import pipeline\n",
+    "\n",
+    "your_username = \"\" # huggingface user name\n",
+    "pipe = pipeline(\"text-generation\", model=f\"{your_username}/{model_dir}\")\n",
+    "\n",
+    "sample_prompt = \"Týðingin verður løgd til almennar\" # sample inputs\n",
+    "\n",
+    "# decoding with beam search of 5\n",
+    "pipe(sample_prompt, max_new_tokens=20, num_beams=5)"
    ]
   }
  ],

--- a/examples/text_classification_flax.ipynb
+++ b/examples/text_classification_flax.ipynb
@@ -1481,6 +1481,9 @@
    },
    "outputs": [],
    "source": [
+    "unreplicated_params = flax.jax_utils.unreplicate(state.params)\n",
+    "model.params = jax.device_get(jax.tree_map(lambda x: x.astype(jnp.float32), unreplicated_params))\n",
+    "\n",
     "model.push_to_hub(model_id, use_auth_token=hf_auth_token)\n",
     "tokenizer.push_to_hub(model_id, use_auth_token=hf_auth_token)"
    ]


### PR DESCRIPTION
# What does this PR do?

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Open a PR directly on the `course` repo (https://github.com/huggingface/course)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes the following: 
- https://github.com/huggingface/transformers/issues/12545
- https://github.com/huggingface/transformers/issues/12554#issuecomment-875656287

Issues above happened mainly because provided examples upload initialized model's parameters, resulting in `jibberish output` as mentioned in the issues.

Fixed with 1) unreplicating params, 2) assigning back to the original flax model class, 3) pushing to the huggingface hub.

## Who can review?

@patrickvonplaten 

Thank you for your review and devotion to the open source project!

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
