### PR TITLE
Initial implementation for Arabic course translation

### DIFF
--- a/course/ar/chapter1/section3.ipynb
+++ b/course/ar/chapter1/section3.ipynb
@@ -1,0 +1,472 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# المحولات، ما الذي يمكنها فعله؟"
+      ],
+      "metadata": {
+        "id": "5yr2y-5cz8QH"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "ثبّت مكتبات المحولات ومجموعات البيانات والتقييم لتتمكّن من تشغيل هذا الدفتر البرمجي."
+      ],
+      "metadata": {
+        "id": "tzUCgOJ_0BRk"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install datasets evaluate IProgress tqdm ipywidgets sacremoses \"transformers[sentencepiece]\""
+      ],
+      "metadata": {
+        "id": "qt-Ym6WL0DXw"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "من مكتبة\n",
+        "\n",
+        "`transformers`\n",
+        "\n",
+        "استورد الدالة\n",
+        "\n",
+        "`pipeline`."
+      ],
+      "metadata": {
+        "id": "oNO84Dn7m9aq"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from transformers import pipeline"
+      ],
+      "metadata": {
+        "id": "SasHk5uVnDl8"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "نختار محولًا مفتوح المصدر ونبدأ في استخدامه. كمثال، استخدمت\n",
+        "\n",
+        "نموذجًا مخصصًا من:\n",
+        "\n",
+        "[مختبر كامل](https://huggingface.co/CAMeL-Lab)\n"
+      ],
+      "metadata": {
+        "id": "Uxyf36TR0U4z"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Fw8owxGXwGQ1",
+        "outputId": "8780c0fa-596b-4e84-eec9-ec70886e628c"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[{'label': 'positive', 'score': 0.757685661315918}]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 17
+        }
+      ],
+      "source": [
+        "sentimentAnalysisModelName = 'MaagDeveloper/CAMeL-Lab-arabic-sentiment-analysis'\n",
+        "classifier = pipeline(task=\"sentiment-analysis\", model=sentimentAnalysisModelName)\n",
+        "\n",
+        "classifier(\"لقد كنتُ أنتظر الدورة من هاجِّنغ فيس طوال حياتي.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "classifier(\n",
+        "    [\"لقد كنتُ أترقّب الدورة من هاجِّنغ فيس طوال حياتي.\", \"أكره هذا بشدّة!\"]\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tdQdVBw8y5kA",
+        "outputId": "ea20d649-542c-44b6-e565-db986a53a246"
+      },
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[{'label': 'positive', 'score': 0.9497042894363403},\n",
+              " {'label': 'negative', 'score': 0.9927158951759338}]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 18
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من\n",
+        "\n",
+        "[موريتس لاورَر](https://huggingface.co/MoritzLaurer) 😅 يارب أكون ترجمت اسمك صح.\n"
+      ],
+      "metadata": {
+        "id": "fDylTUq-4NFw"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "zeroShotTextClassificationModelName = 'MaagDeveloper/MoritzLaurer-mDeBERTa-v3-base-mnli-xnli'\n",
+        "classifier = pipeline(\"zero-shot-classification\", model=zeroShotTextClassificationModelName)\n",
+        "\n",
+        "classifier(\n",
+        "    \"لقد كنتُ أترقّب الدورة من هاجِّنغ فيس طوال حياتي.\",\n",
+        "    candidate_labels=[\"التعليم\", \"التكنولوجيا\", \"الترفيه\"]\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OYM_zzPr4y5U",
+        "outputId": "c0da3f3a-14a8-4213-9982-5953fbd7d9f8"
+      },
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'sequence': 'لقد كنتُ أترقّب الدورة من هاجِّنغ فيس طوال حياتي.',\n",
+              " 'labels': ['التعليم', 'الترفيه', 'التكنولوجيا'],\n",
+              " 'scores': [0.9193072319030762, 0.056315358728170395, 0.024377452209591866]}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من [عابد خولي](https://huggingface.co/akhooli).\n",
+        "\n",
+        "💡 ملحوظة: أضفت\n",
+        "\n",
+        "`truncation=True`\n",
+        "\n",
+        " لتجنب كتابة توكنز أكثر من 30، كما تم تحديده في\n",
+        "\n",
+        " `max_length`.\n"
+      ],
+      "metadata": {
+        "id": "8dO6X7RG9lpx"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "textGenerationModelName = 'MaagDeveloper/akhooli-gpt2-small-arabic'\n",
+        "generator = pipeline(\"text-generation\", model=textGenerationModelName)\n",
+        "generator(\n",
+        "    \"للمهتمين بالتكنولوجيا، سوف نعلمك في هذا الكورس كيف\",\n",
+        "    max_length=30,\n",
+        "    num_return_sequences=2,\n",
+        "    truncation=True\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "GiQusx6a9ijB",
+        "outputId": "718c5d8d-4b93-4322-893a-79388be6a0cd"
+      },
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[{'generated_text': 'للمهتمين بالتكنولوجيا، سوف نعلمك في هذا الكورس كيف تكون الأشياء من دون الحاسوب، يمكن للمرء أن يقول ما الذي يمكنك قوله هكذا.'},\n",
+              " {'generated_text': 'للمهتمين بالتكنولوجيا، سوف نعلمك في هذا الكورس كيف ولماذا يمكنك الحصول على عمل وأنفسك عن غير قصد. سوف تجد له معلومات'}]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 20
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من\n",
+        "\n",
+        "[مختبر تطوير الذكاء الآلي في الجامعة الأمريكية في بيروت (AUB)](https://huggingface.co/aubmindlab).\n"
+      ],
+      "metadata": {
+        "id": "fqjC9JPauzus"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "fillMaskModelName = 'MaagDeveloper/aubmindlab-bert-base-arabertv02'\n",
+        "unmasker = pipeline(\"fill-mask\", model=fillMaskModelName)\n",
+        "unmasker(\"هذا الكورس سيعلمك كل شيء عن النماذج [MASK].\", top_k=2)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "hpAGHI6js3RA",
+        "outputId": "463b66f1-7a32-44e3-c783-5e20b3d98e99"
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[{'score': 0.046427544206380844,\n",
+              "  'token': 4035,\n",
+              "  'token_str': 'البشرية',\n",
+              "  'sequence': 'هذا الكورس سيعلمك كل شيء عن النماذج البشرية.'},\n",
+              " {'score': 0.04319816455245018,\n",
+              "  'token': 2976,\n",
+              "  'token_str': 'الرياضية',\n",
+              "  'sequence': 'هذا الكورس سيعلمك كل شيء عن النماذج الرياضية.'}]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من\n",
+        "\n",
+        "[محمد حاتمي - موحه](https://huggingface.co/aubmindlab).\n"
+      ],
+      "metadata": {
+        "id": "XxlG3ZvIyysy"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "namedEntityRecognitionModelName = 'MaagDeveloper/hatmimoha-arabic-ner'\n",
+        "ner = pipeline(\"ner\", model=namedEntityRecognitionModelName, grouped_entities=True)\n",
+        "ner(\"اسمي محمد وأنا مجرد فلاح من مركز منيا القمح.\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "zK48iUK_wdQW",
+        "outputId": "0cd52d98-e444-4ee3-d3f6-1609bb9074a4"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[{'entity_group': 'PERSON',\n",
+              "  'score': np.float32(0.9798584),\n",
+              "  'word': 'محمد',\n",
+              "  'start': 5,\n",
+              "  'end': 9},\n",
+              " {'entity_group': 'ORGANIZATION',\n",
+              "  'score': np.float32(0.58339274),\n",
+              "  'word': 'مركز منيا القمح',\n",
+              "  'start': 28,\n",
+              "  'end': 43}]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 23
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من\n",
+        "\n",
+        "[زياد أحمد](https://huggingface.co/ZeyadAhmed).\n"
+      ],
+      "metadata": {
+        "id": "_3V-PB5n1bzw"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "questionAnsweringModelName = 'MaagDeveloper/ZeyadAhmed-AraElectra-Arabic-SQuADv2-QA'\n",
+        "question_answerer = pipeline(\"question-answering\", model=questionAnsweringModelName)\n",
+        "question_answerer(\n",
+        "    question=\"ما هو مكان عملي؟\",\n",
+        "    context=\"اسمي محمد وأعمل من المنزل.\",\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "qyUpeWGP0K_D",
+        "outputId": "a03058ab-a654-410f-81f9-5af75b0d0b2e"
+      },
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'score': 0.8270246386528015, 'start': 19, 'end': 25, 'answer': 'المنزل'}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من\n",
+        "\n",
+        "[مجموعة معالجة اللغة الطبيعية بقسم علوم الحاسوب والهندسة في جامعة BUET](https://huggingface.co/csebuetnlp)."
+      ],
+      "metadata": {
+        "id": "uRLz_FgvZQPe"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "summarizationModelName = 'MaagDeveloper/csebuetnlp-mT5_multilingual_XLSum'\n",
+        "summarizer = pipeline(\"summarization\", model=summarizationModelName)\n",
+        "\n",
+        "text = \"فلسطين، هذا البلد الذي يعاني منذ عقود من الاحتلال والصراع المستمر، حيث يعيش شعبه في ظل ظروف صعبة للغاية، يسعى بجهد مستمر لاستعادة حقوقه المشروعة وإقامة دولته المستقلة على أراضيه التي لا تزال محتلة. ومع ذلك، فإن حلم التحرر يظل حياً في قلوب الفلسطينيين الذين لا يتوقفون عن النضال لتحقيق هذا الهدف الكبير، في وقت تواجه فيه القضية الفلسطينية تحديات كبيرة من محاولات تغيير الواقع على الأرض ومحاربة الهوية الوطنية.\"\n",
+        "summary = summarizer(text)\n",
+        "print(summary)\n"
+      ],
+      "metadata": {
+        "id": "ZHCGbZTfRKsy",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "de3f28d3-89d8-4611-8ceb-681ff9bd3a4f"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "[{'summary_text': 'على الرغم من استمرار الاحتلال الفلسطيني منذ عقود، يواجه الفلسطينيون تحديًا كبيراً.'}]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "يوجد العديد من المحولات التي بها جميع اللغات ولكن الأفضل التخصص لضمان نتائج أفضل.\n",
+        "\n",
+        "وبالمثل 🛠️ نختار محولًا مفتوح المصدر ونبدأ في استخدامه.\n",
+        "\n",
+        "كمثال، قمت بنسخ هذا الموديل من\n",
+        "\n",
+        "[إبراهيم محمد](https://huggingface.co/mobarmg)."
+      ],
+      "metadata": {
+        "id": "jgA2U8dkeSr5"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "translateFromArabicToEnglishModelName = 'MaagDeveloper/mobarmg-Marian-en-ar'\n",
+        "translator = pipeline(\"translation\", model=translateFromArabicToEnglishModelName)\n",
+        "\n",
+        "# text = 'لقد كنتُ أنتظر الدورة من هاجِّنغ فيس طوال حياتي.'\n",
+        "text = \"I've been waiting for a HuggingFace course my whole life.\"\n",
+        "translation = translator(text)\n",
+        "print(translation)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 52
+        },
+        "id": "LmKG6hQeasZF",
+        "outputId": "714fc9c7-fd79-47f4-c977-baa631b9a375"
+      },
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "[{'translation_text': 'لقد انتظرت دورة HugggFace طوال حياتي.'}]\n"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/course/ar/chapter1/section8.ipynb
+++ b/course/ar/chapter1/section8.ipynb
@@ -1,0 +1,62 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "KoipzSs3gaQb"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install datasets evaluate IProgress tqdm ipywidgets sacremoses \"transformers[sentencepiece]\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from transformers import pipeline\n",
+        "\n",
+        "fillMaskModelName = 'MaagDeveloper/aubmindlab-bert-base-arabertv02'\n",
+        "unmasker = pipeline(\"fill-mask\", model=fillMaskModelName)\n",
+        "\n",
+        "result = unmasker(\"هذا الكورس سيعلمك كل شيء عن النماذج [MASK].\")\n",
+        "print([r[\"token_str\"] for r in result])\n",
+        "\n",
+        "result = unmasker(\"الغباء الاصطناعي يمكنه تحسين [MASK] بشكل كبير.\")\n",
+        "print([r[\"token_str\"] for r in result])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "losXHNiEgc5L",
+        "outputId": "a7606e28-0f26-4675-ede6-77583562be56"
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "['البشرية', 'الرياضية', 'التجارية', 'الحسابية', 'المصغرة']\n",
+            "['الحياة', 'الذكاء', 'الصحة', 'حياتنا', 'الدماغ']\n"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
What does this PR do?
This PR introduces the initial Arabic translation and localization of the Hugging Face course notebooks, starting with Chapter 1. The content is fully translated into Modern Standard Arabic, while retaining technical clarity and fidelity to the original instructional flow.

Highlights:
Added full Arabic translation for chapter1/section3.ipynb and section8.ipynb.

Localized markdown instructions, comments, and code explanations.

Preserved all functionality and examples using Arabic-centric models from Hugging Face community contributors.

Ensured use of Arabic-specific models (sentiment analysis, zero-shot classification, text generation, NER, summarization, translation, etc.) to align examples with the new audience.

Pipelines and usage remain identical, just tailored for Arabic context and datasets.

This work lays the foundation for the rest of the Arabic course translation and is intended to improve accessibility for Arabic-speaking ML practitioners.

Fixes # (if you have a corresponding issue ID, include it here; otherwise delete this line)

Who can review?
Tagging @sgugger and @LysandreJik for review and alignment with course repo direction. Also tagging @muellerzr for Hugging Face Hub content sync visibility.