### PR TITLE
bug fix in `multilingual.ipynb`

### DIFF
--- a/transformers_doc/en/multilingual.ipynb
+++ b/transformers_doc/en/multilingual.ipynb
@@ -378,7 +378,7 @@
     }
    ],
    "source": [
-    "generated_tokens = model.generate(**encoded_en, forced_bos_token_id=tokenizer.lang_code_to_id(\"en_XX\"))\n",
+    "generated_tokens = model.generate(**encoded_en, forced_bos_token_id=tokenizer.lang_code_to_id[\"en_XX\"])\n",
     "tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)"
    ]
   },
@@ -390,7 +390,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
## What does this PR do?
This PR fixed the following issue:

```bash
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[18], line 1
----> 1 generated_tokens = model.generate(**encoded_en, forced_bos_token_id=tokenizer.lang_code_to_id("en_XX"))
      2 tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)

TypeError: 'dict' object is not callable
```