### PR TITLE
ImportError: cannot import name 'load_metric' from 'datasets'

### DIFF
--- a/examples/multiple_choice.ipynb
+++ b/examples/multiple_choice.ipynb
@@ -157,7 +157,7 @@
    },
    "outputs": [],
    "source": [
-    "from datasets import load_dataset, load_metric"
+    "from datasets import load_dataset"
    ]
   },
   {

--- a/examples/question_answering.ipynb
+++ b/examples/question_answering.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers"
+    "#! pip install datasets transformers evaluate"
    ]
   },
   {
@@ -167,7 +167,7 @@
     "id": "W7QYTpxXIrIl"
    },
    "source": [
-    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset` and `load_metric`.  "
+    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset`.  "
    ]
   },
   {
@@ -178,7 +178,7 @@
    },
    "outputs": [],
    "source": [
-    "from datasets import load_dataset, load_metric"
+    "from datasets import load_dataset"
    ]
   },
   {
@@ -1981,7 +1981,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we can load the metric from the datasets library."
+    "Then we can load the metric from the evaluate library."
    ]
   },
   {
@@ -1990,7 +1990,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "metric = load_metric(\"squad_v2\" if squad_v2 else \"squad\")"
+    "import evaluate\n",
+    "metric = evaluate.load(\"squad_v2\" if squad_v2 else \"squad\")"
    ]
   },
   {

--- a/examples/summarization_ort.ipynb
+++ b/examples/summarization_ort.ipynb
@@ -240,7 +240,7 @@
    "source": [
     "## Loading the dataset\n",
     "\n",
-    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset` and `load_metric`."
+    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset`."
    ]
   },
   {
@@ -250,10 +250,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datasets import load_dataset, load_metric\n",
+    "from datasets import load_dataset, evaluate\n",
     "\n",
     "raw_datasets = load_dataset(task)\n",
-    "metric = load_metric(metric_name)"
+    "metric = evaluate.load(metric_name)"
    ]
   },
   {

--- a/examples/text_classification_quantization_ort.ipynb
+++ b/examples/text_classification_quantization_ort.ipynb
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers[sklearn] optimum[onnxruntime]"
+    "#! pip install datasets transformers[sklearn] optimum[onnxruntime] evaluate"
    ]
   },
   {
@@ -130,18 +130,18 @@
     "id": "W7QYTpxXIrIl"
    },
    "source": [
-    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the dataset and get the metric we need to use for evaluation. This can be easily done with the functions `load_dataset` and `load_metric`.  "
+    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the dataset and get the metric we need to use for evaluation. This can be easily done with the functions `load_dataset`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "id": "IreSlFmlIrIm"
    },
    "outputs": [],
    "source": [
-    "from datasets import load_dataset, load_metric"
+    "from datasets import load_dataset, evaluate"
    ]
   },
   {
@@ -227,7 +227,7 @@
     "actual_task = \"mnli\" if task == \"mnli-mm\" else task\n",
     "validation_split = \"validation_mismatched\" if task == \"mnli-mm\" else \"validation_matched\" if task == \"mnli\" else \"validation\"\n",
     "eval_dataset = load_dataset(\"glue\", actual_task, split=validation_split)\n",
-    "metric = load_metric(\"glue\", actual_task) "
+    "metric = evaluate.load(\"glue\", actual_task) "
    ]
   },
   {
@@ -236,7 +236,7 @@
     "id": "YOCrQwPoIrJG"
    },
    "source": [
-    "Note that `load_metric` has loaded the proper metric associated to your task, which is:\n",
+    "Note that `evaluate.load` has loaded the proper metric associated to your task, which is:\n",
     "\n",
     "- for CoLA: [Matthews Correlation Coefficient](https://en.wikipedia.org/wiki/Matthews_correlation_coefficient)\n",
     "- for MNLI (matched or mismatched): Accuracy\n",

--- a/examples/text_classification_quantization_ort.ipynb
+++ b/examples/text_classification_quantization_ort.ipynb
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "IreSlFmlIrIm"
    },

--- a/examples/token_classification.ipynb
+++ b/examples/token_classification.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers seqeval"
+    "#! pip install datasets transformers seqeval evaluate"
    ]
   },
   {
@@ -171,7 +171,7 @@
     "id": "W7QYTpxXIrIl"
    },
    "source": [
-    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset` and `load_metric`.  "
+    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset`."
    ]
   },
   {
@@ -182,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "from datasets import load_dataset, load_metric"
+    "from datasets import load_dataset"
    ]
   },
   {
@@ -1105,7 +1105,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "metric = load_metric(\"seqeval\")"
+    "import evaluate\n",
+    "metric = evaluate.load(\"seqeval\")"
    ]
   },
   {

--- a/examples/translation.ipynb
+++ b/examples/translation.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install datasets transformers[sentencepiece] sacrebleu"
+    "#! pip install datasets transformers[sentencepiece] sacrebleu evaluate"
    ]
   },
   {
@@ -163,7 +163,7 @@
     "id": "W7QYTpxXIrIl"
    },
    "source": [
-    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset` and `load_metric`. We use the English/Romanian part of the WMT dataset here."
+    "We will use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the data and get the metric we need to use for evaluation (to compare our model to the benchmark). This can be easily done with the functions `load_dataset`. We use the English/Romanian part of the WMT dataset here."
    ]
   },
   {
@@ -182,10 +182,10 @@
     }
    ],
    "source": [
-    "from datasets import load_dataset, load_metric\n",
+    "from datasets import load_dataset, evaluate\n",
     "\n",
     "raw_datasets = load_dataset(\"wmt16\", \"ro-en\")\n",
-    "metric = load_metric(\"sacrebleu\")"
+    "metric = evaluate.load(\"sacrebleu\")"
    ]
   },
   {


### PR DESCRIPTION
## What does this PR do?
the load_metric function has been deprecated and removed in recent versions of the datasets library. It was replaced by the evaluate library, which is now the recommended way to load and use metrics.

This PR replaces `load_metric` with `evaluate.load`.

