### PR TITLE
Fix GRPO marimo Plotly notebook dependencies

### DIFF
--- a/course/en/chapter13/grpo_format.py
+++ b/course/en/chapter13/grpo_format.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "marimo",
+#   "plotly",
+#   "numpy",
+#   "pandas",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.10.6"
@@ -121,11 +131,10 @@ def _(mo, format_buttons):
             }
         )
 
-    # Create a table view
-    mo.md(f"### Results for {format_buttons.value} format")
-    mo.ui.table(results)
-
-    # Create a bar chart comparing rewards by completion
+    display_rows = [
+        {**row, "Reward": f"{row['Reward']:.2f}"}
+        for row in results
+    ]
     fig = px.bar(
         results,
         x="Completion",
@@ -134,7 +143,14 @@ def _(mo, format_buttons):
         title=f"Format Rewards by Completion ({format_buttons.value})",
         hover_data=["Detail"],
     )
-    mo.ui.plotly(fig)
+
+    mo.vstack(
+        [
+            mo.md(f"### Results for {format_buttons.value} format"),
+            mo.ui.table(display_rows, selection=None),
+            mo.ui.plotly(fig),
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/course/en/chapter13/grpo_length.py
+++ b/course/en/chapter13/grpo_length.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "marimo",
+#   "plotly",
+#   "numpy",
+#   "pandas",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.10.6"
@@ -70,8 +80,19 @@ def _(mo, slider):
             {"Completion": completion, "Length": len(completion), "Reward": reward}
         )
 
+    display_rows = [
+        {**row, "Reward": f"{row['Reward']:.2f}"}
+        for row in results
+    ]
     fig = px.bar(results, x="Completion", y="Reward", color="Length")
-    mo.ui.plotly(fig)
+
+    mo.vstack(
+        [
+            mo.md("### Reward comparison"),
+            mo.ui.table(display_rows, selection=None),
+            mo.ui.plotly(fig),
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/course/en/chapter13/grpo_math.py
+++ b/course/en/chapter13/grpo_math.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "marimo",
+#   "plotly",
+#   "numpy",
+#   "pandas",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.10.6"
@@ -122,11 +132,10 @@ def _(mo, tolerance_slider):
             }
         )
 
-    # Create a table view
-    mo.md("### Results")
-    mo.ui.table(results)
-
-    # Create a bar chart
+    display_rows = [
+        {**row, "Reward": f"{row['Reward']:.2f}"}
+        for row in results
+    ]
     fig = px.bar(
         results,
         x="Problem",
@@ -135,7 +144,14 @@ def _(mo, tolerance_slider):
         hover_data=["Correct Answer", "Model Answer"],
         title="Rewards by Problem",
     )
-    mo.ui.plotly(fig)
+
+    mo.vstack(
+        [
+            mo.md("### Reward comparison"),
+            mo.ui.table(display_rows, selection=None),
+            mo.ui.plotly(fig),
+        ]
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?
This fixes the three GRPO marimo demos embedded in the LLM course.

They were failing in the browser because the Plotly examples depend on packages like `numpy` and `pandas`, but those dependencies were not declared explicitly. As a result, the marimo embed could get stuck in a broken install state instead of loading normally.

To fix that, I added inline dependency metadata to each notebook so marimo knows up front that they require `plotly`, `numpy`, and `pandas`. I also kept the existing Plotly visualizations, added a table to `grpo_length.py`, and cleaned up the existing tables in the other two demos so the outputs are easier to inspect.



## Who can review?
(Feel free to tag members/contributors who may be interested in your PR.)

@burtenshaw as we discussed earlier about me helping out with fixes in the LLM course repo (the files in this PR are the source for some marimo notebooks in chapter 12 of the LLM course) 

@mlabonne as the original author of the marimo notebook files' source code.
