### PR TITLE
replace deprecated tokenizer with processing_class in chapter 3

### DIFF
--- a/course/en/chapter3/section3.ipynb
+++ b/course/en/chapter3/section3.ipynb
@@ -81,7 +81,7 @@
     "    train_dataset=tokenized_datasets[\"train\"],\n",
     "    eval_dataset=tokenized_datasets[\"validation\"],\n",
     "    data_collator=data_collator,\n",
-    "    tokenizer=tokenizer,\n",
+    "    processing_class=tokenizer,\n",
     ")"
    ]
   },
@@ -177,7 +177,7 @@
     "    train_dataset=tokenized_datasets[\"train\"],\n",
     "    eval_dataset=tokenized_datasets[\"validation\"],\n",
     "    data_collator=data_collator,\n",
-    "    tokenizer=tokenizer,\n",
+    "    processing_class=tokenizer,\n",
     "    compute_metrics=compute_metrics,\n",
     ")"
    ]


### PR DESCRIPTION
# What does this PR do?

Replacing the deprecated parameter, `tokenizer`, with `processing_class`.

Fixes [#37734 in transformers](https://github.com/huggingface/transformers/issues/37734)

## Who can review?

@stevhliu

