### PR TITLE
fix(training.ipynb): add import Trainer from transformers

### DIFF
--- a/transformers_doc/en/training.ipynb
+++ b/transformers_doc/en/training.ipynb
@@ -186,7 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import TrainingArguments\n",
+    "from transformers import TrainingArguments, Trainer\n",
     "\n",
     "training_args = TrainingArguments(\n",
     "    output_dir=\"yelp_review_classifier\",\n",

--- a/transformers_doc/es/training.ipynb
+++ b/transformers_doc/es/training.ipynb
@@ -303,7 +303,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import TrainingArguments\n",
+    "from transformers import TrainingArguments, Trainer\n",
     "\n",
     "training_args = TrainingArguments(output_dir=\"test_trainer\", eval_strategy=\"epoch\")"
    ]

--- a/transformers_doc/pt/training.ipynb
+++ b/transformers_doc/pt/training.ipynb
@@ -330,7 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import TrainingArguments\n",
+    "from transformers import TrainingArguments, Trainer\n",
     "\n",
     "training_args = TrainingArguments(output_dir=\"test_trainer\", eval_strategy=\"epoch\")"
    ]


### PR DESCRIPTION
# What does this PR do?

<!--
Thank you for submitting a PR to improve our notebooks!

Someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.

Note: the notebooks in the `course` and `transformers_doc` directories are auto-generated, so are best fixed at their source. Instead, follow the instructions below for these notebooks:

- `course`: Open a PR directly on the `course` repo (https://github.com/huggingface/course)
- `transformers_doc`: Open a PR directly on the `transformers` repo (https://github.com/huggingface/transformers)

-->

<!-- Remove if not applicable -->


Fixes # (training.ipynb): These code is missing import Trainer from the transformers.

ERROR from https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/training.ipynb:
<img width="1014" height="830" alt="image" src="https://github.com/user-attachments/assets/7811165d-0fbe-4734-b418-db88e799a0ba" />

Fixed:
<img width="1178" height="614" alt="image" src="https://github.com/user-attachments/assets/ddfe2a0b-1247-4916-8a73-74d5e1c88497" />


## Who can review?

Hi, @Vaibhavs10 @pcuenca could you please help review?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 2 people.


`examples`:

- PyTorch NLP & Accelerate: @sgugger
- TensorFlow: @Rocketknight1, @gante
- Computer vision: @NielsRogge
- Speech: @anton-l, @patrickvonplaten
- ONNX: @lewtun
- Optimum: @echarlaix
- Tokenizers: @n1t0, @Narsil
- Benchmarks: @patrickvonplaten

`huggingface_hub`: @muellerzr, @LysandreJik

`longform_qa`: @yjernite

`sagemaker`: @philschmid

 -->
