### PR TITLE
[lerobot] Specify Python version 3.12 and update training script command

### DIFF
--- a/lerobot/training-act.ipynb
+++ b/lerobot/training-act.ipynb
@@ -31,7 +31,7 @@
    },
    "source": [
     "## Install conda\n",
-    "This cell uses `condacolab` to bootstrap a full Conda environment inside Google Colab.\n"
+    "This cell uses `condacolab` to bootstrap a full Conda environment with Python 3.12 inside Google Colab.\n"
    ]
   },
   {
@@ -48,7 +48,8 @@
    "source": [
     "!pip install -q condacolab\n",
     "import condacolab\n",
-    "condacolab.install()"
+    "condacolab.install()\n",
+    "!conda install python=3.12 -c conda-forge"
    ]
   },
   {
@@ -107,7 +108,7 @@
    "source": [
     "## Start training ACT with LeRobot\n",
     "\n",
-    "This cell runs the `train.py` script from the `lerobot` library to train a robot control policy.  \n",
+    "This cell runs the `lerobot-train` script from the `lerobot` library to train a robot control policy.  \n",
     "\n",
     "Make sure to adjust the following arguments to your setup:\n",
     "\n",
@@ -147,7 +148,7 @@
    },
    "outputs": [],
    "source": [
-    "!cd lerobot && python src/lerobot/scripts/lerobot_train.py \\\n",
+    "!cd lerobot && lerobot_train \\\n",
     "  --dataset.repo_id=${HF_USER}/hf_act_record \\\n",
     "  --policy.type=act \\\n",
     "  --output_dir=outputs/train/hf_act_record0 \\\n",

--- a/lerobot/training-smolvla.ipynb
+++ b/lerobot/training-smolvla.ipynb
@@ -31,7 +31,7 @@
       },
       "source": [
         "## Install conda\n",
-        "This cell uses `condacolab` to bootstrap a full Conda environment inside Google Colab.\n"
+        "This cell uses `condacolab` to bootstrap a full Conda environment with Python 3.12 inside Google Colab.\n"
       ]
     },
     {
@@ -48,7 +48,8 @@
       "source": [
         "!pip install -q condacolab\n",
         "import condacolab\n",
-        "condacolab.install()"
+        "condacolab.install()\n",
+        "!conda install python=3.12 -c conda-forge"
       ]
     },
     {
@@ -127,7 +128,7 @@
       "source": [
         "## Start training SmolVLA with LeRobot\n",
         "\n",
-        "This cell runs the `train.py` script from the `lerobot` library to train a robot control policy.  \n",
+        "This cell runs the `lerobot-train` script from the `lerobot` library to train a robot control policy.  \n",
         "\n",
         "Make sure to adjust the following arguments to your setup:\n",
         "\n",
@@ -155,7 +156,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!cd lerobot && python lerobot/scripts/train.py \\\n",
+        "!cd lerobot && lerobot-train \\\n",
         "  --policy.path=lerobot/smolvla_base \\\n",
         "  --dataset.repo_id=${HF_USER}/mydataset \\\n",
         "  --batch_size=64 \\\n",


### PR DESCRIPTION
## What does this PR do?

This PR makes 2 updates to the ACT and SmolVLA training notebooks: 
1. Install Python 3.12 in the Conda environment. Lerobot requires Python >=3.12 but condacolab installs Python 3.11.11 by default. 
2. Call `lerobot-train` to invoke the training script. The references to `train.py` are outdated. 

## How is it tested?

* Run notebook in Colab
* Verify that installation and training cells run successfully without errors

## Who can review?

@pkooij 